### PR TITLE
Feature/code cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,98 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Virtual environments
+.venv/
+env/
+venv/
+ENV/
+.conda/
+conda-meta/
+
+# Jupyter Notebook checkpoints
+.ipynb_checkpoints
+
+# PyInstaller
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
+.pytest_cache/
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# Data, model weights, and outputs
+data/*.jsonl
+data/*.abc
+data/*.xml
+data/*.mid
+data/*.midi
+data/*.mp3
+data/*.png
+data/*.pdf
+data/output/
+data/interleaved/
+data/augmented/
+data/original/
+data/*/
+output/
+output/*
+feature/
+feature/*
+*.pth
+*.ckpt
+
+# Gradio demo artifacts
+gradio/__pycache__/
+gradio/*.pyc
+gradio/output/
+gradio/.ipynb_checkpoints
+
+# Clamp2, RL, pretrain, finetune, inference outputs
+clamp2/feature/
+clamp2/output/
+RL/output/
+RL/*.pth
+pretrain/*.pth
+finetune/*.pth
+inference/output/
+inference/*.pth
+
+# Logs
+*.log
+
+# MacOS
+.DS_Store
+
+# VSCode
+.vscode/
+
+# Misc
+*.swp
+*.swo
+*~

--- a/RL/config.py
+++ b/RL/config.py
@@ -1,35 +1,43 @@
-import os
-
 # Configuration for the data
-DATA_INDEX_PATH = ''
+DATA_INDEX_PATH = ""
 
 # Configuration for the model
 PATCH_STREAM = True
-PATCH_SIZE = 16                                                # Patch Size
-PATCH_LENGTH = 1024                                             # Patch Length
-CHAR_NUM_LAYERS = 6                                             # Number of layers in the decoder
-PATCH_NUM_LAYERS = 20                                           # Number of layers in the encoder
-HIDDEN_SIZE = 1280                                               # Hidden Size
+PATCH_SIZE = 16  # Patch Size
+PATCH_LENGTH = 1024  # Patch Length
+CHAR_NUM_LAYERS = 6  # Number of layers in the decoder
+PATCH_NUM_LAYERS = 20  # Number of layers in the encoder
+HIDDEN_SIZE = 1280  # Hidden Size
 
-# Configuration for the training     
-BETA = 0.1                                                      # beta in DPO's objective function
-LAMBDA = 10                                                     # lambda in DPOP's objective function
+# Configuration for the training
+BETA = 0.1  # beta in DPO's objective function
+LAMBDA = 10  # lambda in DPOP's objective function
 LEARNING_RATE = 1e-6
-OPTIMIZATION_STEPS = 10000                                      # Optimization steps for DPO
-WANDB_LOGGING = False                                           # Whether to log to wandb
-WANDB_KEY = '<your_wandb_key>'
+OPTIMIZATION_STEPS = 10000  # Optimization steps for DPO
+WANDB_LOGGING = False  # Whether to log to wandb
+WANDB_KEY = "<your_wandb_key>"
 
-PRETRAINED_PATH = ''
-EXP_TAG = ''
-NAME =  EXP_TAG + \
-        "_beta_" + str(BETA) + \
-        "_lambda_" + str(LAMBDA) + \
-        "_p_size_" + str(PATCH_SIZE) + \
-        "_p_length_" + str(PATCH_LENGTH) + \
-        "_p_layers_" + str(PATCH_NUM_LAYERS) + \
-        "_c_layers_" + str(CHAR_NUM_LAYERS) + \
-        "_h_size_" + str(HIDDEN_SIZE) + \
-        "_lr_" + str(LEARNING_RATE)
+PRETRAINED_PATH = ""
+EXP_TAG = ""
+NAME = (
+    EXP_TAG
+    + "_beta_"
+    + str(BETA)
+    + "_lambda_"
+    + str(LAMBDA)
+    + "_p_size_"
+    + str(PATCH_SIZE)
+    + "_p_length_"
+    + str(PATCH_LENGTH)
+    + "_p_layers_"
+    + str(PATCH_NUM_LAYERS)
+    + "_c_layers_"
+    + str(CHAR_NUM_LAYERS)
+    + "_h_size_"
+    + str(HIDDEN_SIZE)
+    + "_lr_"
+    + str(LEARNING_RATE)
+)
 
-WEIGHTS_PATH = "weights_notagen_" + NAME + ".pth"                  # Path to save weights
+WEIGHTS_PATH = "weights_notagen_" + NAME + ".pth"  # Path to save weights
 WANDB_NAME = NAME

--- a/RL/data.py
+++ b/RL/data.py
@@ -1,17 +1,16 @@
-gt_feature_folder = '../clamp2/feature/schubert_interleaved'
-output_feature_folder = '../clamp2/feature/weights_notagen_schubert-RL2_beta_0.1_lambda_10_p_size_16_p_length_1024_p_layers_20_h_size_1280_lr_1e-06_k_9_p_0.9_temp_1.2'
-output_original_abc_folder = '../output/original/weights_notagen_schubert-RL2_beta_0.1_lambda_10_p_size_16_p_length_1024_p_layers_20_h_size_1280_lr_1e-06_k_9_p_0.9_temp_1.2'
-output_interleaved_abc_folder = '../output/interleaved/weights_notagen_schubert-RL2_beta_0.1_lambda_10_p_size_16_p_length_1024_p_layers_20_h_size_1280_lr_1e-06_k_9_p_0.9_temp_1.2'
-data_index_path = 'schubert_RL3.json'
+gt_feature_folder = "../clamp2/feature/schubert_interleaved"
+output_feature_folder = "../clamp2/feature/weights_notagen_schubert-RL2_beta_0.1_lambda_10_p_size_16_p_length_1024_p_layers_20_h_size_1280_lr_1e-06_k_9_p_0.9_temp_1.2"
+output_original_abc_folder = "../output/original/weights_notagen_schubert-RL2_beta_0.1_lambda_10_p_size_16_p_length_1024_p_layers_20_h_size_1280_lr_1e-06_k_9_p_0.9_temp_1.2"
+output_interleaved_abc_folder = "../output/interleaved/weights_notagen_schubert-RL2_beta_0.1_lambda_10_p_size_16_p_length_1024_p_layers_20_h_size_1280_lr_1e-06_k_9_p_0.9_temp_1.2"
+data_index_path = "schubert_RL3.json"
 data_select_portion = 0.1
 
 import os
 import re
 import json
-import random
 import numpy as np
 from config import *
-from abctoolkit.check import check_alignment_rotated, check_alignment_unrotated
+from abctoolkit.check import check_alignment_unrotated
 from abctoolkit.rotate import unrotate_abc
 
 
@@ -21,11 +20,12 @@ def load_npy_files(folder_path_list):
     """
     npy_list = []
     for file_path in folder_path_list:
-        if file_path.endswith('.npy'):
+        if file_path.endswith(".npy"):
             # file_path = os.path.join(folder_path, file_name)
             np_array = np.load(file_path)[0]
             npy_list.append(np_array)
     return npy_list
+
 
 def average_npy(npy_list):
     """
@@ -33,17 +33,18 @@ def average_npy(npy_list):
     """
     return np.mean(npy_list, axis=0)
 
+
 def cosine_similarity(vec1, vec2):
     """
     Compute cosine similarity between two numpy arrays.
     """
     dot_product = np.dot(vec1, vec2)
-    
+
     norm_vec1 = np.linalg.norm(vec1)
     norm_vec2 = np.linalg.norm(vec2)
-    
+
     cosine_sim = dot_product / (norm_vec1 * norm_vec2)
-    
+
     return cosine_sim
 
 
@@ -63,8 +64,12 @@ def generate_preference_dict():
         output_feature_sim_dict[file[:-4]] = sim
 
     threshold = int(len(output_feature_sim_dict) * data_select_portion)
-    sorted_output_files = sorted(output_feature_sim_dict.keys(), key=lambda item: output_feature_sim_dict[item], reverse=True)
-    
+    sorted_output_files = sorted(
+        output_feature_sim_dict.keys(),
+        key=lambda item: output_feature_sim_dict[item],
+        reverse=True,
+    )
+
     chosen_index = 0
     i = 0
     chosen_abc_paths = []
@@ -73,15 +78,19 @@ def generate_preference_dict():
         chosen_flag = True
 
         file = sorted_output_files[i]
-        output_interleaved_abc_path = os.path.join(output_interleaved_abc_folder, file + '.abc')
+        output_interleaved_abc_path = os.path.join(
+            output_interleaved_abc_folder, file + ".abc"
+        )
 
-        with open(output_interleaved_abc_path, 'r') as f:
+        with open(output_interleaved_abc_path, "r") as f:
             abc_lines = f.readlines()
 
         # check aligment
         try:
             abc_lines_unrotated = unrotate_abc(abc_lines)
-            barline_equal_flag, bar_no_equal_flag, bar_dur_equal_flag = check_alignment_unrotated(abc_lines_unrotated)
+            barline_equal_flag, bar_no_equal_flag, bar_dur_equal_flag = (
+                check_alignment_unrotated(abc_lines_unrotated)
+            )
             if not (barline_equal_flag and bar_no_equal_flag and bar_dur_equal_flag):
                 raise Exception
         except:
@@ -89,9 +98,9 @@ def generate_preference_dict():
 
         # check header: sheets where staves for the same instrument are not grouped together are excluded from the chosen set.
         appeared_inst = set()
-        last_inst = ''
+        last_inst = ""
         for line in abc_lines:
-            if line.startswith('V:') and 'nm=' in line:
+            if line.startswith("V:") and "nm=" in line:
                 match = re.search(r'nm="([^"]+)"', line)
                 if match:
                     inst = match.group(1)
@@ -100,10 +109,10 @@ def generate_preference_dict():
                         break
                     else:
                         last_inst = inst
-                        appeared_inst.add(inst)                           
+                        appeared_inst.add(inst)
 
         # check plagiarism: sheets with sim > 0.95 are excluded
-        output_feature_path = os.path.join(output_feature_folder, file + '.npy')
+        output_feature_path = os.path.join(output_feature_folder, file + ".npy")
         output_feature = np.load(output_feature_path)[0]
         for gt_feature_file in os.listdir(gt_feature_folder):
             gt_feature_path = os.path.join(gt_feature_folder, gt_feature_file)
@@ -114,23 +123,24 @@ def generate_preference_dict():
                 break
 
         if chosen_flag:
-            original_abc_path = os.path.join(output_original_abc_folder, file + '.abc')
+            original_abc_path = os.path.join(output_original_abc_folder, file + ".abc")
             chosen_abc_paths.append(original_abc_path)
             chosen_index += 1
         else:
-            print(file, 'skipped')
+            print(file, "skipped")
 
         i += 1
 
-    rejected_abc_paths = [os.path.join(output_original_abc_folder, file + '.abc') for file in sorted_output_files[-threshold:]]
-    preference_dict = {'chosen': chosen_abc_paths, 'rejected': rejected_abc_paths}
+    rejected_abc_paths = [
+        os.path.join(output_original_abc_folder, file + ".abc")
+        for file in sorted_output_files[-threshold:]
+    ]
+    preference_dict = {"chosen": chosen_abc_paths, "rejected": rejected_abc_paths}
 
-    with open(data_index_path, 'w') as w:
+    with open(data_index_path, "w") as w:
         json.dump(preference_dict, w, indent=4)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
 
     generate_preference_dict()
-
-    

--- a/RL/train.py
+++ b/RL/train.py
@@ -1,24 +1,19 @@
 import os
-import gc
-import time
-import math
 import json
 import wandb
 import torch
 import random
 import numpy as np
-from abctoolkit.transpose import Key2index, Key2Mode
 from utils import *
 from config import *
-from data import generate_preference_dict
 from tqdm import tqdm
 from copy import deepcopy
-from torch.utils.data import Dataset, DataLoader
-from transformers import GPT2Config, get_scheduler, get_constant_schedule_with_warmup
+from torch.utils.data import Dataset
+from transformers import GPT2Config
 
 
 device = torch.device("cuda") if torch.cuda.is_available() else torch.device("cpu")
-    
+
 # Set random seed
 seed = 0
 random.seed(seed)
@@ -30,18 +25,22 @@ torch.backends.cudnn.benchmark = False
 
 patchilizer = Patchilizer()
 
-patch_config = GPT2Config(num_hidden_layers=PATCH_NUM_LAYERS, 
-                    max_length=PATCH_LENGTH, 
-                    max_position_embeddings=PATCH_LENGTH,
-                    n_embd=HIDDEN_SIZE,
-                    num_attention_heads=HIDDEN_SIZE//64,
-                    vocab_size=1)
-char_config = GPT2Config(num_hidden_layers=CHAR_NUM_LAYERS, 
-                            max_length=PATCH_SIZE+1, 
-                            max_position_embeddings=PATCH_SIZE+1,
-                            hidden_size=HIDDEN_SIZE,
-                            num_attention_heads=HIDDEN_SIZE//64,
-                            vocab_size=128)
+patch_config = GPT2Config(
+    num_hidden_layers=PATCH_NUM_LAYERS,
+    max_length=PATCH_LENGTH,
+    max_position_embeddings=PATCH_LENGTH,
+    n_embd=HIDDEN_SIZE,
+    num_attention_heads=HIDDEN_SIZE // 64,
+    vocab_size=1,
+)
+char_config = GPT2Config(
+    num_hidden_layers=CHAR_NUM_LAYERS,
+    max_length=PATCH_SIZE + 1,
+    max_position_embeddings=PATCH_SIZE + 1,
+    hidden_size=HIDDEN_SIZE,
+    num_attention_heads=HIDDEN_SIZE // 64,
+    vocab_size=128,
+)
 
 model_ref = NotaGenLMHeadModel(encoder_config=patch_config, decoder_config=char_config)
 model = NotaGenLMHeadModel(encoder_config=patch_config, decoder_config=char_config)
@@ -52,32 +51,51 @@ model = model.to(device)
 
 
 # print parameter number
-print("Parameter Number: "+str(sum(p.numel() for p in model.parameters() if p.requires_grad)))
+print(
+    "Parameter Number: "
+    + str(sum(p.numel() for p in model.parameters() if p.requires_grad))
+)
 
 optimizer = torch.optim.AdamW(model.parameters(), lr=LEARNING_RATE)
 
 
 def collate_batch(input_batches):
-    pos_input_patches, pos_input_masks, neg_input_patches, neg_input_masks = input_batches
+    pos_input_patches, pos_input_masks, neg_input_patches, neg_input_masks = (
+        input_batches
+    )
     pos_input_patches = pos_input_patches.unsqueeze(0)
     pos_input_masks = pos_input_masks.unsqueeze(0)
     neg_input_patches = neg_input_patches.unsqueeze(0)
     neg_input_masks = neg_input_masks.unsqueeze(0)
-    pos_input_patches = torch.nn.utils.rnn.pad_sequence(pos_input_patches, batch_first=True, padding_value=0)
-    pos_input_masks = torch.nn.utils.rnn.pad_sequence(pos_input_masks, batch_first=True, padding_value=0)
-    neg_input_patches = torch.nn.utils.rnn.pad_sequence(neg_input_patches, batch_first=True, padding_value=0)
-    neg_input_masks = torch.nn.utils.rnn.pad_sequence(neg_input_masks, batch_first=True, padding_value=0)
-    return (pos_input_patches.to(device), pos_input_masks.to(device),
-            neg_input_patches.to(device), neg_input_masks.to(device))
+    pos_input_patches = torch.nn.utils.rnn.pad_sequence(
+        pos_input_patches, batch_first=True, padding_value=0
+    )
+    pos_input_masks = torch.nn.utils.rnn.pad_sequence(
+        pos_input_masks, batch_first=True, padding_value=0
+    )
+    neg_input_patches = torch.nn.utils.rnn.pad_sequence(
+        neg_input_patches, batch_first=True, padding_value=0
+    )
+    neg_input_masks = torch.nn.utils.rnn.pad_sequence(
+        neg_input_masks, batch_first=True, padding_value=0
+    )
+    return (
+        pos_input_patches.to(device),
+        pos_input_masks.to(device),
+        neg_input_patches.to(device),
+        neg_input_masks.to(device),
+    )
 
 
 class NotaGenDataset(Dataset):
     def __init__(self, preference_dict):
         self.preference_dict = preference_dict
         self.pair_list = []
-        for pos_filepath in self.preference_dict['chosen']:
-            for neg_filepath in self.preference_dict['rejected']:
-                self.pair_list.append({'chosen': pos_filepath, 'rejected': neg_filepath})
+        for pos_filepath in self.preference_dict["chosen"]:
+            for neg_filepath in self.preference_dict["rejected"]:
+                self.pair_list.append(
+                    {"chosen": pos_filepath, "rejected": neg_filepath}
+                )
 
     def __len__(self):
         return len(self.pair_list)
@@ -85,12 +103,12 @@ class NotaGenDataset(Dataset):
     def __getitem__(self, idx):
         try:
             pair = self.pair_list[idx]
-            pos_filepath = pair['chosen']
-            neg_filepath = pair['rejected']
+            pos_filepath = pair["chosen"]
+            neg_filepath = pair["rejected"]
 
-            with open(pos_filepath, 'r', encoding='utf-8') as f:
+            with open(pos_filepath, "r", encoding="utf-8") as f:
                 pos_abc_text = f.read()
-            with open(neg_filepath, 'r', encoding='utf-8') as f:
+            with open(neg_filepath, "r", encoding="utf-8") as f:
                 neg_abc_text = f.read()
 
             pos_file_bytes = patchilizer.encode(pos_abc_text)
@@ -106,7 +124,7 @@ class NotaGenDataset(Dataset):
             return pos_file_bytes, pos_file_masks, neg_file_bytes, neg_file_masks
         except Exception as e:
             print(e)
-            return self.__getitem__((idx+1) % len(self.pair_list))
+            return self.__getitem__((idx + 1) % len(self.pair_list))
 
 
 def process_one_batch(batch):
@@ -121,37 +139,37 @@ def process_one_batch(batch):
         ref_pos_logps = model_ref(pos_input_patches_ref, pos_input_masks_ref).detach()
         ref_neg_logps = model_ref(neg_input_patches_ref, neg_input_masks_ref).detach()
     logits = (policy_pos_logps - policy_neg_logps) - (ref_pos_logps - ref_neg_logps)
-    loss = - torch.nn.functional.logsigmoid(BETA * (logits - LAMBDA * max(0, ref_pos_logps - policy_pos_logps)))
+    loss = -torch.nn.functional.logsigmoid(
+        BETA * (logits - LAMBDA * max(0, ref_pos_logps - policy_pos_logps))
+    )
     return loss
 
 
-
-# train 
+# train
 if __name__ == "__main__":
-    
+
     # Initialize wandb
     if WANDB_LOGGING:
         wandb.login(key=WANDB_KEY)
-        wandb.init(project="notagen",
-                   name=WANDB_NAME)
-    
+        wandb.init(project="notagen", name=WANDB_NAME)
+
     # load data
-    with open(DATA_INDEX_PATH, 'r') as f:
+    with open(DATA_INDEX_PATH, "r") as f:
         preference_dict = json.loads(f.read())
 
     train_set = NotaGenDataset(preference_dict)
 
     # Load model actor/ref
     if os.path.exists(PRETRAINED_PATH):
-        checkpoint = torch.load(PRETRAINED_PATH, map_location='cpu')
+        checkpoint = torch.load(PRETRAINED_PATH, map_location="cpu")
         cpu_model = deepcopy(model)
-        cpu_model.load_state_dict(checkpoint['model'])
+        cpu_model.load_state_dict(checkpoint["model"])
         model.load_state_dict(cpu_model.state_dict())
         cpu_model_ref = deepcopy(model_ref)
-        cpu_model_ref.load_state_dict(checkpoint['model'])
+        cpu_model_ref.load_state_dict(checkpoint["model"])
         model_ref.load_state_dict(cpu_model_ref.state_dict())
     else:
-        raise Exception('No pre-trained model loaded.')
+        raise Exception("No pre-trained model loaded.")
 
     model.train()
     total_train_loss = 0
@@ -159,7 +177,7 @@ if __name__ == "__main__":
 
     tqdm_set = tqdm(range(OPTIMIZATION_STEPS))
     for i in tqdm_set:
-        idx = random.randint(0, len(train_set)-1)
+        idx = random.randint(0, len(train_set) - 1)
         batch = train_set[idx]
         batch = collate_batch(batch)
 
@@ -167,20 +185,22 @@ if __name__ == "__main__":
         total_train_loss += loss.item()
 
         loss.backward()
-        torch.nn.utils.clip_grad_norm(model.parameters(),max_norm=1.0 )
+        torch.nn.utils.clip_grad_norm(model.parameters(), max_norm=1.0)
         optimizer.step()
 
         model.zero_grad(set_to_none=True)
-        tqdm_set.set_postfix({'train_loss': total_train_loss / (i + 1)})
+        tqdm_set.set_postfix({"train_loss": total_train_loss / (i + 1)})
 
         # Log the training loss to wandb
         if WANDB_LOGGING:
-            wandb.log({"train_loss": total_train_loss / (i + 1)}, step=i+1)
+            wandb.log({"train_loss": total_train_loss / (i + 1)}, step=i + 1)
 
-    checkpoint = {'model': model.module.state_dict() if hasattr(model, "module") else model.state_dict()}
+    checkpoint = {
+        "model": (
+            model.module.state_dict()
+            if hasattr(model, "module")
+            else model.state_dict()
+        )
+    }
 
     torch.save(checkpoint, WEIGHTS_PATH)
-
-
-
-

--- a/RL/utils.py
+++ b/RL/utils.py
@@ -1,20 +1,18 @@
 import torch
 import random
 import bisect
-import json
 import re
 import numpy as np
 from config import *
-from transformers import GPT2Model, GPT2LMHeadModel, LlamaModel, LlamaForCausalLM, PreTrainedModel
+from transformers import GPT2Model, GPT2LMHeadModel, PreTrainedModel
 from samplings import top_p_sampling, top_k_sampling, temperature_sampling
-from tokenizers import Tokenizer
 
 
 class Patchilizer:
     def __init__(self, stream=PATCH_STREAM):
         self.stream = stream
         self.delimiters = ["|:", "::", ":|", "[|", "||", "|]", "|"]
-        self.regexPattern = '(' + '|'.join(map(re.escape, self.delimiters)) + ')'
+        self.regexPattern = "(" + "|".join(map(re.escape, self.delimiters)) + ")"
         self.bos_token_id = 1
         self.eos_token_id = 2
         self.special_token_id = 0
@@ -34,11 +32,17 @@ class Patchilizer:
                     new_line_bars = line_bars
                 else:
                     if line_bars[0] in self.delimiters:
-                        new_line_bars = [line_bars[i] + line_bars[i + 1] for i in range(0, len(line_bars), 2)]
+                        new_line_bars = [
+                            line_bars[i] + line_bars[i + 1]
+                            for i in range(0, len(line_bars), 2)
+                        ]
                     else:
-                        new_line_bars = [line_bars[0]] + [line_bars[i] + line_bars[i + 1] for i in range(1, len(line_bars), 2)]
-                    if 'V' not in new_line_bars[-1]:
-                        new_line_bars[-2] += new_line_bars[-1]  
+                        new_line_bars = [line_bars[0]] + [
+                            line_bars[i] + line_bars[i + 1]
+                            for i in range(1, len(line_bars), 2)
+                        ]
+                    if "V" not in new_line_bars[-1]:
+                        new_line_bars[-2] += new_line_bars[-1]
                         new_line_bars = new_line_bars[:-1]
                 new_bars += new_line_bars
         except:
@@ -49,14 +53,16 @@ class Patchilizer:
     def split_patches(self, abc_text, patch_size=PATCH_SIZE, generate_last=False):
         if not generate_last and len(abc_text) % patch_size != 0:
             abc_text += chr(self.eos_token_id)
-        patches = [abc_text[i : i + patch_size] for i in range(0, len(abc_text), patch_size)]
+        patches = [
+            abc_text[i : i + patch_size] for i in range(0, len(abc_text), patch_size)
+        ]
         return patches
 
     def patch2chars(self, patch):
         """
         Convert a patch into a bar.
         """
-        bytes = ''
+        bytes = ""
         for idx in patch:
             if idx == self.eos_token_id:
                 break
@@ -64,7 +70,6 @@ class Patchilizer:
                 pass
             bytes += chr(idx)
         return bytes
-        
 
     def patchilize_metadata(self, metadata_lines):
 
@@ -73,74 +78,92 @@ class Patchilizer:
             metadata_patches += self.split_patches(line)
 
         return metadata_patches
-    
-    def patchilize_tunebody(self, tunebody_lines, encode_mode='train'):
+
+    def patchilize_tunebody(self, tunebody_lines, encode_mode="train"):
 
         tunebody_patches = []
         bars = self.split_bars(tunebody_lines)
-        if encode_mode == 'train':
+        if encode_mode == "train":
             for bar in bars:
                 tunebody_patches += self.split_patches(bar)
-        elif encode_mode == 'generate':
+        elif encode_mode == "generate":
             for bar in bars[:-1]:
                 tunebody_patches += self.split_patches(bar)
             tunebody_patches += self.split_patches(bars[-1], generate_last=True)
-       
+
         return tunebody_patches
 
-    def encode(self, abc_text, patch_length=PATCH_LENGTH, patch_size=PATCH_SIZE, add_special_patches=True, cut=True):
+    def encode(
+        self,
+        abc_text,
+        patch_length=PATCH_LENGTH,
+        patch_size=PATCH_SIZE,
+        add_special_patches=True,
+        cut=True,
+    ):
 
-        lines = abc_text.split('\n')
+        lines = abc_text.split("\n")
         lines = list(filter(None, lines))
-        lines = [line + '\n' for line in lines]
+        lines = [line + "\n" for line in lines]
 
         tunebody_index = -1
         for i, line in enumerate(lines):
-            if line.startswith('[r:'):
+            if line.startswith("[r:"):
                 tunebody_index = i
                 break
 
-        metadata_lines = lines[: tunebody_index]
+        metadata_lines = lines[:tunebody_index]
         tunebody_lines = lines[tunebody_index:]
 
         metadata_patches = self.patchilize_metadata(metadata_lines)
-        tunebody_patches = self.patchilize_tunebody(tunebody_lines, encode_mode='train')
+        tunebody_patches = self.patchilize_tunebody(tunebody_lines, encode_mode="train")
 
         if add_special_patches:
-            bos_patch = chr(self.bos_token_id) * (patch_size - 1) + chr(self.eos_token_id)
-            eos_patch = chr(self.bos_token_id) + chr(self.eos_token_id) * (patch_size - 1)
+            bos_patch = chr(self.bos_token_id) * (patch_size - 1) + chr(
+                self.eos_token_id
+            )
+            eos_patch = chr(self.bos_token_id) + chr(self.eos_token_id) * (
+                patch_size - 1
+            )
 
             metadata_patches = [bos_patch] + metadata_patches
             tunebody_patches = tunebody_patches + [eos_patch]
 
         if self.stream:
             if len(metadata_patches) + len(tunebody_patches) > patch_length:
-                available_cut_indexes = [0] + [index + 1 for index, patch in enumerate(tunebody_patches) if
-                                               '\n' in patch]
-                line_index_for_cut_index = list(range(len(available_cut_indexes)))  
+                available_cut_indexes = [0] + [
+                    index + 1
+                    for index, patch in enumerate(tunebody_patches)
+                    if "\n" in patch
+                ]
+                line_index_for_cut_index = list(range(len(available_cut_indexes)))
                 end_index = len(metadata_patches) + len(tunebody_patches) - patch_length
-                biggest_index = bisect.bisect_left(available_cut_indexes, end_index)  
-                available_cut_indexes = available_cut_indexes[:biggest_index + 1]
+                biggest_index = bisect.bisect_left(available_cut_indexes, end_index)
+                available_cut_indexes = available_cut_indexes[: biggest_index + 1]
 
                 if len(available_cut_indexes) == 1:
-                    choices = ['head']
+                    choices = ["head"]
                 elif len(available_cut_indexes) == 2:
-                    choices = ['head', 'tail']
+                    choices = ["head", "tail"]
                 else:
-                    choices = ['head', 'tail', 'middle']
+                    choices = ["head", "tail", "middle"]
                 choice = random.choice(choices)
-                if choice == 'head':
+                if choice == "head":
                     patches = metadata_patches + tunebody_patches[0:]
                 else:
-                    if choice == 'tail':
+                    if choice == "tail":
                         cut_index = len(available_cut_indexes) - 1
                     else:
-                        cut_index = random.choice(range(1, len(available_cut_indexes) - 1))
+                        cut_index = random.choice(
+                            range(1, len(available_cut_indexes) - 1)
+                        )
 
                     line_index = line_index_for_cut_index[cut_index]
                     stream_tunebody_lines = tunebody_lines[line_index:]
 
-                    stream_tunebody_patches = self.patchilize_tunebody(stream_tunebody_lines, encode_mode='train')
+                    stream_tunebody_patches = self.patchilize_tunebody(
+                        stream_tunebody_lines, encode_mode="train"
+                    )
                     if add_special_patches:
                         stream_tunebody_patches = stream_tunebody_patches + [eos_patch]
                     patches = metadata_patches + stream_tunebody_patches
@@ -149,49 +172,65 @@ class Patchilizer:
         else:
             patches = metadata_patches + tunebody_patches
 
-        patches = patches[: patch_length]
+        patches = patches[:patch_length]
 
         # encode to ids
         id_patches = []
         for patch in patches:
-            id_patch = [ord(c) for c in patch] + [self.special_token_id] * (patch_size - len(patch))
+            id_patch = [ord(c) for c in patch] + [self.special_token_id] * (
+                patch_size - len(patch)
+            )
             id_patches.append(id_patch)
 
         return id_patches
 
-    def encode_generate(self, abc_code, patch_length=PATCH_LENGTH, patch_size=PATCH_SIZE, add_special_patches=True):
+    def encode_generate(
+        self,
+        abc_code,
+        patch_length=PATCH_LENGTH,
+        patch_size=PATCH_SIZE,
+        add_special_patches=True,
+    ):
 
-        lines = abc_code.split('\n')
+        lines = abc_code.split("\n")
         lines = list(filter(None, lines))
-    
+
         tunebody_index = None
         for i, line in enumerate(lines):
-            if line.startswith('[V:') or line.startswith('[r:'):
+            if line.startswith("[V:") or line.startswith("[r:"):
                 tunebody_index = i
                 break
-    
-        metadata_lines = lines[ : tunebody_index]
-        tunebody_lines = lines[tunebody_index : ]   
-    
-        metadata_lines = [line + '\n' for line in metadata_lines]
+
+        metadata_lines = lines[:tunebody_index]
+        tunebody_lines = lines[tunebody_index:]
+
+        metadata_lines = [line + "\n" for line in metadata_lines]
         if self.stream:
-            if not abc_code.endswith('\n'): 
-                tunebody_lines = [tunebody_lines[i] + '\n' for i in range(len(tunebody_lines) - 1)] + [tunebody_lines[-1]]
+            if not abc_code.endswith("\n"):
+                tunebody_lines = [
+                    tunebody_lines[i] + "\n" for i in range(len(tunebody_lines) - 1)
+                ] + [tunebody_lines[-1]]
             else:
-                tunebody_lines = [tunebody_lines[i] + '\n' for i in range(len(tunebody_lines))]
+                tunebody_lines = [
+                    tunebody_lines[i] + "\n" for i in range(len(tunebody_lines))
+                ]
         else:
-            tunebody_lines = [line + '\n' for line in tunebody_lines]
-    
+            tunebody_lines = [line + "\n" for line in tunebody_lines]
+
         metadata_patches = self.patchilize_metadata(metadata_lines)
-        tunebody_patches = self.patchilize_tunebody(tunebody_lines, encode_mode='generate')
-    
+        tunebody_patches = self.patchilize_tunebody(
+            tunebody_lines, encode_mode="generate"
+        )
+
         if add_special_patches:
-            bos_patch = chr(self.bos_token_id) * (patch_size - 1) + chr(self.eos_token_id)
+            bos_patch = chr(self.bos_token_id) * (patch_size - 1) + chr(
+                self.eos_token_id
+            )
 
             metadata_patches = [bos_patch] + metadata_patches
-    
+
         patches = metadata_patches + tunebody_patches
-        patches = patches[ : patch_length]
+        patches = patches[:patch_length]
 
         # encode to ids
         id_patches = []
@@ -199,34 +238,33 @@ class Patchilizer:
             if len(patch) < PATCH_SIZE and patch[-1] != chr(self.eos_token_id):
                 id_patch = [ord(c) for c in patch]
             else:
-                id_patch = [ord(c) for c in patch] + [self.special_token_id] * (patch_size - len(patch))
+                id_patch = [ord(c) for c in patch] + [self.special_token_id] * (
+                    patch_size - len(patch)
+                )
             id_patches.append(id_patch)
-        
+
         return id_patches
 
     def decode(self, patches):
         """
         Decode patches into music.
         """
-        return ''.join(self.patch2chars(patch) for patch in patches)
-
-        
+        return "".join(self.patch2chars(patch) for patch in patches)
 
 
 class PatchLevelDecoder(PreTrainedModel):
     """
-    A Patch-level Decoder model for generating patch features in an auto-regressive manner. 
+    A Patch-level Decoder model for generating patch features in an auto-regressive manner.
     It inherits PreTrainedModel from transformers.
     """
+
     def __init__(self, config):
         super().__init__(config)
         self.patch_embedding = torch.nn.Linear(PATCH_SIZE * 128, config.n_embd)
         torch.nn.init.normal_(self.patch_embedding.weight, std=0.02)
         self.base = GPT2Model(config)
 
-    def forward(self,
-                patches: torch.Tensor,
-                masks=None) -> torch.Tensor:
+    def forward(self, patches: torch.Tensor, masks=None) -> torch.Tensor:
         """
         The forward pass of the patch-level decoder model.
         :param patches: the patches to be encoded
@@ -237,11 +275,10 @@ class PatchLevelDecoder(PreTrainedModel):
         patches = patches.reshape(len(patches), -1, PATCH_SIZE * (128))
         patches = self.patch_embedding(patches.to(self.device))
 
-        if masks==None:
+        if masks == None:
             return self.base(inputs_embeds=patches)
         else:
-            return self.base(inputs_embeds=patches,
-                             attention_mask=masks)
+            return self.base(inputs_embeds=patches, attention_mask=masks)
 
 
 class CharLevelDecoder(PreTrainedModel):
@@ -249,6 +286,7 @@ class CharLevelDecoder(PreTrainedModel):
     A Char-level Decoder model for generating the chars within each patch in an auto-regressive manner
     based on the encoded patch features. It inherits PreTrainedModel from transformers.
     """
+
     def __init__(self, config):
         super().__init__(config)
         self.special_token_id = 0
@@ -256,60 +294,75 @@ class CharLevelDecoder(PreTrainedModel):
 
         self.base = GPT2LMHeadModel(config)
 
-    def forward(self,
-                encoded_patches: torch.Tensor,
-                target_patches: torch.Tensor):
+    def forward(self, encoded_patches: torch.Tensor, target_patches: torch.Tensor):
         """
         The forward pass of the char-level decoder model.
         :param encoded_patches: the encoded patches
         :param target_patches: the target patches
         :return: the output of the model
         """
-        target_patches = torch.cat((torch.ones_like(target_patches[:, 0:1]) * self.bos_token_id,
-                                        target_patches), dim=1)  # [patch_len, patch_size + 1]
+        target_patches = torch.cat(
+            (
+                torch.ones_like(target_patches[:, 0:1]) * self.bos_token_id,
+                target_patches,
+            ),
+            dim=1,
+        )  # [patch_len, patch_size + 1]
 
-        target_masks = target_patches == self.special_token_id  # [patch_len, patch_size + 1]
+        target_masks = (
+            target_patches == self.special_token_id
+        )  # [patch_len, patch_size + 1]
         labels = target_patches.clone().masked_fill_(target_masks, -100)
 
         target_masks = torch.ones_like(labels)
         target_masks = target_masks.masked_fill_(labels == -100, 0)
 
-        input_embeds = torch.nn.functional.embedding(target_patches, self.base.transformer.wte.weight)
-        input_embeds = torch.cat((encoded_patches.unsqueeze(1), input_embeds[:, 1:, :]), dim=1)
-        logits = self.base(inputs_embeds=input_embeds,
-                           attention_mask=target_masks).logits  # [patch_len, patch_size + 1, vocab_size]
+        input_embeds = torch.nn.functional.embedding(
+            target_patches, self.base.transformer.wte.weight
+        )
+        input_embeds = torch.cat(
+            (encoded_patches.unsqueeze(1), input_embeds[:, 1:, :]), dim=1
+        )
+        logits = self.base(
+            inputs_embeds=input_embeds, attention_mask=target_masks
+        ).logits  # [patch_len, patch_size + 1, vocab_size]
         logits = logits[:, :-1, :]
-        token_logps = torch.gather(logits.log_softmax(-1), dim=-1, index=target_patches[:, 1:].unsqueeze(-1)).squeeze(-1)   # [patch_len, patch_size]
+        token_logps = torch.gather(
+            logits.log_softmax(-1), dim=-1, index=target_patches[:, 1:].unsqueeze(-1)
+        ).squeeze(
+            -1
+        )  # [patch_len, patch_size]
         token_logps = token_logps[target_masks[:, 1:] == 1]
         all_logps = token_logps.sum()
 
         return all_logps
 
-    def generate(self,
-                 encoded_patch: torch.Tensor,   # [hidden_size]
-                 tokens: torch.Tensor): # [1]
+    def generate(
+        self, encoded_patch: torch.Tensor, tokens: torch.Tensor  # [hidden_size]
+    ):  # [1]
         """
         The generate function for generating a patch based on the encoded patch and already generated tokens.
         :param encoded_patch: the encoded patch
         :param tokens: already generated tokens in the patch
         :return: the probability distribution of next token
         """
-        encoded_patch = encoded_patch.reshape(1, 1, -1) # [1, 1, hidden_size]
+        encoded_patch = encoded_patch.reshape(1, 1, -1)  # [1, 1, hidden_size]
         tokens = tokens.reshape(1, -1)
 
         # Get input embeddings
         tokens = torch.nn.functional.embedding(tokens, self.base.transformer.wte.weight)
 
         # Concatenate the encoded patch with the input embeddings
-        tokens = torch.cat((encoded_patch, tokens[:,1:,:]), dim=1)
-        
+        tokens = torch.cat((encoded_patch, tokens[:, 1:, :]), dim=1)
+
         # Get output from model
         outputs = self.base(inputs_embeds=tokens)
-        
+
         # Get probabilities of next token
         probs = torch.nn.functional.softmax(outputs.logits.squeeze(0)[-1], dim=-1)
 
         return probs
+
 
 def safe_normalize_probs(probs):
     epsilon = 1e-12
@@ -324,6 +377,7 @@ def safe_normalize_probs(probs):
         probs[0] = 1.0
     return probs
 
+
 class NotaGenLMHeadModel(PreTrainedModel):
     """
     NotaGen is a language model with a hierarchical structure.
@@ -332,6 +386,7 @@ class NotaGenLMHeadModel(PreTrainedModel):
     The char-level decoder is used to generate the chars within each patch in an auto-regressive manner.
     It inherits PreTrainedModel from transformers.
     """
+
     def __init__(self, encoder_config, decoder_config):
         super().__init__(encoder_config)
         self.special_token_id = 0
@@ -340,9 +395,7 @@ class NotaGenLMHeadModel(PreTrainedModel):
         self.patch_level_decoder = PatchLevelDecoder(encoder_config)
         self.char_level_decoder = CharLevelDecoder(decoder_config)
 
-    def forward(self,
-                patches: torch.Tensor,
-                masks: torch.Tensor):
+    def forward(self, patches: torch.Tensor, masks: torch.Tensor):
         """
         The forward pass of the bGPT model.
         :param patches: the patches to be encoded
@@ -360,11 +413,7 @@ class NotaGenLMHeadModel(PreTrainedModel):
 
         return self.char_level_decoder(encoded_patches, patches)
 
-    def generate(self,
-                 patches: torch.Tensor,
-                 top_k=0,
-                 top_p=1,
-                 temperature=1.0):
+    def generate(self, patches: torch.Tensor, top_k=0, top_p=1, temperature=1.0):
         """
         The generate function for generating patches based on patches.
         :param patches: the patches to be encoded
@@ -374,33 +423,41 @@ class NotaGenLMHeadModel(PreTrainedModel):
         :return: the generated patches
         """
         if patches.shape[-1] % PATCH_SIZE != 0:
-            tokens = patches[:,:,-(patches.shape[-1]%PATCH_SIZE):].squeeze(0, 1)
-            tokens = torch.cat((torch.tensor([self.bos_token_id], device=self.device), tokens), dim=-1)
-            patches = patches[:,:,:-(patches.shape[-1]%PATCH_SIZE)]
+            tokens = patches[:, :, -(patches.shape[-1] % PATCH_SIZE) :].squeeze(0, 1)
+            tokens = torch.cat(
+                (torch.tensor([self.bos_token_id], device=self.device), tokens), dim=-1
+            )
+            patches = patches[:, :, : -(patches.shape[-1] % PATCH_SIZE)]
         else:
-            tokens =  torch.tensor([self.bos_token_id], device=self.device)
+            tokens = torch.tensor([self.bos_token_id], device=self.device)
 
-        patches = patches.reshape(len(patches), -1, PATCH_SIZE) # [bs, seq, patch_size]
-        encoded_patches = self.patch_level_decoder(patches)["last_hidden_state"]    # [bs, seq, hidden_size]
-        generated_patch = []            
+        patches = patches.reshape(len(patches), -1, PATCH_SIZE)  # [bs, seq, patch_size]
+        encoded_patches = self.patch_level_decoder(patches)[
+            "last_hidden_state"
+        ]  # [bs, seq, hidden_size]
+        generated_patch = []
 
         while True:
-            prob = self.char_level_decoder.generate(encoded_patches[0][-1], tokens).cpu().detach().numpy()  # [128]
+            prob = (
+                self.char_level_decoder.generate(encoded_patches[0][-1], tokens)
+                .cpu()
+                .detach()
+                .numpy()
+            )  # [128]
             prob = safe_normalize_probs(prob)
-            prob = top_k_sampling(prob, top_k=top_k, return_probs=True) # [128]
+            prob = top_k_sampling(prob, top_k=top_k, return_probs=True)  # [128]
             prob = safe_normalize_probs(prob)
-            prob = top_p_sampling(prob, top_p=top_p, return_probs=True) # [128]
+            prob = top_p_sampling(prob, top_p=top_p, return_probs=True)  # [128]
             prob = safe_normalize_probs(prob)
-            token = temperature_sampling(prob, temperature=temperature) # int
+            token = temperature_sampling(prob, temperature=temperature)  # int
             char = chr(token)
             generated_patch.append(token)
 
-            if len(tokens) >= PATCH_SIZE:# or token == self.eos_token_id:
+            if len(tokens) >= PATCH_SIZE:  # or token == self.eos_token_id:
                 break
             else:
-                tokens = torch.cat((tokens, torch.tensor([token], device=self.device)), dim=0)
-        
+                tokens = torch.cat(
+                    (tokens, torch.tensor([token], device=self.device)), dim=0
+                )
+
         return generated_patch
-
-
-

--- a/clamp2/config.py
+++ b/clamp2/config.py
@@ -2,13 +2,9 @@ EVAL_SPLIT = 0.01  # Fraction of training data used for evaluation
 WANDB_KEY = "<your_wandb_key>"  # Set M3/CLaMP2_WANDB_LOG=False if no API key for Weights and Biases logging
 
 # -------------------- Configuration for M3 Training --------------------
-TRAIN_FOLDERS = [
-    "<path_to_training_data>"  # Directory containing training data
-]
+TRAIN_FOLDERS = ["<path_to_training_data>"]  # Directory containing training data
 
-EVAL_FOLDERS = [
-    ""  # (Optional) Directory containing evaluation data
-]
+EVAL_FOLDERS = [""]  # (Optional) Directory containing evaluation data
 
 PATCH_SIZE = 64  # Size of each patch
 PATCH_LENGTH = 512  # Length of the patches
@@ -25,16 +21,27 @@ M3_WANDB_LOG = True  # Enable logging to Weights and Biases
 M3_LOAD_CKPT = True  # Load model weights from a checkpoint if available
 
 M3_WEIGHTS_PATH = (
-    "weights_m3_p_size_" + str(PATCH_SIZE) +
-    "_p_length_" + str(PATCH_LENGTH) +
-    "_t_layers_" + str(TOKEN_NUM_LAYERS) +
-    "_p_layers_" + str(PATCH_NUM_LAYERS) +
-    "_h_size_" + str(M3_HIDDEN_SIZE) +
-    "_lr_" + str(M3_LEARNING_RATE) +
-    "_batch_" + str(M3_BATCH_SIZE) +
-    "_mask_" + str(M3_MASK_RATIO) + ".pth"
+    "weights_m3_p_size_"
+    + str(PATCH_SIZE)
+    + "_p_length_"
+    + str(PATCH_LENGTH)
+    + "_t_layers_"
+    + str(TOKEN_NUM_LAYERS)
+    + "_p_layers_"
+    + str(PATCH_NUM_LAYERS)
+    + "_h_size_"
+    + str(M3_HIDDEN_SIZE)
+    + "_lr_"
+    + str(M3_LEARNING_RATE)
+    + "_batch_"
+    + str(M3_BATCH_SIZE)
+    + "_mask_"
+    + str(M3_MASK_RATIO)
+    + ".pth"
 )  # Path to store the model weights
-M3_LOGS_PATH = M3_WEIGHTS_PATH.replace("weights", "logs").replace("pth", "txt")  # Path to save training logs
+M3_LOGS_PATH = M3_WEIGHTS_PATH.replace("weights", "logs").replace(
+    "pth", "txt"
+)  # Path to save training logs
 
 # -------------------- Configuration for CLaMP2 Training ----------------
 TRAIN_JSONL = "<path_to_training_jsonl>"  # Path to the JSONL file with training data
@@ -55,13 +62,24 @@ CLAMP2_WANDB_LOG = True  # Enable logging to Weights and Biases
 CLAMP2_LOAD_CKPT = True  # Load weights from a checkpoint if available
 
 CLAMP2_WEIGHTS_PATH = (
-    "weights_clamp2_h_size_" + str(CLAMP2_HIDDEN_SIZE) +
-    "_lr_" + str(CLAMP2_LEARNING_RATE) +
-    "_batch_" + str(CLAMP2_BATCH_SIZE) +
-    "_scale_" + str(LOGIT_SCALE) +
-    "_t_length_" + str(MAX_TEXT_LENGTH) +
-    "_t_model_" + TEXT_MODEL_NAME.replace("/", "_") +
-    "_t_dropout_" + str(TEXT_DROPOUT) +
-    "_m3_" + str(CLAMP2_LOAD_M3) + ".pth"
+    "weights_clamp2_h_size_"
+    + str(CLAMP2_HIDDEN_SIZE)
+    + "_lr_"
+    + str(CLAMP2_LEARNING_RATE)
+    + "_batch_"
+    + str(CLAMP2_BATCH_SIZE)
+    + "_scale_"
+    + str(LOGIT_SCALE)
+    + "_t_length_"
+    + str(MAX_TEXT_LENGTH)
+    + "_t_model_"
+    + TEXT_MODEL_NAME.replace("/", "_")
+    + "_t_dropout_"
+    + str(TEXT_DROPOUT)
+    + "_m3_"
+    + str(CLAMP2_LOAD_M3)
+    + ".pth"
 )  # Path to store CLaMP2 model weights
-CLAMP2_LOGS_PATH = CLAMP2_WEIGHTS_PATH.replace("weights", "logs").replace("pth", "txt")  # Path to save training logs
+CLAMP2_LOGS_PATH = CLAMP2_WEIGHTS_PATH.replace("weights", "logs").replace(
+    "pth", "txt"
+)  # Path to save training logs

--- a/clamp2/extract_clamp2.py
+++ b/clamp2/extract_clamp2.py
@@ -1,5 +1,5 @@
-input_dir = ''  # interleaved abc folder
-output_dir = ''  # feature folder
+input_dir = ""  # interleaved abc folder
+output_dir = ""  # feature folder
 
 import os
 import json
@@ -12,17 +12,18 @@ from utils import *
 from samplings import *
 from accelerate import Accelerator
 from transformers import BertConfig, AutoTokenizer
-import argparse
 
 
 normalize = True
 
 os.makedirs("logs", exist_ok=True)
-for file in ["logs/files_extract_clamp2.json",
-             "logs/files_shuffle_extract_clamp2.json",
-             "logs/log_extract_clamp2.txt",
-             "logs/pass_extract_clamp2.txt",
-             "logs/skip_extract_clamp2.txt"]:
+for file in [
+    "logs/files_extract_clamp2.json",
+    "logs/files_shuffle_extract_clamp2.json",
+    "logs/log_extract_clamp2.txt",
+    "logs/pass_extract_clamp2.txt",
+    "logs/skip_extract_clamp2.txt",
+]:
     if os.path.exists(file):
         os.remove(file)
 
@@ -36,7 +37,7 @@ with open("logs/files_extract_clamp2.json", "w", encoding="utf-8") as f:
     json.dump(files, f)
 random.shuffle(files)
 with open("logs/files_shuffle_extract_clamp2.json", "w", encoding="utf-8") as f:
-    json.dump(files, f) 
+    json.dump(files, f)
 
 accelerator = Accelerator()
 device = accelerator.device
@@ -44,27 +45,37 @@ print("Using device:", device)
 with open("logs/log_extract_clamp.txt", "a", encoding="utf-8") as f:
     f.write("Using device: " + str(device) + "\n")
 
-m3_config = BertConfig(vocab_size=1,
-                        hidden_size=M3_HIDDEN_SIZE,
-                        num_hidden_layers=PATCH_NUM_LAYERS,
-                        num_attention_heads=M3_HIDDEN_SIZE//64,
-                        intermediate_size=M3_HIDDEN_SIZE*4,
-                        max_position_embeddings=PATCH_LENGTH)
-model = CLaMP2Model(m3_config,
-                    text_model_name=TEXT_MODEL_NAME,
-                    hidden_size=CLAMP2_HIDDEN_SIZE,
-                    load_m3=CLAMP2_LOAD_M3)
+m3_config = BertConfig(
+    vocab_size=1,
+    hidden_size=M3_HIDDEN_SIZE,
+    num_hidden_layers=PATCH_NUM_LAYERS,
+    num_attention_heads=M3_HIDDEN_SIZE // 64,
+    intermediate_size=M3_HIDDEN_SIZE * 4,
+    max_position_embeddings=PATCH_LENGTH,
+)
+model = CLaMP2Model(
+    m3_config,
+    text_model_name=TEXT_MODEL_NAME,
+    hidden_size=CLAMP2_HIDDEN_SIZE,
+    load_m3=CLAMP2_LOAD_M3,
+)
 model = model.to(device)
 tokenizer = AutoTokenizer.from_pretrained(TEXT_MODEL_NAME)
 patchilizer = M3Patchilizer()
 
 # print parameter number
-print("Parameter Number: "+str(sum(p.numel() for p in model.parameters() if p.requires_grad)))
+print(
+    "Parameter Number: "
+    + str(sum(p.numel() for p in model.parameters() if p.requires_grad))
+)
 
 model.eval()
-checkpoint = torch.load(CLAMP2_WEIGHTS_PATH, map_location='cpu', weights_only=True)
-print(f"Successfully Loaded CLaMP 2 Checkpoint from Epoch {checkpoint['epoch']} with loss {checkpoint['min_eval_loss']}")
-model.load_state_dict(checkpoint['model'])
+checkpoint = torch.load(CLAMP2_WEIGHTS_PATH, map_location="cpu", weights_only=True)
+print(
+    f"Successfully Loaded CLaMP 2 Checkpoint from Epoch {checkpoint['epoch']} with loss {checkpoint['min_eval_loss']}"
+)
+model.load_state_dict(checkpoint["model"])
+
 
 def extract_feature(filename, get_normalized=normalize):
     with open(filename, "r", encoding="utf-8") as f:
@@ -72,12 +83,12 @@ def extract_feature(filename, get_normalized=normalize):
 
     filtered_lines = []
     for line in lines:
-        if line.startswith('%') and not line.startswith('%%'):
+        if line.startswith("%") and not line.startswith("%%"):
             pass
         else:
             filtered_lines.append(line)
 
-    item = ''.join(filtered_lines)
+    item = "".join(filtered_lines)
 
     if filename.endswith(".txt"):
         item = list(set(item.split("\n")))
@@ -86,7 +97,7 @@ def extract_feature(filename, get_normalized=normalize):
         item = [c for c in item if len(c) > 0]
         item = tokenizer.sep_token.join(item)
         input_data = tokenizer(item, return_tensors="pt")
-        input_data = input_data['input_ids'].squeeze(0)
+        input_data = input_data["input_ids"].squeeze(0)
         max_input_length = MAX_TEXT_LENGTH
     else:
         input_data = patchilizer.encode(item, add_special_patches=True)
@@ -95,49 +106,74 @@ def extract_feature(filename, get_normalized=normalize):
 
     segment_list = []
     for i in range(0, len(input_data), max_input_length):
-        segment_list.append(input_data[i:i+max_input_length])
+        segment_list.append(input_data[i : i + max_input_length])
     segment_list[-1] = input_data[-max_input_length:]
 
     last_hidden_states_list = []
 
     for input_segment in segment_list:
-        input_masks = torch.tensor([1]*input_segment.size(0))
+        input_masks = torch.tensor([1] * input_segment.size(0))
         if filename.endswith(".txt"):
-            pad_indices = torch.ones(MAX_TEXT_LENGTH - input_segment.size(0)).long() * tokenizer.pad_token_id
+            pad_indices = (
+                torch.ones(MAX_TEXT_LENGTH - input_segment.size(0)).long()
+                * tokenizer.pad_token_id
+            )
         else:
-            pad_indices = torch.ones((PATCH_LENGTH - input_segment.size(0), PATCH_SIZE)).long() * patchilizer.pad_token_id
-        input_masks = torch.cat((input_masks, torch.zeros(max_input_length - input_segment.size(0))), 0)
+            pad_indices = (
+                torch.ones((PATCH_LENGTH - input_segment.size(0), PATCH_SIZE)).long()
+                * patchilizer.pad_token_id
+            )
+        input_masks = torch.cat(
+            (input_masks, torch.zeros(max_input_length - input_segment.size(0))), 0
+        )
         input_segment = torch.cat((input_segment, pad_indices), 0)
 
         if filename.endswith(".txt"):
-            last_hidden_states = model.get_text_features(text_inputs=input_segment.unsqueeze(0).to(device),
-                                                         text_masks=input_masks.unsqueeze(0).to(device),
-                                                         get_normalized=get_normalized)
+            last_hidden_states = model.get_text_features(
+                text_inputs=input_segment.unsqueeze(0).to(device),
+                text_masks=input_masks.unsqueeze(0).to(device),
+                get_normalized=get_normalized,
+            )
         else:
-            last_hidden_states = model.get_music_features(music_inputs=input_segment.unsqueeze(0).to(device),
-                                                          music_masks=input_masks.unsqueeze(0).to(device),
-                                                          get_normalized=get_normalized)
+            last_hidden_states = model.get_music_features(
+                music_inputs=input_segment.unsqueeze(0).to(device),
+                music_masks=input_masks.unsqueeze(0).to(device),
+                get_normalized=get_normalized,
+            )
         if not get_normalized:
-            last_hidden_states = last_hidden_states[:, :input_masks.sum().long().item(), :]
+            last_hidden_states = last_hidden_states[
+                :, : input_masks.sum().long().item(), :
+            ]
         last_hidden_states_list.append(last_hidden_states)
 
     if not get_normalized:
-        last_hidden_states_list = [last_hidden_states[0] for last_hidden_states in last_hidden_states_list]
-        last_hidden_states_list[-1] = last_hidden_states_list[-1][-(len(input_data)%max_input_length):]
+        last_hidden_states_list = [
+            last_hidden_states[0] for last_hidden_states in last_hidden_states_list
+        ]
+        last_hidden_states_list[-1] = last_hidden_states_list[-1][
+            -(len(input_data) % max_input_length) :
+        ]
         last_hidden_states_list = torch.concat(last_hidden_states_list, 0)
     else:
         full_chunk_cnt = len(input_data) // max_input_length
         remain_chunk_len = len(input_data) % max_input_length
         if remain_chunk_len == 0:
-            feature_weights = torch.tensor([max_input_length] * full_chunk_cnt, device=device).view(-1, 1)
+            feature_weights = torch.tensor(
+                [max_input_length] * full_chunk_cnt, device=device
+            ).view(-1, 1)
         else:
-            feature_weights = torch.tensor([max_input_length] * full_chunk_cnt + [remain_chunk_len], device=device).view(-1, 1)
-        
+            feature_weights = torch.tensor(
+                [max_input_length] * full_chunk_cnt + [remain_chunk_len], device=device
+            ).view(-1, 1)
+
         last_hidden_states_list = torch.concat(last_hidden_states_list, 0)
         last_hidden_states_list = last_hidden_states_list * feature_weights
-        last_hidden_states_list = last_hidden_states_list.sum(dim=0) / feature_weights.sum()
+        last_hidden_states_list = (
+            last_hidden_states_list.sum(dim=0) / feature_weights.sum()
+        )
 
     return last_hidden_states_list
+
 
 def process_directory(input_dir, output_dir, files):
     print(f"Found {len(files)} files in total")
@@ -157,7 +193,7 @@ def process_directory(input_dir, output_dir, files):
 
     # process the files
     for file in tqdm(files_to_process):
-        output_subdir = output_dir + os.path.dirname(file)[len(input_dir):]
+        output_subdir = output_dir + os.path.dirname(file)[len(input_dir) :]
         try:
             os.makedirs(output_subdir, exist_ok=True)
         except Exception as e:
@@ -165,7 +201,9 @@ def process_directory(input_dir, output_dir, files):
             with open("logs/log_extract_clamp.txt", "a") as f:
                 f.write(output_subdir + " can not be created\n" + str(e) + "\n")
 
-        output_file = os.path.join(output_subdir, os.path.splitext(os.path.basename(file))[0] + ".npy")
+        output_file = os.path.join(
+            output_subdir, os.path.splitext(os.path.basename(file))[0] + ".npy"
+        )
 
         if os.path.exists(output_file):
             print(f"Skipping {file}, output already exists")
@@ -183,6 +221,7 @@ def process_directory(input_dir, output_dir, files):
             print(f"Failed to process {file}: {e}")
             with open("logs/log_extract_clamp.txt", "a", encoding="utf-8") as f:
                 f.write("Failed to process " + file + ": " + str(e) + "\n")
+
 
 with open("logs/files_shuffle_extract_clamp2.json", "r", encoding="utf-8") as f:
     files = json.load(f)

--- a/clamp2/statistics.py
+++ b/clamp2/statistics.py
@@ -1,12 +1,10 @@
-gt_feature_folder = ''
-output_feature_folder = ''
+gt_feature_folder = ""
+output_feature_folder = ""
 
 import os
-import json
-import random
-import re
 import numpy as np
 from config import *
+
 
 def load_npy_files(folder_path_list):
     """
@@ -14,11 +12,12 @@ def load_npy_files(folder_path_list):
     """
     npy_list = []
     for file_path in folder_path_list:
-        if file_path.endswith('.npy'):
+        if file_path.endswith(".npy"):
             # file_path = os.path.join(folder_path, file_name)
             np_array = np.load(file_path)[0]
             npy_list.append(np_array)
     return npy_list
+
 
 def average_npy(npy_list):
     """
@@ -26,19 +25,19 @@ def average_npy(npy_list):
     """
     return np.mean(npy_list, axis=0)
 
+
 def cosine_similarity(vec1, vec2):
     """
     Compute cosine similarity between two numpy arrays.
     """
     dot_product = np.dot(vec1, vec2)
-    
+
     norm_vec1 = np.linalg.norm(vec1)
     norm_vec2 = np.linalg.norm(vec2)
-    
-    cosine_sim = dot_product / (norm_vec1 * norm_vec2)
-    
-    return cosine_sim
 
+    cosine_sim = dot_product / (norm_vec1 * norm_vec2)
+
+    return cosine_sim
 
 
 def test_generated_results_similarity():
@@ -57,12 +56,9 @@ def test_generated_results_similarity():
         clamp2score_list.append(clamp2score)
     avg_clampscore = sum(clamp2score_list) / len(clamp2score_list)
 
-    print('average clamp 2 score:', avg_clampscore)
-    
+    print("average clamp 2 score:", avg_clampscore)
 
 
-
-if __name__ == '__main__':
+if __name__ == "__main__":
 
     test_generated_results_similarity()
-

--- a/clamp2/utils.py
+++ b/clamp2/utils.py
@@ -6,7 +6,13 @@ import random
 from config import *
 from unidecode import unidecode
 from torch.nn import functional as F
-from transformers import AutoModel, BertModel, GPT2LMHeadModel, PreTrainedModel, GPT2Config
+from transformers import (
+    AutoModel,
+    BertModel,
+    GPT2LMHeadModel,
+    PreTrainedModel,
+    GPT2Config,
+)
 
 try:
     import torch.distributed.nn
@@ -21,16 +27,17 @@ try:
 except ImportError:
     hvd = None
 
+
 class ClipLoss(torch.nn.Module):
 
     def __init__(
-            self,
-            local_loss=False,
-            gather_with_grad=False,
-            cache_labels=False,
-            rank=0,
-            world_size=1,
-            use_horovod=False,
+        self,
+        local_loss=False,
+        gather_with_grad=False,
+        cache_labels=False,
+        rank=0,
+        world_size=1,
+        use_horovod=False,
     ):
         super().__init__()
         self.local_loss = local_loss
@@ -45,18 +52,20 @@ class ClipLoss(torch.nn.Module):
         self.labels = {}
 
     def gather_features(
-            self,
-            image_features,
-            text_features,
-            local_loss=False,
-            gather_with_grad=False,
-            rank=0,
-            world_size=1,
-            use_horovod=False
+        self,
+        image_features,
+        text_features,
+        local_loss=False,
+        gather_with_grad=False,
+        rank=0,
+        world_size=1,
+        use_horovod=False,
     ):
-        assert has_distributed, 'torch.distributed did not import correctly, please use a PyTorch version with support.'
+        assert (
+            has_distributed
+        ), "torch.distributed did not import correctly, please use a PyTorch version with support."
         if use_horovod:
-            assert hvd is not None, 'Please install horovod'
+            assert hvd is not None, "Please install horovod"
             if gather_with_grad:
                 all_image_features = hvd.allgather(image_features)
                 all_text_features = hvd.allgather(text_features)
@@ -66,8 +75,12 @@ class ClipLoss(torch.nn.Module):
                     all_text_features = hvd.allgather(text_features)
                 if not local_loss:
                     # ensure grads for local rank when all_* features don't have a gradient
-                    gathered_image_features = list(all_image_features.chunk(world_size, dim=0))
-                    gathered_text_features = list(all_text_features.chunk(world_size, dim=0))
+                    gathered_image_features = list(
+                        all_image_features.chunk(world_size, dim=0)
+                    )
+                    gathered_text_features = list(
+                        all_text_features.chunk(world_size, dim=0)
+                    )
                     gathered_image_features[rank] = image_features
                     gathered_text_features[rank] = text_features
                     all_image_features = torch.cat(gathered_image_features, dim=0)
@@ -75,11 +88,19 @@ class ClipLoss(torch.nn.Module):
         else:
             # We gather tensors from all gpus
             if gather_with_grad:
-                all_image_features = torch.cat(torch.distributed.nn.all_gather(image_features), dim=0)
-                all_text_features = torch.cat(torch.distributed.nn.all_gather(text_features), dim=0)
+                all_image_features = torch.cat(
+                    torch.distributed.nn.all_gather(image_features), dim=0
+                )
+                all_text_features = torch.cat(
+                    torch.distributed.nn.all_gather(text_features), dim=0
+                )
             else:
-                gathered_image_features = [torch.zeros_like(image_features) for _ in range(world_size)]
-                gathered_text_features = [torch.zeros_like(text_features) for _ in range(world_size)]
+                gathered_image_features = [
+                    torch.zeros_like(image_features) for _ in range(world_size)
+                ]
+                gathered_text_features = [
+                    torch.zeros_like(text_features) for _ in range(world_size)
+                ]
                 dist.all_gather(gathered_image_features, image_features)
                 dist.all_gather(gathered_text_features, text_features)
                 if not local_loss:
@@ -107,70 +128,83 @@ class ClipLoss(torch.nn.Module):
     def get_logits(self, image_features, text_features, logit_scale):
         if self.world_size > 1:
             all_image_features, all_text_features = self.gather_features(
-                image_features, text_features,
-                self.local_loss, self.gather_with_grad, self.rank, self.world_size, self.use_horovod)
+                image_features,
+                text_features,
+                self.local_loss,
+                self.gather_with_grad,
+                self.rank,
+                self.world_size,
+                self.use_horovod,
+            )
 
             if self.local_loss:
                 logits_per_image = logit_scale * image_features @ all_text_features.T
                 logits_per_text = logit_scale * text_features @ all_image_features.T
             else:
-                logits_per_image = logit_scale * all_image_features @ all_text_features.T
+                logits_per_image = (
+                    logit_scale * all_image_features @ all_text_features.T
+                )
                 logits_per_text = logits_per_image.T
         else:
             logits_per_image = logit_scale * image_features @ text_features.T
             logits_per_text = logit_scale * text_features @ image_features.T
-        
+
         return logits_per_image, logits_per_text
 
     def forward(self, image_features, text_features, logit_scale, output_dict=False):
         device = image_features.device
-        logits_per_image, logits_per_text = self.get_logits(image_features, text_features, logit_scale)
+        logits_per_image, logits_per_text = self.get_logits(
+            image_features, text_features, logit_scale
+        )
 
         labels = self.get_ground_truth(device, logits_per_image.shape[0])
 
         total_loss = (
-            F.cross_entropy(logits_per_image, labels) +
-            F.cross_entropy(logits_per_text, labels)
+            F.cross_entropy(logits_per_image, labels)
+            + F.cross_entropy(logits_per_text, labels)
         ) / 2
 
         return {"contrastive_loss": total_loss} if output_dict else total_loss
-    
+
+
 class M3Patchilizer:
     def __init__(self):
         self.delimiters = ["|:", "::", ":|", "[|", "||", "|]", "|"]
-        self.regexPattern = '(' + '|'.join(map(re.escape, self.delimiters)) + ')'
+        self.regexPattern = "(" + "|".join(map(re.escape, self.delimiters)) + ")"
         self.pad_token_id = 0
         self.bos_token_id = 1
         self.eos_token_id = 2
         self.mask_token_id = 3
 
     def split_bars(self, body):
-        bars = re.split(self.regexPattern, ''.join(body))
+        bars = re.split(self.regexPattern, "".join(body))
         bars = list(filter(None, bars))  # remove empty strings
         if bars[0] in self.delimiters:
             bars[1] = bars[0] + bars[1]
             bars = bars[1:]
         bars = [bars[i * 2] + bars[i * 2 + 1] for i in range(len(bars) // 2)]
         return bars
-    
+
     def bar2patch(self, bar, patch_size=PATCH_SIZE):
         patch = [self.bos_token_id] + [ord(c) for c in bar] + [self.eos_token_id]
         patch = patch[:patch_size]
         patch += [self.pad_token_id] * (patch_size - len(patch))
         return patch
-    
-    def patch2bar(self, patch):
-        return ''.join(chr(idx) if idx > self.mask_token_id else '' for idx in patch)
 
-    def encode(self,
-               item,
-               patch_size=PATCH_SIZE,
-               add_special_patches=False,
-               truncate=False,
-               random_truncate=False):
-        
+    def patch2bar(self, patch):
+        return "".join(chr(idx) if idx > self.mask_token_id else "" for idx in patch)
+
+    def encode(
+        self,
+        item,
+        patch_size=PATCH_SIZE,
+        add_special_patches=False,
+        truncate=False,
+        random_truncate=False,
+    ):
+
         item = unidecode(item)
-        lines = re.findall(r'.*?\n|.*$', item)
+        lines = re.findall(r".*?\n|.*$", item)
         lines = list(filter(None, lines))  # remove empty lines
 
         patches = []
@@ -178,24 +212,28 @@ class M3Patchilizer:
         if lines[0].split(" ")[0] == "ticks_per_beat":
             patch = ""
             for line in lines:
-                if patch.startswith(line.split(" ")[0]) and (len(patch) + len(" ".join(line.split(" ")[1:])) <= patch_size-2):
+                if patch.startswith(line.split(" ")[0]) and (
+                    len(patch) + len(" ".join(line.split(" ")[1:])) <= patch_size - 2
+                ):
                     patch = patch[:-1] + "\t" + " ".join(line.split(" ")[1:])
                 else:
                     if patch:
                         patches.append(patch)
                     patch = line
-            if patch!="":
+            if patch != "":
                 patches.append(patch)
         else:
             for line in lines:
-                if len(line) > 1 and ((line[0].isalpha() and line[1] == ':') or line.startswith('%%')):
+                if len(line) > 1 and (
+                    (line[0].isalpha() and line[1] == ":") or line.startswith("%%")
+                ):
                     patches.append(line)
                 else:
                     bars = self.split_bars(line)
                     if bars:
-                        bars[-1] += '\n'
+                        bars[-1] += "\n"
                         patches.extend(bars)
-        
+
         if add_special_patches:
             bos_patch = chr(self.bos_token_id) * patch_size
             eos_patch = chr(self.eos_token_id) * patch_size
@@ -204,44 +242,48 @@ class M3Patchilizer:
         if len(patches) > PATCH_LENGTH and truncate:
             choices = ["head", "tail", "middle"]
             choice = random.choice(choices)
-            if choice=="head" or random_truncate==False:
+            if choice == "head" or random_truncate == False:
                 patches = patches[:PATCH_LENGTH]
-            elif choice=="tail":
+            elif choice == "tail":
                 patches = patches[-PATCH_LENGTH:]
             else:
-                start = random.randint(1, len(patches)-PATCH_LENGTH)
-                patches = patches[start:start+PATCH_LENGTH]
+                start = random.randint(1, len(patches) - PATCH_LENGTH)
+                patches = patches[start : start + PATCH_LENGTH]
 
         patches = [self.bar2patch(patch) for patch in patches]
 
         return patches
 
     def decode(self, patches):
-        return ''.join(self.patch2bar(patch) for patch in patches)
+        return "".join(self.patch2bar(patch) for patch in patches)
+
 
 class M3PatchEncoder(PreTrainedModel):
     def __init__(self, config):
         super(M3PatchEncoder, self).__init__(config)
-        self.patch_embedding = torch.nn.Linear(PATCH_SIZE*128, M3_HIDDEN_SIZE)
+        self.patch_embedding = torch.nn.Linear(PATCH_SIZE * 128, M3_HIDDEN_SIZE)
         torch.nn.init.normal_(self.patch_embedding.weight, std=0.02)
         self.base = BertModel(config=config)
         self.pad_token_id = 0
         self.bos_token_id = 1
         self.eos_token_id = 2
         self.mask_token_id = 3
-        
-    def forward(self,
-                input_patches, # [batch_size, seq_length, hidden_size]
-                input_masks):  # [batch_size, seq_length]
+
+    def forward(
+        self, input_patches, input_masks  # [batch_size, seq_length, hidden_size]
+    ):  # [batch_size, seq_length]
         # Transform input_patches into embeddings
         input_patches = torch.nn.functional.one_hot(input_patches, num_classes=128)
-        input_patches = input_patches.reshape(len(input_patches), -1, PATCH_SIZE*128).type(torch.FloatTensor)
+        input_patches = input_patches.reshape(
+            len(input_patches), -1, PATCH_SIZE * 128
+        ).type(torch.FloatTensor)
         input_patches = self.patch_embedding(input_patches.to(self.device))
 
         # Apply BERT model to input_patches and input_masks
         return self.base(inputs_embeds=input_patches, attention_mask=input_masks)
 
-class M3TokenDecoder(PreTrainedModel):    
+
+class M3TokenDecoder(PreTrainedModel):
     def __init__(self, config):
         super(M3TokenDecoder, self).__init__(config)
         self.base = GPT2LMHeadModel(config=config)
@@ -249,15 +291,19 @@ class M3TokenDecoder(PreTrainedModel):
         self.bos_token_id = 1
         self.eos_token_id = 2
         self.mask_token_id = 3
-        
-    def forward(self,
-                patch_features,  # [batch_size, hidden_size]
-                target_patches): # [batch_size, seq_length]
+
+    def forward(
+        self, patch_features, target_patches  # [batch_size, hidden_size]
+    ):  # [batch_size, seq_length]
         # get input embeddings
-        inputs_embeds = torch.nn.functional.embedding(target_patches, self.base.transformer.wte.weight)
+        inputs_embeds = torch.nn.functional.embedding(
+            target_patches, self.base.transformer.wte.weight
+        )
 
         # concatenate the encoded patches with the input embeddings
-        inputs_embeds = torch.cat((patch_features.unsqueeze(1), inputs_embeds[:,1:,:]), dim=1)
+        inputs_embeds = torch.cat(
+            (patch_features.unsqueeze(1), inputs_embeds[:, 1:, :]), dim=1
+        )
 
         # preparing the labels for model training
         target_masks = target_patches == self.pad_token_id
@@ -267,13 +313,13 @@ class M3TokenDecoder(PreTrainedModel):
         target_masks = ~target_masks
         target_masks = target_masks.type(torch.int)
 
-        return self.base(inputs_embeds=inputs_embeds,
-                         attention_mask=target_masks,
-                         labels=target_patches)
-        
-    def generate(self,
-                 patch_feature,
-                 tokens):
+        return self.base(
+            inputs_embeds=inputs_embeds,
+            attention_mask=target_masks,
+            labels=target_patches,
+        )
+
+    def generate(self, patch_feature, tokens):
         # reshape the patch_feature and tokens
         patch_feature = patch_feature.reshape(1, 1, -1)
         tokens = tokens.reshape(1, -1)
@@ -282,15 +328,16 @@ class M3TokenDecoder(PreTrainedModel):
         tokens = torch.nn.functional.embedding(tokens, self.base.transformer.wte.weight)
 
         # concatenate the encoded patches with the input embeddings
-        tokens = torch.cat((patch_feature, tokens[:,1:,:]), dim=1)
-        
+        tokens = torch.cat((patch_feature, tokens[:, 1:, :]), dim=1)
+
         # get the outputs from the model
         outputs = self.base(inputs_embeds=tokens)
-        
+
         # get the probabilities of the next token
         probs = torch.nn.functional.softmax(outputs.logits.squeeze(0)[-1], dim=-1)
 
         return probs.detach().cpu().numpy()
+
 
 class M3Model(PreTrainedModel):
     def __init__(self, encoder_config, decoder_config):
@@ -301,141 +348,179 @@ class M3Model(PreTrainedModel):
         self.bos_token_id = 1
         self.eos_token_id = 2
         self.mask_token_id = 3
-        
-    def forward(self,
-                input_patches,      # [batch_size, seq_length, hidden_size]
-                input_masks,        # [batch_size, seq_length]
-                selected_indices,   # [batch_size, seq_length]
-                target_patches):    # [batch_size, seq_length, hidden_size]
-        input_patches = input_patches.reshape(len(input_patches), -1, PATCH_SIZE).to(self.device)
+
+    def forward(
+        self,
+        input_patches,  # [batch_size, seq_length, hidden_size]
+        input_masks,  # [batch_size, seq_length]
+        selected_indices,  # [batch_size, seq_length]
+        target_patches,
+    ):  # [batch_size, seq_length, hidden_size]
+        input_patches = input_patches.reshape(len(input_patches), -1, PATCH_SIZE).to(
+            self.device
+        )
         input_masks = input_masks.to(self.device)
         selected_indices = selected_indices.to(self.device)
-        target_patches = target_patches.reshape(len(target_patches), -1, PATCH_SIZE).to(self.device)
+        target_patches = target_patches.reshape(len(target_patches), -1, PATCH_SIZE).to(
+            self.device
+        )
 
         # Pass the input_patches and input_masks through the encoder
         outputs = self.encoder(input_patches, input_masks)["last_hidden_state"]
-        
+
         # Use selected_indices to form target_patches
         target_patches = target_patches[selected_indices.bool()]
         patch_features = outputs[selected_indices.bool()]
-        
+
         # Pass patch_features and target_patches through the decoder
         return self.decoder(patch_features, target_patches)
 
+
 class CLaMP2Model(PreTrainedModel):
-    def __init__(self,
-                 music_config,
-                 global_rank=None,
-                 world_size=None,
-                 text_model_name=TEXT_MODEL_NAME,
-                 hidden_size=CLAMP2_HIDDEN_SIZE,
-                 load_m3=CLAMP2_LOAD_M3):
+    def __init__(
+        self,
+        music_config,
+        global_rank=None,
+        world_size=None,
+        text_model_name=TEXT_MODEL_NAME,
+        hidden_size=CLAMP2_HIDDEN_SIZE,
+        load_m3=CLAMP2_LOAD_M3,
+    ):
         super(CLaMP2Model, self).__init__(music_config)
 
-        self.text_model = AutoModel.from_pretrained(text_model_name) # Load the text model
-        self.text_proj = torch.nn.Linear(self.text_model.config.hidden_size, hidden_size) # Linear layer for text projections
-        torch.nn.init.normal_(self.text_proj.weight, std=0.02) # Initialize weights with normal distribution
+        self.text_model = AutoModel.from_pretrained(
+            text_model_name
+        )  # Load the text model
+        self.text_proj = torch.nn.Linear(
+            self.text_model.config.hidden_size, hidden_size
+        )  # Linear layer for text projections
+        torch.nn.init.normal_(
+            self.text_proj.weight, std=0.02
+        )  # Initialize weights with normal distribution
 
-        self.music_model = M3PatchEncoder(music_config) # Initialize the music model
-        self.music_proj = torch.nn.Linear(M3_HIDDEN_SIZE, hidden_size) # Linear layer for music projections
-        torch.nn.init.normal_(self.music_proj.weight, std=0.02) # Initialize weights with normal distribution
+        self.music_model = M3PatchEncoder(music_config)  # Initialize the music model
+        self.music_proj = torch.nn.Linear(
+            M3_HIDDEN_SIZE, hidden_size
+        )  # Linear layer for music projections
+        torch.nn.init.normal_(
+            self.music_proj.weight, std=0.02
+        )  # Initialize weights with normal distribution
 
-        if global_rank==None or world_size==None:
+        if global_rank == None or world_size == None:
             global_rank = 0
             world_size = 1
 
-        self.loss_fn = ClipLoss(local_loss=False,
-                                gather_with_grad=True,
-                                cache_labels=False,
-                                rank=global_rank,
-                                world_size=world_size,
-                                use_horovod=False)
+        self.loss_fn = ClipLoss(
+            local_loss=False,
+            gather_with_grad=True,
+            cache_labels=False,
+            rank=global_rank,
+            world_size=world_size,
+            use_horovod=False,
+        )
 
         if load_m3 and os.path.exists(M3_WEIGHTS_PATH):
-            checkpoint = torch.load(M3_WEIGHTS_PATH, map_location='cpu', weights_only=True)
-            decoder_config = GPT2Config(vocab_size=128,
-                            n_positions=PATCH_SIZE,
-                            n_embd=M3_HIDDEN_SIZE,
-                            n_layer=TOKEN_NUM_LAYERS,
-                            n_head=M3_HIDDEN_SIZE//64,
-                            n_inner=M3_HIDDEN_SIZE*4)
+            checkpoint = torch.load(
+                M3_WEIGHTS_PATH, map_location="cpu", weights_only=True
+            )
+            decoder_config = GPT2Config(
+                vocab_size=128,
+                n_positions=PATCH_SIZE,
+                n_embd=M3_HIDDEN_SIZE,
+                n_layer=TOKEN_NUM_LAYERS,
+                n_head=M3_HIDDEN_SIZE // 64,
+                n_inner=M3_HIDDEN_SIZE * 4,
+            )
             model = M3Model(music_config, decoder_config)
-            model.load_state_dict(checkpoint['model'])
+            model.load_state_dict(checkpoint["model"])
             self.music_model = model.encoder
             model = None
-            print(f"Successfully Loaded M3 Checkpoint from Epoch {checkpoint['epoch']} with loss {checkpoint['min_eval_loss']}")
-            
+            print(
+                f"Successfully Loaded M3 Checkpoint from Epoch {checkpoint['epoch']} with loss {checkpoint['min_eval_loss']}"
+            )
+
     def avg_pooling(self, input_features, input_masks):
-        input_masks = input_masks.unsqueeze(-1).to(self.device) # add a dimension to match the feature dimension
-        input_features = input_features * input_masks # apply mask to input_features
-        avg_pool = input_features.sum(dim=1) / input_masks.sum(dim=1) # calculate average pooling
-        
+        input_masks = input_masks.unsqueeze(-1).to(
+            self.device
+        )  # add a dimension to match the feature dimension
+        input_features = input_features * input_masks  # apply mask to input_features
+        avg_pool = input_features.sum(dim=1) / input_masks.sum(
+            dim=1
+        )  # calculate average pooling
+
         return avg_pool
-    
-    def get_text_features(self,
-                          text_inputs,
-                          text_masks,
-                          get_normalized=False):
-        text_features = self.text_model(text_inputs.to(self.device),
-                                        attention_mask=text_masks.to(self.device))['last_hidden_state']
+
+    def get_text_features(self, text_inputs, text_masks, get_normalized=False):
+        text_features = self.text_model(
+            text_inputs.to(self.device), attention_mask=text_masks.to(self.device)
+        )["last_hidden_state"]
 
         if get_normalized:
             text_features = self.avg_pooling(text_features, text_masks)
             text_features = self.text_proj(text_features)
-        
+
         return text_features
-    
-    def get_music_features(self,
-                            music_inputs,
-                            music_masks,
-                            get_normalized=False):
-        music_features = self.music_model(music_inputs.to(self.device),
-                                          music_masks.to(self.device))['last_hidden_state']
+
+    def get_music_features(self, music_inputs, music_masks, get_normalized=False):
+        music_features = self.music_model(
+            music_inputs.to(self.device), music_masks.to(self.device)
+        )["last_hidden_state"]
 
         if get_normalized:
             music_features = self.avg_pooling(music_features, music_masks)
             music_features = self.music_proj(music_features)
-        
+
         return music_features
 
-    def forward(self,
-                text_inputs,    # [batch_size, seq_length]
-                text_masks,     # [batch_size, seq_length]
-                music_inputs,   # [batch_size, seq_length, hidden_size]
-                music_masks):   # [batch_size, seq_length]
+    def forward(
+        self,
+        text_inputs,  # [batch_size, seq_length]
+        text_masks,  # [batch_size, seq_length]
+        music_inputs,  # [batch_size, seq_length, hidden_size]
+        music_masks,
+    ):  # [batch_size, seq_length]
         # Compute the text features
-        text_features = self.get_text_features(text_inputs, text_masks, get_normalized=True)
+        text_features = self.get_text_features(
+            text_inputs, text_masks, get_normalized=True
+        )
 
         # Compute the music features
-        music_features = self.get_music_features(music_inputs, music_masks, get_normalized=True)
+        music_features = self.get_music_features(
+            music_inputs, music_masks, get_normalized=True
+        )
 
-        return self.loss_fn(text_features,
-                            music_features,
-                            LOGIT_SCALE,
-                            output_dict=False)
+        return self.loss_fn(
+            text_features, music_features, LOGIT_SCALE, output_dict=False
+        )
+
 
 def split_data(data, eval_ratio=EVAL_SPLIT):
     random.shuffle(data)
-    split_idx = int(len(data)*eval_ratio)
+    split_idx = int(len(data) * eval_ratio)
     eval_set = data[:split_idx]
     train_set = data[split_idx:]
     return train_set, eval_set
 
+
 def mask_patches(target_patches, patchilizer, mode):
     indices = list(range(len(target_patches)))
     random.shuffle(indices)
-    selected_indices = indices[:math.ceil(M3_MASK_RATIO*len(indices))]
+    selected_indices = indices[: math.ceil(M3_MASK_RATIO * len(indices))]
     sorted_indices = sorted(selected_indices)
     input_patches = torch.tensor(target_patches)
 
-    if mode=="eval":
+    if mode == "eval":
         choice = "original"
     else:
-        choice = random.choices(["mask", "shuffle", "original"], weights=[0.8, 0.1, 0.1])[0]
-    
-    if choice=="mask":
-        input_patches[sorted_indices] = torch.tensor([patchilizer.mask_token_id]*PATCH_SIZE)
-    elif choice=="shuffle":
+        choice = random.choices(
+            ["mask", "shuffle", "original"], weights=[0.8, 0.1, 0.1]
+        )[0]
+
+    if choice == "mask":
+        input_patches[sorted_indices] = torch.tensor(
+            [patchilizer.mask_token_id] * PATCH_SIZE
+        )
+    elif choice == "shuffle":
         for idx in sorted_indices:
             patch = input_patches[idx]
             try:
@@ -447,15 +532,16 @@ def mask_patches(target_patches, patchilizer, mode):
             random.shuffle(indices)
             indices = [0] + indices + list(range(index_eos, len(patch)))
             input_patches[idx] = patch[indices]
-    
+
     selected_indices = torch.zeros(len(target_patches))
-    selected_indices[sorted_indices] = 1.
+    selected_indices[sorted_indices] = 1.0
 
     return input_patches, selected_indices
-    
+
+
 def remove_instrument_info(item):
     # remove instrument information from symbolic music
-    lines = re.findall(r'.*?\n|.*$', item)
+    lines = re.findall(r".*?\n|.*$", item)
     lines = list(filter(None, lines))
     if lines[0].split(" ")[0] == "ticks_per_beat":
         type = "mtf"
@@ -464,7 +550,7 @@ def remove_instrument_info(item):
 
     cleaned_lines = []
     for line in lines:
-        if type=="abc" and line.startswith("V:"):
+        if type == "abc" and line.startswith("V:"):
             # find the position of " nm=" or " snm="
             nm_pos = line.find(" nm=")
             snm_pos = line.find(" snm=")
@@ -475,9 +561,9 @@ def remove_instrument_info(item):
                 line = line[:snm_pos]
             if nm_pos != -1 or snm_pos != -1:
                 line += "\n"
-        elif type=="mtf" and line.startswith("program_change"):
+        elif type == "mtf" and line.startswith("program_change"):
             line = " ".join(line.split(" ")[:-1]) + " 0\n"
-                
+
         cleaned_lines.append(line)
-        
-    return ''.join(cleaned_lines)
+
+    return "".join(cleaned_lines)

--- a/data/1_batch_xml2abc.py
+++ b/data/1_batch_xml2abc.py
@@ -1,38 +1,45 @@
-ORI_FOLDER = ""  # Replace with the path to your folder containing XML (.xml, .mxl, .musicxml) files
-DES_FOLDER = ""   # The script will convert the musicxml files and output standard abc notation files to this folder
-
 import os
-import math
 import random
 import subprocess
-from tqdm import tqdm
 from multiprocessing import Pool
+
+from tqdm import tqdm
+
+
+ORI_FOLDER = ""  # Replace with the path to your folder containing XML (.xml, .mxl, .musicxml) files
+DES_FOLDER = ""  # The script will convert the musicxml files and output standard abc notation files to this folder
 
 
 def convert_xml2abc(file_list):
-    cmd = 'python xml2abc.py -d 8 -c 6 -x '
+    cmd = "python xml2abc.py -d 8 -c 6 -x "
     for file in tqdm(file_list):
         filename = os.path.basename(file)
         os.makedirs(DES_FOLDER, exist_ok=True)
 
         try:
-            p = subprocess.Popen(cmd + '"' + file + '"', stdout=subprocess.PIPE, shell=True)
+            p = subprocess.Popen(
+                cmd + '"' + file + '"', stdout=subprocess.PIPE, shell=True
+            )
             result = p.communicate()
-            output = result[0].decode('utf-8')
+            output = result[0].decode("utf-8")
 
-            if output == '':
+            if output == "":
                 with open("logs/xml2abc_error_log.txt", "a", encoding="utf-8") as f:
-                    f.write(file + '\n')
+                    f.write(file + "\n")
                 continue
             else:
-                with open(os.path.join(DES_FOLDER, filename.rsplit('.', 1)[0] + '.abc'), 'w', encoding='utf-8') as f:
+                with open(
+                    os.path.join(DES_FOLDER, filename.rsplit(".", 1)[0] + ".abc"),
+                    "w",
+                    encoding="utf-8",
+                ) as f:
                     f.write(output)
         except Exception as e:
             with open("logs/xml2abc_error_log.txt", "a", encoding="utf-8") as f:
-                f.write(file + ' ' + str(e) + '\n')
+                f.write(file + " " + str(e) + "\n")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     file_list = []
     os.makedirs("logs", exist_ok=True)
 

--- a/data/2_data_preprocess.py
+++ b/data/2_data_preprocess.py
@@ -1,26 +1,30 @@
-ORI_FOLDER = ''  # Replace with the path to your folder containing standard ABC notation files
-INTERLEAVED_FOLDER = ''   # Output interleaved ABC notation files to this folder
-AUGMENTED_FOLDER = ''   # Output key-augmented and rest-omitted ABC notation files to this folder
-EVAL_SPLIT = 0.1    # The ratio of eval data 
-
 import os
 import re
 import json
-import shutil
 import random
 from tqdm import tqdm
 from abctoolkit.utils import (
-    remove_information_field, 
-    remove_bar_no_annotations, 
-    Quote_re, 
+    remove_information_field,
+    remove_bar_no_annotations,
+    Quote_re,
     Barlines,
-    extract_metadata_and_parts, 
+    extract_metadata_and_parts,
     extract_global_and_local_metadata,
-    extract_barline_and_bartext_dict)
+    extract_barline_and_bartext_dict,
+)
 from abctoolkit.convert import unidecode_abc_lines
 from abctoolkit.rotate import rotate_abc
 from abctoolkit.check import check_alignment_unrotated
 from abctoolkit.transpose import Key2index, transpose_an_abc_text
+
+ORI_FOLDER = (
+    ""  # Replace with the path to your folder containing standard ABC notation files
+)
+INTERLEAVED_FOLDER = ""  # Output interleaved ABC notation files to this folder
+AUGMENTED_FOLDER = (
+    ""  # Output key-augmented and rest-omitted ABC notation files to this folder
+)
+EVAL_SPLIT = 0.1  # The ratio of eval data
 
 os.makedirs(INTERLEAVED_FOLDER, exist_ok=True)
 os.makedirs(AUGMENTED_FOLDER, exist_ok=True)
@@ -31,28 +35,30 @@ for key in Key2index.keys():
 
 def abc_preprocess_pipeline(abc_path):
 
-    with open(abc_path, 'r', encoding='utf-8') as f:
+    with open(abc_path, "r", encoding="utf-8") as f:
         abc_lines = f.readlines()
 
     # delete blank lines
-    abc_lines = [line for line in abc_lines if line.strip() != '']
+    abc_lines = [line for line in abc_lines if line.strip() != ""]
 
     # unidecode
     abc_lines = unidecode_abc_lines(abc_lines)
 
     # clean information field
-    abc_lines = remove_information_field(abc_lines=abc_lines, info_fields=['X:', 'T:', 'C:', 'W:', 'w:', 'Z:', '%%MIDI'])
+    abc_lines = remove_information_field(
+        abc_lines=abc_lines, info_fields=["X:", "T:", "C:", "W:", "w:", "Z:", "%%MIDI"]
+    )
 
     # delete bar number annotations
     abc_lines = remove_bar_no_annotations(abc_lines)
 
     # delete \"
     for i, line in enumerate(abc_lines):
-        if re.search(r'^[A-Za-z]:', line) or line.startswith('%'):
+        if re.search(r"^[A-Za-z]:", line) or line.startswith("%"):
             continue
         else:
-            if r'\"' in line:
-                abc_lines[i] = abc_lines[i].replace(r'\"', '')
+            if r"\"" in line:
+                abc_lines[i] = abc_lines[i].replace(r"\"", "")
 
     # delete text annotations with quotes
     for i, line in enumerate(abc_lines):
@@ -60,14 +66,14 @@ def abc_preprocess_pipeline(abc_path):
         for quote_content in quote_contents:
             for barline in Barlines:
                 if barline in quote_content:
-                    line = line.replace(quote_content, '')
+                    line = line.replace(quote_content, "")
                     abc_lines[i] = line
 
     # check bar alignment
     try:
         _, bar_no_equal_flag, _ = check_alignment_unrotated(abc_lines)
         if not bar_no_equal_flag:
-            print(abc_path, 'Unequal bar number')
+            print(abc_path, "Unequal bar number")
             raise Exception
     except:
         raise Exception
@@ -77,72 +83,92 @@ def abc_preprocess_pipeline(abc_path):
         quote_matches = re.findall(r'"[^"]*"', line)
         for match in quote_matches:
             if match == '""':
-                line = line.replace(match, '')
-            if match[1] in ['^', '_']:
+                line = line.replace(match, "")
+            if match[1] in ["^", "_"]:
                 sub_string = match
-                pattern = r'([^a-zA-Z0-9])\1+'
-                sub_string = re.sub(pattern, r'\1', sub_string)
+                pattern = r"([^a-zA-Z0-9])\1+"
+                sub_string = re.sub(pattern, r"\1", sub_string)
                 if len(sub_string) <= 40:
                     line = line.replace(match, sub_string)
                 else:
-                    line = line.replace(match, '')
+                    line = line.replace(match, "")
         abc_lines[i] = line
 
     abc_name = os.path.splitext(os.path.split(abc_path)[-1])[0]
 
     # transpose
     metadata_lines, part_text_dict = extract_metadata_and_parts(abc_lines)
-    global_metadata_dict, local_metadata_dict = extract_global_and_local_metadata(metadata_lines)
-    if global_metadata_dict['K'][0] == 'none':
-        global_metadata_dict['K'][0] = 'C'
-    ori_key = global_metadata_dict['K'][0]
+    global_metadata_dict, local_metadata_dict = extract_global_and_local_metadata(
+        metadata_lines
+    )
+    if global_metadata_dict["K"][0] == "none":
+        global_metadata_dict["K"][0] = "C"
+    ori_key = global_metadata_dict["K"][0]
 
     interleaved_abc = rotate_abc(abc_lines)
-    interleaved_path = os.path.join(INTERLEAVED_FOLDER, abc_name + '.abc')
-    with open(interleaved_path, 'w') as w:
+    interleaved_path = os.path.join(INTERLEAVED_FOLDER, abc_name + ".abc")
+    with open(interleaved_path, "w") as w:
         w.writelines(interleaved_abc)
 
     for key in Key2index.keys():
         transposed_abc_text = transpose_an_abc_text(abc_lines, key)
-        transposed_abc_lines = transposed_abc_text.split('\n')
+        transposed_abc_lines = transposed_abc_text.split("\n")
         transposed_abc_lines = list(filter(None, transposed_abc_lines))
-        transposed_abc_lines = [line + '\n' for line in transposed_abc_lines]
+        transposed_abc_lines = [line + "\n" for line in transposed_abc_lines]
 
         # rest reduction
-        metadata_lines, prefix_dict, left_barline_dict, bar_text_dict, right_barline_dict = \
-            extract_barline_and_bartext_dict(transposed_abc_lines)
+        (
+            metadata_lines,
+            prefix_dict,
+            left_barline_dict,
+            bar_text_dict,
+            right_barline_dict,
+        ) = extract_barline_and_bartext_dict(transposed_abc_lines)
         reduced_abc_lines = metadata_lines
-        for i in range(len(bar_text_dict['V:1'])):
-            line = ''
+        for i in range(len(bar_text_dict["V:1"])):
+            line = ""
             for symbol in prefix_dict.keys():
                 valid_flag = False
                 for char in bar_text_dict[symbol][i]:
-                    if char.isalpha() and not char in ['Z', 'z', 'X', 'x']:
+                    if char.isalpha() and char not in ["Z", "z", "X", "x"]:
                         valid_flag = True
                         break
                 if valid_flag:
                     if i == 0:
-                        part_patch = '[' + symbol + ']' + prefix_dict[symbol] + left_barline_dict[symbol][0] + bar_text_dict[symbol][0] + right_barline_dict[symbol][0]
+                        part_patch = (
+                            "["
+                            + symbol
+                            + "]"
+                            + prefix_dict[symbol]
+                            + left_barline_dict[symbol][0]
+                            + bar_text_dict[symbol][0]
+                            + right_barline_dict[symbol][0]
+                        )
                     else:
-                        part_patch = '[' + symbol + ']' + bar_text_dict[symbol][i] + right_barline_dict[symbol][i]
+                        part_patch = (
+                            "["
+                            + symbol
+                            + "]"
+                            + bar_text_dict[symbol][i]
+                            + right_barline_dict[symbol][i]
+                        )
                     line += part_patch
-            line += '\n'
+            line += "\n"
             reduced_abc_lines.append(line)
-            
-            reduced_abc_name = abc_name + '_' + key
-            reduced_abc_path = os.path.join(AUGMENTED_FOLDER, key, reduced_abc_name + '.abc')
-        
-            with open(reduced_abc_path, 'w', encoding='utf-8') as w:
+
+            reduced_abc_name = abc_name + "_" + key
+            reduced_abc_path = os.path.join(
+                AUGMENTED_FOLDER, key, reduced_abc_name + ".abc"
+            )
+
+            with open(reduced_abc_path, "w", encoding="utf-8") as w:
                 w.writelines(reduced_abc_lines)
 
     return abc_name, ori_key
 
 
+if __name__ == "__main__":
 
-
-
-if __name__ == '__main__':
-    
     data = []
     file_list = os.listdir(ORI_FOLDER)
     for file in tqdm(file_list):
@@ -150,32 +176,25 @@ if __name__ == '__main__':
         try:
             abc_name, ori_key = abc_preprocess_pipeline(ori_abc_path)
         except:
-            print(ori_abc_path, 'failed to pre-process.')
+            print(ori_abc_path, "failed to pre-process.")
             continue
 
-        data.append({
-            'path': os.path.join(AUGMENTED_FOLDER, abc_name),
-            'key': ori_key
-        })
+        data.append({"path": os.path.join(AUGMENTED_FOLDER, abc_name), "key": ori_key})
 
     random.shuffle(data)
-    eval_data = data[ : int(EVAL_SPLIT * len(data))]
-    train_data = data[int(EVAL_SPLIT * len(data)) : ]
+    eval_data = data[: int(EVAL_SPLIT * len(data))]
+    train_data = data[int(EVAL_SPLIT * len(data)) :]
 
-    data_index_path = AUGMENTED_FOLDER + '.jsonl'
-    eval_index_path = AUGMENTED_FOLDER + '_eval.jsonl'
-    train_index_path = AUGMENTED_FOLDER + '_train.jsonl'
+    data_index_path = AUGMENTED_FOLDER + ".jsonl"
+    eval_index_path = AUGMENTED_FOLDER + "_eval.jsonl"
+    train_index_path = AUGMENTED_FOLDER + "_train.jsonl"
 
-
-    with open(data_index_path, 'w', encoding='utf-8') as w:
+    with open(data_index_path, "w", encoding="utf-8") as w:
         for d in data:
-            w.write(json.dumps(d) + '\n')
-    with open(eval_index_path, 'w', encoding='utf-8') as w:
+            w.write(json.dumps(d) + "\n")
+    with open(eval_index_path, "w", encoding="utf-8") as w:
         for d in eval_data:
-            w.write(json.dumps(d) + '\n')
-    with open(train_index_path, 'w', encoding='utf-8') as w:
+            w.write(json.dumps(d) + "\n")
+    with open(train_index_path, "w", encoding="utf-8") as w:
         for d in train_data:
-            w.write(json.dumps(d) + '\n')
-
-    
-
+            w.write(json.dumps(d) + "\n")

--- a/data/3_batch_abc2xml.py
+++ b/data/3_batch_abc2xml.py
@@ -1,38 +1,50 @@
-ORI_FOLDER = ""  # Replace with the path to your folder containing standard/interleaved abc files
-DES_FOLDER = ""   # The script will convert the abc files and output musicxml files to this folder
-
 import os
 import math
 import random
 import subprocess
-from tqdm import tqdm
 from multiprocessing import Pool
 
+from tqdm import tqdm
+
+
+ORI_FOLDER = (
+    ""  # Replace with the path to your folder containing standard/interleaved abc files
+)
+DES_FOLDER = (
+    ""  # The script will convert the abc files and output musicxml files to this folder
+)
+
+
 def convert_abc2xml(file_list):
-    cmd = 'python abc2xml.py '
+    cmd = "python abc2xml.py "
     for file in tqdm(file_list):
-        filename = file.split('/')[-1]  # Extract file name
+        filename = file.split("/")[-1]  # Extract file name
         os.makedirs(DES_FOLDER, exist_ok=True)
 
         try:
-            p = subprocess.Popen(cmd + '"' + file + '"', stdout=subprocess.PIPE, shell=True)
+            p = subprocess.Popen(
+                cmd + '"' + file + '"', stdout=subprocess.PIPE, shell=True
+            )
             result = p.communicate()
-            output = result[0].decode('utf-8')
+            output = result[0].decode("utf-8")
 
-            if output == '':
+            if output == "":
                 with open("logs/abc2xml_error_log.txt", "a", encoding="utf-8") as f:
-                    f.write(file + '\n')
+                    f.write(file + "\n")
                 continue
             else:
-                output_path = f"{DES_FOLDER}/" + ".".join(filename.split(".")[:-1]) + ".xml"
-                with open(output_path, 'w', encoding='utf-8') as f:
+                output_path = (
+                    f"{DES_FOLDER}/" + ".".join(filename.split(".")[:-1]) + ".xml"
+                )
+                with open(output_path, "w", encoding="utf-8") as f:
                     f.write(output)
         except Exception as e:
             with open("logs/abc2xml_error_log.txt", "a", encoding="utf-8") as f:
-                f.write(file + ' ' + str(e) + '\n')
+                f.write(file + " " + str(e) + "\n")
             pass
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     file_list = []
     os.makedirs("logs", exist_ok=True)
 

--- a/data/abc2xml.py
+++ b/data/abc2xml.py
@@ -431,7 +431,7 @@ prevloc = 0
 
 def detectBeamBreak(line, loc, t):
     global prevloc  # location in string 'line' of previous note match
-    xs = line[prevloc:loc + 1]  # string between previous and current note match
+    xs = line[prevloc : loc + 1]  # string between previous and current note match
     xs = xs.lstrip()  # first note match starts on a space!
     prevloc = loc  # location in string 'line' of current note match
     b = pObj("bbrk", [" " in xs])  # space somewhere between two notes -> beambreak
@@ -787,6 +787,7 @@ def fixSlurs(x):  # repair slurs when after broken sign or grace-close
 def splitHeaderVoices(abctext):
     def escField(x):
         return "[" + x.replace("]", r"%5d") + "]"  # hope nobody uses %5d in a field
+
     r1 = re.compile(r"%.*$")  # comments
     r2 = re.compile(
         r"^([A-Zw]:.*$)|\[[A-Zw]:[^]]*]$"
@@ -2788,9 +2789,12 @@ class MusicXml:
             def getMidNum(sndnm):  # find midi number of GM drum sound name
                 pnms = sndnm.split("-")  # sound name parts (from I:percmap)
                 ps = s.percsnd[:]  # copy of the instruments
-                
+
                 def _f(ip, xs, pnm):
-                    return ip < len(xs) and xs[ip].find(pnm) > -1  # part xs[ip] and pnm match
+                    return (
+                        ip < len(xs) and xs[ip].find(pnm) > -1
+                    )  # part xs[ip] and pnm match
+
                 for ip, pnm in enumerate(pnms):  # match all percmap sound name parts
                     ps = [
                         (nm, mnum) for nm, mnum in ps if _f(ip, nm.split("-"), pnm)
@@ -2893,7 +2897,10 @@ class MusicXml:
                 prg = prg_nw or s.midprg[1]
                 vol = vol_nw or s.midprg[2]
                 pan = pan_nw or s.midprg[3]
-                instId = "I%s-%s" % (s.pid, "")  # only look for real instruments, no percussion
+                instId = "I%s-%s" % (
+                    s.pid,
+                    "",
+                )  # only look for real instruments, no percussion
                 if instId in s.midiInst:
                     instChange(ch, prg)  # instChance -> doFields
                 s.midprg = [ch, prg, vol, pan]  # mknote: new instrument -> s.midiInst
@@ -2923,6 +2930,7 @@ class MusicXml:
 
         def f(x):
             return [x] if isinstance(x, uni_type) else x
+
         s.staves = lmap(f, mkStaves(score, vdefs))  # [[vid] for each staff]
         s.grands = lmap(f, mkGrand(score, vdefs))  # [staff-id], staff-id == [vid][0]
         s.groups = mkGroups(score)
@@ -3121,9 +3129,12 @@ class MusicXml:
             for id, voice in voices:
                 if lbrk_insert:  # insert linebreak at EOL
                     r1 = re.compile(r"\[[wA-Z]:[^]]*\]")  # inline field
-                    
+
                     def has_abc(x):
-                        return r1.sub("", x).strip()  # empty if line only contains inline fields
+                        return r1.sub(
+                            "", x
+                        ).strip()  # empty if line only contains inline fields
+
                     voice = "\n".join(
                         [
                             balk.rstrip("$!") + "$" if has_abc(balk) else balk

--- a/data/abc2xml.py
+++ b/data/abc2xml.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # coding=latin-1
-'''
+"""
 Copyright (C) 2012-2018: Willem G. Vree
 Contributions: Nils Liberg, Nicolas Froment, Norman Schmidt, Reinier Maliepaard, Martin Tarenskeen,
                Paul Villiger, Alexander Scheutzow, Herbert Schneider, David Randolph, Michael Strasser
@@ -11,21 +11,33 @@ Lesser GNU General Public License as published by the Free Software Foundation;
 This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
 without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 See the Lesser GNU General Public License for more details. <http://www.gnu.org/licenses/lgpl.html>.
-'''
+"""
 
 from functools import reduce
-from pyparsing import Word, OneOrMore, Optional, Literal, NotAny, MatchFirst
+from pyparsing import Word, OneOrMore, Optional, Literal, MatchFirst
 from pyparsing import Group, oneOf, Suppress, ZeroOrMore, Combine, FollowedBy
-from pyparsing import srange, CharsNotIn, StringEnd, LineEnd, White, Regex
-from pyparsing import nums, alphas, alphanums, ParseException, Forward
-try:    import xml.etree.cElementTree as E
-except: import xml.etree.ElementTree as E
-import types, sys, os, re, datetime
+from pyparsing import srange, CharsNotIn, StringEnd, Regex
+from pyparsing import nums, alphanums, ParseException, Forward
+
+try:
+    import xml.etree.cElementTree as E
+except ImportError:
+    import xml.etree.ElementTree as E
+import types
+import sys
+import os
+import re
+import datetime
 
 VERSION = 245
 
 python3 = sys.version_info[0] > 2
-lmap = lambda f, xs: list (map (f, xs))   # eager map for python 3
+
+
+def lmap(f, xs):
+    return list(map(f, xs))  # eager map for python 3
+
+
 if python3:
     int_type = int
     list_type = list
@@ -40,2213 +52,3489 @@ else:
     stdin = sys.stdin
 
 info_list = []  # diagnostic messages
-def info (s, warn=1):
-    x = (warn and '-- ' or '') + s
-    info_list.append (x + '\n')         # collect messages
-    if __name__ == '__main__':          # only write to stdout when called as main progeam
-        try: sys.stderr.write (x + '\n')
-        except: sys.stderr.write (repr (x) + '\n')
 
-def getInfo (): # get string of diagnostic messages, then clear messages
+
+def info(s, warn=1):
+    x = (warn and "-- " or "") + s
+    info_list.append(x + "\n")  # collect messages
+    if __name__ == "__main__":  # only write to stdout when called as main progeam
+        try:
+            sys.stderr.write(x + "\n")
+        except Exception:
+            sys.stderr.write(repr(x) + "\n")
+
+
+def getInfo():  # get string of diagnostic messages, then clear messages
     global info_list
-    xs = ''.join (info_list)
+    xs = "".join(info_list)
     info_list = []
     return xs
 
-def abc_grammar ():     # header, voice and lyrics grammar for ABC
-    #-----------------------------------------------------------------
+
+def abc_grammar():  # header, voice and lyrics grammar for ABC
+    # -----------------------------------------------------------------
     # expressions that catch and skip some syntax errors (see corresponding parse expressions)
-    #-----------------------------------------------------------------
-    b1 = Word (u"-,'<>\u2019#", exact=1)    # catch misplaced chars in chords
-    b2 = Regex ('[^H-Wh-w~=]*')             # same in user defined symbol definition
-    b3 = Regex ('[^=]*')                    # same, second part
+    # -----------------------------------------------------------------
+    b1 = Word("-,'<>\u2019#", exact=1)  # catch misplaced chars in chords
+    b2 = Regex("[^H-Wh-w~=]*")  # same in user defined symbol definition
+    b3 = Regex("[^=]*")  # same, second part
 
-    #-----------------------------------------------------------------
+    # -----------------------------------------------------------------
     # ABC header (field_str elements are matched later with reg. epr's)
-    #-----------------------------------------------------------------
+    # -----------------------------------------------------------------
 
-    number = Word (nums).setParseAction (lambda t: int (t[0]))
-    field_str = Regex (r'[^]]*')  # match anything until end of field
-    field_str.setParseAction (lambda t: t[0].strip ())  # and strip spacing
+    number = Word(nums).setParseAction(lambda t: int(t[0]))
+    field_str = Regex(r"[^]]*")  # match anything until end of field
+    field_str.setParseAction(lambda t: t[0].strip())  # and strip spacing
 
-    userdef_symbol  = Word (srange ('[H-Wh-w~]'), exact=1)
-    fieldId = oneOf ('K L M Q P I T C O A Z N G H R B D F S E r Y') # info fields
-    X_field = Literal ('X') + Suppress (':') + field_str
-    U_field = Literal ('U') + Suppress (':') + b2 + Optional (userdef_symbol, 'H') + b3 + Suppress ('=') + field_str
-    V_field = Literal ('V') + Suppress (':') + Word (alphanums + '_') + field_str
-    inf_fld = fieldId + Suppress (':') + field_str
-    ifield = Suppress ('[') + (X_field | U_field | V_field | inf_fld) + Suppress (']')
-    abc_header = OneOrMore (ifield) + StringEnd ()
+    userdef_symbol = Word(srange("[H-Wh-w~]"), exact=1)
+    fieldId = oneOf("K L M Q P I T C O A Z N G H R B D F S E r Y")  # info fields
+    X_field = Literal("X") + Suppress(":") + field_str
+    U_field = (
+        Literal("U")
+        + Suppress(":")
+        + b2
+        + Optional(userdef_symbol, "H")
+        + b3
+        + Suppress("=")
+        + field_str
+    )
+    V_field = Literal("V") + Suppress(":") + Word(alphanums + "_") + field_str
+    inf_fld = fieldId + Suppress(":") + field_str
+    ifield = Suppress("[") + (X_field | U_field | V_field | inf_fld) + Suppress("]")
+    abc_header = OneOrMore(ifield) + StringEnd()
 
-    #---------------------------------------------------------------------------------
+    # ---------------------------------------------------------------------------------
     # I:score with recursive part groups and {* grand staff marker
-    #---------------------------------------------------------------------------------
+    # ---------------------------------------------------------------------------------
 
-    voiceId = Suppress (Optional ('*')) + Word (alphanums + '_')
-    voice_gr = Suppress ('(') + OneOrMore (voiceId | Suppress ('|')) + Suppress (')')
-    simple_part = voiceId | voice_gr | Suppress ('|')
-    grand_staff = oneOf ('{* {') + OneOrMore (simple_part) + Suppress ('}')
-    part = Forward ()
-    part_seq = OneOrMore (part | Suppress ('|'))
-    brace_gr = Suppress ('{') + part_seq + Suppress ('}')
-    bracket_gr = Suppress ('[') + part_seq + Suppress (']')
-    part <<= MatchFirst (simple_part | grand_staff | brace_gr | bracket_gr | Suppress ('|'))
-    abc_scoredef = Suppress (oneOf ('staves score')) + OneOrMore (part)
+    voiceId = Suppress(Optional("*")) + Word(alphanums + "_")
+    voice_gr = Suppress("(") + OneOrMore(voiceId | Suppress("|")) + Suppress(")")
+    simple_part = voiceId | voice_gr | Suppress("|")
+    grand_staff = oneOf("{* {") + OneOrMore(simple_part) + Suppress("}")
+    part = Forward()
+    part_seq = OneOrMore(part | Suppress("|"))
+    brace_gr = Suppress("{") + part_seq + Suppress("}")
+    bracket_gr = Suppress("[") + part_seq + Suppress("]")
+    part <<= MatchFirst(
+        simple_part | grand_staff | brace_gr | bracket_gr | Suppress("|")
+    )
+    abc_scoredef = Suppress(oneOf("staves score")) + OneOrMore(part)
 
-    #----------------------------------------
+    # ----------------------------------------
     # ABC lyric lines (white space sensitive)
-    #----------------------------------------
+    # ----------------------------------------
 
-    skip_note   = oneOf ('* -')
-    extend_note = Literal ('_')
-    measure_end = Literal ('|')
-    syl_str     = CharsNotIn ('*-_| \t\n\\]')
-    syl_chars   = Combine (OneOrMore (syl_str | Regex (r'\\.')))
-    white       = Word (' \t')
-    syllable    = syl_chars + Optional ('-')
-    lyr_elem    = (syllable | skip_note | extend_note | measure_end) + Optional (white).suppress ()
-    lyr_line    = Optional (white).suppress () + ZeroOrMore (lyr_elem)
-    
-    syllable.setParseAction (lambda t: pObj ('syl', t))
-    skip_note.setParseAction (lambda t: pObj ('skip', t))
-    extend_note.setParseAction (lambda t: pObj ('ext', t))
-    measure_end.setParseAction (lambda t: pObj ('sbar', t))
-    lyr_line_wsp = lyr_line.leaveWhitespace ()   # parse actions must be set before calling leaveWhitespace
+    skip_note = oneOf("* -")
+    extend_note = Literal("_")
+    measure_end = Literal("|")
+    syl_str = CharsNotIn("*-_| \t\n\\]")
+    syl_chars = Combine(OneOrMore(syl_str | Regex(r"\\.")))
+    white = Word(" \t")
+    syllable = syl_chars + Optional("-")
+    lyr_elem = (syllable | skip_note | extend_note | measure_end) + Optional(
+        white
+    ).suppress()
+    lyr_line = Optional(white).suppress() + ZeroOrMore(lyr_elem)
 
-    #---------------------------------------------------------------------------------
+    syllable.setParseAction(lambda t: pObj("syl", t))
+    skip_note.setParseAction(lambda t: pObj("skip", t))
+    extend_note.setParseAction(lambda t: pObj("ext", t))
+    measure_end.setParseAction(lambda t: pObj("sbar", t))
+    lyr_line_wsp = (
+        lyr_line.leaveWhitespace()
+    )  # parse actions must be set before calling leaveWhitespace
+
+    # ---------------------------------------------------------------------------------
     # ABC voice (not white space sensitive, beams detected in note/rest parse actions)
-    #---------------------------------------------------------------------------------
+    # ---------------------------------------------------------------------------------
 
-    inline_field =  Suppress ('[') + (inf_fld | U_field | V_field) + Suppress (']')
-    lyr_fld = Suppress ('[') + Suppress ('w') + Suppress (':') + lyr_line_wsp + Suppress (']')  # lyric line
-    lyr_blk = OneOrMore (lyr_fld)       # verses
-    fld_or_lyr = inline_field | lyr_blk # inline field or block of lyric verses
+    inline_field = Suppress("[") + (inf_fld | U_field | V_field) + Suppress("]")
+    lyr_fld = (
+        Suppress("[") + Suppress("w") + Suppress(":") + lyr_line_wsp + Suppress("]")
+    )  # lyric line
+    lyr_blk = OneOrMore(lyr_fld)  # verses
+    fld_or_lyr = inline_field | lyr_blk  # inline field or block of lyric verses
 
-    note_length = Optional (number, 1) + Group (ZeroOrMore ('/')) + Optional (number, 2)
-    octaveHigh = OneOrMore ("'").setParseAction (lambda t: len(t))
-    octaveLow = OneOrMore (',').setParseAction (lambda t: -len(t))
-    octave  = octaveHigh | octaveLow
+    note_length = Optional(number, 1) + Group(ZeroOrMore("/")) + Optional(number, 2)
+    octaveHigh = OneOrMore("'").setParseAction(lambda t: len(t))
+    octaveLow = OneOrMore(",").setParseAction(lambda t: -len(t))
+    octave = octaveHigh | octaveLow
 
-    basenote = oneOf ('C D E F G A B c d e f g a b y')  # includes spacer for parse efficiency
-    accidental = oneOf ('^^ __ ^ _ =')
-    rest_sym  = oneOf ('x X z Z')
-    slur_beg = oneOf ("( (, (' .( .(, .('") + ~Word (nums)    # no tuplet_start
-    slur_ends = OneOrMore (oneOf (') .)'))
+    basenote = oneOf(
+        "C D E F G A B c d e f g a b y"
+    )  # includes spacer for parse efficiency
+    accidental = oneOf("^^ __ ^ _ =")
+    rest_sym = oneOf("x X z Z")
+    slur_beg = oneOf("( (, (' .( .(, .('") + ~Word(nums)  # no tuplet_start
+    slur_ends = OneOrMore(oneOf(") .)"))
 
-    long_decoration = Combine (oneOf ('! +') + CharsNotIn ('!+ \n') + oneOf ('! +'))
-    staccato        = Literal ('.') + ~Literal ('|')    # avoid dotted barline
-    pizzicato       = Literal ('!+!')   # special case: plus sign is old style deco marker
-    decoration      = slur_beg | staccato | userdef_symbol | long_decoration | pizzicato
-    decorations     = OneOrMore (decoration)
+    long_decoration = Combine(oneOf("! +") + CharsNotIn("!+ \n") + oneOf("! +"))
+    staccato = Literal(".") + ~Literal("|")  # avoid dotted barline
+    pizzicato = Literal("!+!")  # special case: plus sign is old style deco marker
+    decoration = slur_beg | staccato | userdef_symbol | long_decoration | pizzicato
+    decorations = OneOrMore(decoration)
 
-    tie = oneOf ('.- -')
-    rest = Optional (accidental) + rest_sym + note_length
-    pitch = Optional (accidental) + basenote + Optional (octave, 0)
-    note = pitch + note_length + Optional (tie) + Optional (slur_ends)
-    dec_note = Optional (decorations) + pitch + note_length + Optional (tie) + Optional (slur_ends)
+    tie = oneOf(".- -")
+    rest = Optional(accidental) + rest_sym + note_length
+    pitch = Optional(accidental) + basenote + Optional(octave, 0)
+    note = pitch + note_length + Optional(tie) + Optional(slur_ends)
+    dec_note = (
+        Optional(decorations)
+        + pitch
+        + note_length
+        + Optional(tie)
+        + Optional(slur_ends)
+    )
     chord_note = dec_note | rest | b1
-    grace_notes = Forward ()
-    chord = Suppress ('[') + OneOrMore (chord_note | grace_notes) + Suppress (']') + note_length + Optional (tie) + Optional (slur_ends)
+    grace_notes = Forward()
+    chord = (
+        Suppress("[")
+        + OneOrMore(chord_note | grace_notes)
+        + Suppress("]")
+        + note_length
+        + Optional(tie)
+        + Optional(slur_ends)
+    )
     stem = note | chord | rest
 
-    broken = Combine (OneOrMore ('<') | OneOrMore ('>'))
+    broken = Combine(OneOrMore("<") | OneOrMore(">"))
 
-    tuplet_num   = Suppress ('(') + number
-    tuplet_into  = Suppress (':') + Optional (number, 0)
-    tuplet_notes = Suppress (':') + Optional (number, 0)
-    tuplet_start = tuplet_num + Optional (tuplet_into + Optional (tuplet_notes))
+    tuplet_num = Suppress("(") + number
+    tuplet_into = Suppress(":") + Optional(number, 0)
+    tuplet_notes = Suppress(":") + Optional(number, 0)
+    tuplet_start = tuplet_num + Optional(tuplet_into + Optional(tuplet_notes))
 
-    acciaccatura    = Literal ('/')
-    grace_stem      = Optional (decorations) + stem
-    grace_notes     <<= Group (Suppress ('{') + Optional (acciaccatura) + OneOrMore (grace_stem) + Suppress ('}'))
+    acciaccatura = Literal("/")
+    grace_stem = Optional(decorations) + stem
+    grace_notes <<= Group(
+        Suppress("{") + Optional(acciaccatura) + OneOrMore(grace_stem) + Suppress("}")
+    )
 
-    text_expression  = Optional (oneOf ('^ _ < > @'), '^') + Optional (CharsNotIn ('"'), "")
-    chord_accidental = oneOf ('# b =')
-    triad            = oneOf ('ma Maj maj M mi min m aug dim o + -')
-    seventh          = oneOf ('7 ma7 Maj7 M7 maj7 mi7 min7 m7 dim7 o7 -7 aug7 +7 m7b5 mi7b5')
-    sixth            = oneOf ('6 ma6 M6 mi6 min6 m6')
-    ninth            = oneOf ('9 ma9 M9 maj9 Maj9 mi9 min9 m9')
-    elevn            = oneOf ('11 ma11 M11 maj11 Maj11 mi11 min11 m11')
-    thirt            = oneOf ('13 ma13 M13 maj13 Maj13 mi13 min13 m13')
-    suspended        = oneOf ('sus sus2 sus4')
-    chord_degree     = Combine (Optional (chord_accidental) + oneOf ('2 4 5 6 7 9 11 13'))
-    chord_kind       = Optional (seventh | sixth | ninth | elevn | thirt | triad) + Optional (suspended)
-    chord_root       = oneOf ('C D E F G A B') + Optional (chord_accidental)
-    chord_bass       = oneOf ('C D E F G A B') + Optional (chord_accidental) # needs a different parse action
-    chordsym         = chord_root + chord_kind + ZeroOrMore (chord_degree) + Optional (Suppress ('/') + chord_bass)
-    chord_sym        = chordsym + Optional (Literal ('(') + CharsNotIn (')') + Literal (')')).suppress ()
-    chord_or_text    = Suppress ('"') + (chord_sym ^ text_expression) + Suppress ('"')
+    text_expression = Optional(oneOf("^ _ < > @"), "^") + Optional(CharsNotIn('"'), "")
+    chord_accidental = oneOf("# b =")
+    triad = oneOf("ma Maj maj M mi min m aug dim o + -")
+    seventh = oneOf("7 ma7 Maj7 M7 maj7 mi7 min7 m7 dim7 o7 -7 aug7 +7 m7b5 mi7b5")
+    sixth = oneOf("6 ma6 M6 mi6 min6 m6")
+    ninth = oneOf("9 ma9 M9 maj9 Maj9 mi9 min9 m9")
+    elevn = oneOf("11 ma11 M11 maj11 Maj11 mi11 min11 m11")
+    thirt = oneOf("13 ma13 M13 maj13 Maj13 mi13 min13 m13")
+    suspended = oneOf("sus sus2 sus4")
+    chord_degree = Combine(Optional(chord_accidental) + oneOf("2 4 5 6 7 9 11 13"))
+    chord_kind = Optional(seventh | sixth | ninth | elevn | thirt | triad) + Optional(
+        suspended
+    )
+    chord_root = oneOf("C D E F G A B") + Optional(chord_accidental)
+    chord_bass = oneOf("C D E F G A B") + Optional(
+        chord_accidental
+    )  # needs a different parse action
+    chordsym = (
+        chord_root
+        + chord_kind
+        + ZeroOrMore(chord_degree)
+        + Optional(Suppress("/") + chord_bass)
+    )
+    chord_sym = (
+        chordsym + Optional(Literal("(") + CharsNotIn(")") + Literal(")")).suppress()
+    )
+    chord_or_text = Suppress('"') + (chord_sym ^ text_expression) + Suppress('"')
 
-    volta_nums = Optional ('[').suppress () + Combine (Word (nums) + ZeroOrMore (oneOf (', -') + Word (nums)))
-    volta_text = Literal ('[').suppress () + Regex (r'"[^"]+"')
+    volta_nums = Optional("[").suppress() + Combine(
+        Word(nums) + ZeroOrMore(oneOf(", -") + Word(nums))
+    )
+    volta_text = Literal("[").suppress() + Regex(r'"[^"]+"')
     volta = volta_nums | volta_text
-    invisible_barline = oneOf ('[|] []')
-    dashed_barline = oneOf (': .|')
-    double_rep = Literal (':') + FollowedBy (':')   # otherwise ambiguity with dashed barline
-    voice_overlay = Combine (OneOrMore ('&'))
-    bare_volta = FollowedBy (Literal ('[') + Word (nums))   # no barline, but volta follows (volta is parsed in next measure)
-    bar_left = (oneOf ('[|: |: [: :') + Optional (volta)) | Optional ('|').suppress () + volta | oneOf ('| [|')
-    bars = ZeroOrMore (':') + ZeroOrMore ('[') + OneOrMore (oneOf ('| ]'))
-    bar_right = invisible_barline | double_rep | Combine (bars) | dashed_barline | voice_overlay | bare_volta
-    
-    errors =  ~bar_right + Optional (Word (' \n')) + CharsNotIn (':&|', exact=1)
-    linebreak = Literal ('$') | ~decorations + Literal ('!')    # no need for I:linebreak !!!
-    element = fld_or_lyr | broken | decorations | stem | chord_or_text | grace_notes | tuplet_start | linebreak | errors
-    measure      = Group (ZeroOrMore (inline_field) + Optional (bar_left) + ZeroOrMore (element) + bar_right + Optional (linebreak) + Optional (lyr_blk))
-    noBarMeasure = Group (ZeroOrMore (inline_field) + Optional (bar_left) + OneOrMore (element) + Optional (linebreak) + Optional (lyr_blk))
-    abc_voice = ZeroOrMore (measure) + Optional (noBarMeasure | Group (bar_left)) + ZeroOrMore (inline_field).suppress () + StringEnd ()
+    invisible_barline = oneOf("[|] []")
+    dashed_barline = oneOf(": .|")
+    double_rep = Literal(":") + FollowedBy(
+        ":"
+    )  # otherwise ambiguity with dashed barline
+    voice_overlay = Combine(OneOrMore("&"))
+    bare_volta = FollowedBy(
+        Literal("[") + Word(nums)
+    )  # no barline, but volta follows (volta is parsed in next measure)
+    bar_left = (
+        (oneOf("[|: |: [: :") + Optional(volta))
+        | Optional("|").suppress() + volta
+        | oneOf("| [|")
+    )
+    bars = ZeroOrMore(":") + ZeroOrMore("[") + OneOrMore(oneOf("| ]"))
+    bar_right = (
+        invisible_barline
+        | double_rep
+        | Combine(bars)
+        | dashed_barline
+        | voice_overlay
+        | bare_volta
+    )
 
-    #----------------------------------------
+    errors = ~bar_right + Optional(Word(" \n")) + CharsNotIn(":&|", exact=1)
+    linebreak = Literal("$") | ~decorations + Literal(
+        "!"
+    )  # no need for I:linebreak !!!
+    element = (
+        fld_or_lyr
+        | broken
+        | decorations
+        | stem
+        | chord_or_text
+        | grace_notes
+        | tuplet_start
+        | linebreak
+        | errors
+    )
+    measure = Group(
+        ZeroOrMore(inline_field)
+        + Optional(bar_left)
+        + ZeroOrMore(element)
+        + bar_right
+        + Optional(linebreak)
+        + Optional(lyr_blk)
+    )
+    noBarMeasure = Group(
+        ZeroOrMore(inline_field)
+        + Optional(bar_left)
+        + OneOrMore(element)
+        + Optional(linebreak)
+        + Optional(lyr_blk)
+    )
+    abc_voice = (
+        ZeroOrMore(measure)
+        + Optional(noBarMeasure | Group(bar_left))
+        + ZeroOrMore(inline_field).suppress()
+        + StringEnd()
+    )
+
+    # ----------------------------------------
     # I:percmap note [step] [midi] [note-head]
-    #----------------------------------------
+    # ----------------------------------------
 
-    white2 = (white | StringEnd ()).suppress ()
-    w3 = Optional (white2)
-    percid = Word (alphanums + '-')
-    step = basenote + Optional (octave, 0)
-    pitchg = Group (Optional (accidental, '') + step + FollowedBy (white2))
-    stepg = Group (step + FollowedBy (white2)) | Literal ('*')
-    midi = (Literal ('*') | number | pitchg | percid)
-    nhd = Optional (Combine (percid + Optional ('+')), '')
-    perc_wsp = Literal ('percmap') + w3 + pitchg + w3 + Optional (stepg, '*') + w3 + Optional (midi, '*') + w3 + nhd
-    abc_percmap = perc_wsp.leaveWhitespace ()
+    white2 = (white | StringEnd()).suppress()
+    w3 = Optional(white2)
+    percid = Word(alphanums + "-")
+    step = basenote + Optional(octave, 0)
+    pitchg = Group(Optional(accidental, "") + step + FollowedBy(white2))
+    stepg = Group(step + FollowedBy(white2)) | Literal("*")
+    midi = Literal("*") | number | pitchg | percid
+    nhd = Optional(Combine(percid + Optional("+")), "")
+    perc_wsp = (
+        Literal("percmap")
+        + w3
+        + pitchg
+        + w3
+        + Optional(stepg, "*")
+        + w3
+        + Optional(midi, "*")
+        + w3
+        + nhd
+    )
+    abc_percmap = perc_wsp.leaveWhitespace()
 
-    #----------------------------------------------------------------
+    # ----------------------------------------------------------------
     # Parse actions to convert all relevant results into an abstract
     # syntax tree where all tree nodes are instances of pObj
-    #----------------------------------------------------------------
+    # ----------------------------------------------------------------
 
-    ifield.setParseAction (lambda t: pObj ('field', t))
-    grand_staff.setParseAction (lambda t: pObj ('grand', t, 1)) # 1 = keep ordered list of results
-    brace_gr.setParseAction (lambda t: pObj ('bracegr', t, 1))
-    bracket_gr.setParseAction (lambda t: pObj ('bracketgr', t, 1))
-    voice_gr.setParseAction (lambda t: pObj ('voicegr', t, 1))
-    voiceId.setParseAction (lambda t: pObj ('vid', t, 1))
-    abc_scoredef.setParseAction (lambda t: pObj ('score', t, 1))
-    note_length.setParseAction (lambda t: pObj ('dur', (t[0], (t[2] << len (t[1])) >> 1)))
-    chordsym.setParseAction (lambda t: pObj ('chordsym', t))
-    chord_root.setParseAction (lambda t: pObj ('root', t))
-    chord_kind.setParseAction (lambda t: pObj ('kind', t))
-    chord_degree.setParseAction (lambda t: pObj ('degree', t))
-    chord_bass.setParseAction (lambda t: pObj ('bass', t))
-    text_expression.setParseAction (lambda t: pObj ('text', t))
-    inline_field.setParseAction (lambda t: pObj ('inline', t))
-    lyr_fld.setParseAction (lambda t: pObj ('lyr_fld', t, 1))
-    lyr_blk.setParseAction (lambda t: pObj ('lyr_blk', t, 1)) # 1 = keep ordered list of lyric lines
-    grace_notes.setParseAction (doGrace)
-    acciaccatura.setParseAction (lambda t: pObj ('accia', t))
-    note.setParseAction (noteActn)
-    rest.setParseAction (restActn)
-    decorations.setParseAction (lambda t: pObj ('deco', t))
-    pizzicato.setParseAction (lambda t: ['!plus!']) # translate !+!
-    slur_ends.setParseAction (lambda t: pObj ('slurs', t))
-    chord.setParseAction (lambda t: pObj ('chord', t, 1))
-    dec_note.setParseAction (noteActn)
-    tie.setParseAction (lambda t: pObj ('tie', t))
-    pitch.setParseAction (lambda t: pObj ('pitch', t))
-    bare_volta.setParseAction (lambda t: ['|']) # return barline that user forgot
-    dashed_barline.setParseAction (lambda t: ['.|'])
-    bar_right.setParseAction (lambda t: pObj ('rbar', t))
-    bar_left.setParseAction (lambda t: pObj ('lbar', t))
-    broken.setParseAction (lambda t: pObj ('broken', t))
-    tuplet_start.setParseAction (lambda t: pObj ('tup', t))
-    linebreak.setParseAction (lambda t: pObj ('linebrk', t))
-    measure.setParseAction (doMaat)
-    noBarMeasure.setParseAction (doMaat)
-    b1.setParseAction (errorWarn)
-    b2.setParseAction (errorWarn)
-    b3.setParseAction (errorWarn)
-    errors.setParseAction (errorWarn)
+    ifield.setParseAction(lambda t: pObj("field", t))
+    grand_staff.setParseAction(
+        lambda t: pObj("grand", t, 1)
+    )  # 1 = keep ordered list of results
+    brace_gr.setParseAction(lambda t: pObj("bracegr", t, 1))
+    bracket_gr.setParseAction(lambda t: pObj("bracketgr", t, 1))
+    voice_gr.setParseAction(lambda t: pObj("voicegr", t, 1))
+    voiceId.setParseAction(lambda t: pObj("vid", t, 1))
+    abc_scoredef.setParseAction(lambda t: pObj("score", t, 1))
+    note_length.setParseAction(lambda t: pObj("dur", (t[0], (t[2] << len(t[1])) >> 1)))
+    chordsym.setParseAction(lambda t: pObj("chordsym", t))
+    chord_root.setParseAction(lambda t: pObj("root", t))
+    chord_kind.setParseAction(lambda t: pObj("kind", t))
+    chord_degree.setParseAction(lambda t: pObj("degree", t))
+    chord_bass.setParseAction(lambda t: pObj("bass", t))
+    text_expression.setParseAction(lambda t: pObj("text", t))
+    inline_field.setParseAction(lambda t: pObj("inline", t))
+    lyr_fld.setParseAction(lambda t: pObj("lyr_fld", t, 1))
+    lyr_blk.setParseAction(
+        lambda t: pObj("lyr_blk", t, 1)
+    )  # 1 = keep ordered list of lyric lines
+    grace_notes.setParseAction(doGrace)
+    acciaccatura.setParseAction(lambda t: pObj("accia", t))
+    note.setParseAction(noteActn)
+    rest.setParseAction(restActn)
+    decorations.setParseAction(lambda t: pObj("deco", t))
+    pizzicato.setParseAction(lambda t: ["!plus!"])  # translate !+!
+    slur_ends.setParseAction(lambda t: pObj("slurs", t))
+    chord.setParseAction(lambda t: pObj("chord", t, 1))
+    dec_note.setParseAction(noteActn)
+    tie.setParseAction(lambda t: pObj("tie", t))
+    pitch.setParseAction(lambda t: pObj("pitch", t))
+    bare_volta.setParseAction(lambda t: ["|"])  # return barline that user forgot
+    dashed_barline.setParseAction(lambda t: [".|"])
+    bar_right.setParseAction(lambda t: pObj("rbar", t))
+    bar_left.setParseAction(lambda t: pObj("lbar", t))
+    broken.setParseAction(lambda t: pObj("broken", t))
+    tuplet_start.setParseAction(lambda t: pObj("tup", t))
+    linebreak.setParseAction(lambda t: pObj("linebrk", t))
+    measure.setParseAction(doMaat)
+    noBarMeasure.setParseAction(doMaat)
+    b1.setParseAction(errorWarn)
+    b2.setParseAction(errorWarn)
+    b3.setParseAction(errorWarn)
+    errors.setParseAction(errorWarn)
 
     return abc_header, abc_voice, abc_scoredef, abc_percmap
 
-class pObj (object):    # every relevant parse result is converted into a pObj
-    def __init__ (s, name, t, seq=0):   # t = list of nested parse results
-        s.name = name   # name uniqueliy identifies this pObj
-        rest = []       # collect parse results that are not a pObj
-        attrs = {}      # new attributes
-        for x in t:     # nested pObj's become attributes of this pObj
-            if type (x) == pObj:
-                attrs [x.name] = attrs.get (x.name, []) + [x]
-            else:
-                rest.append (x)             # collect non-pObj's (mostly literals)
-        for name, xs in attrs.items ():
-            if len (xs) == 1: xs = xs[0]    # only list if more then one pObj
-            setattr (s, name, xs)           # create the new attributes
-        s.t = rest      # all nested non-pObj's (mostly literals)
-        s.objs = seq and t or []            # for nested ordered (lyric) pObj's
 
-    def __repr__ (s):   # make a nice string representation of a pObj
+class pObj(object):  # every relevant parse result is converted into a pObj
+    def __init__(s, name, t, seq=0):  # t = list of nested parse results
+        s.name = name  # name uniqueliy identifies this pObj
+        rest = []  # collect parse results that are not a pObj
+        attrs = {}  # new attributes
+        for x in t:  # nested pObj's become attributes of this pObj
+            if isinstance(x, pObj):
+                attrs[x.name] = attrs.get(x.name, []) + [x]
+            else:
+                rest.append(x)  # collect non-pObj's (mostly literals)
+        for name, xs in attrs.items():
+            if len(xs) == 1:
+                xs = xs[0]  # only list if more then one pObj
+            setattr(s, name, xs)  # create the new attributes
+        s.t = rest  # all nested non-pObj's (mostly literals)
+        s.objs = seq and t or []  # for nested ordered (lyric) pObj's
+
+    def __repr__(s):  # make a nice string representation of a pObj
         r = []
-        for nm in dir (s):
-            if nm.startswith ('_'): continue # skip build in attributes
-            elif nm == 'name': continue     # redundant
+        for nm in dir(s):
+            if nm.startswith("_"):
+                continue  # skip build in attributes
+            elif nm == "name":
+                continue  # redundant
             else:
-                x = getattr (s, nm)
-                if not x: continue          # s.t may be empty (list of non-pObj's)
-                if type (x) == list_type:  r.extend (x)
-                else:                           r.append (x)
+                x = getattr(s, nm)
+                if not x:
+                    continue  # s.t may be empty (list of non-pObj's)
+                if isinstance(x, list_type):
+                    r.extend(x)
+                else:
+                    r.append(x)
         xs = []
-        for x in r:     # recursively call __repr__ and convert all strings to latin-1
-            if isinstance (x, str_type): xs.append (x)          # string -> no recursion
-            else:                        xs.append (repr (x))   # pObj -> recursive call
-        return '(' + s.name + ' ' +','.join (xs) + ')'
+        for x in r:  # recursively call __repr__ and convert all strings to latin-1
+            if isinstance(x, str_type):
+                xs.append(x)  # string -> no recursion
+            else:
+                xs.append(repr(x))  # pObj -> recursive call
+        return "(" + s.name + " " + ",".join(xs) + ")"
 
-global prevloc                  # global to remember previous match position of a note/rest
+
+global prevloc  # global to remember previous match position of a note/rest
 prevloc = 0
-def detectBeamBreak (line, loc, t):
-    global prevloc              # location in string 'line' of previous note match
-    xs = line[prevloc:loc+1]    # string between previous and current note match
-    xs = xs.lstrip ()           # first note match starts on a space!
-    prevloc = loc               # location in string 'line' of current note match
-    b = pObj ('bbrk', [' ' in xs])      # space somewhere between two notes -> beambreak
-    t.insert (0, b)             # insert beambreak as a nested parse result
 
-def noteActn (line, loc, t):    # detect beambreak between previous and current note/rest
-    if 'y' in t[0].t: return [] # discard spacer
-    detectBeamBreak (line, loc, t)      # adds beambreak to parse result t as side effect
-    return pObj ('note', t)
 
-def restActn (line, loc, t):    # detect beambreak between previous and current note/rest
-    detectBeamBreak (line, loc, t)  # adds beambreak to parse result t as side effect
-    return pObj ('rest', t)
+def detectBeamBreak(line, loc, t):
+    global prevloc  # location in string 'line' of previous note match
+    xs = line[prevloc:loc + 1]  # string between previous and current note match
+    xs = xs.lstrip()  # first note match starts on a space!
+    prevloc = loc  # location in string 'line' of current note match
+    b = pObj("bbrk", [" " in xs])  # space somewhere between two notes -> beambreak
+    t.insert(0, b)  # insert beambreak as a nested parse result
 
-def errorWarn (line, loc, t):   # warning for misplaced symbols and skip them
-    if not t[0]: return []      # only warn if catched string not empty
-    info ('**misplaced symbol: %s' % t[0], warn=0)
-    lineCopy = line [:]
+
+def noteActn(line, loc, t):  # detect beambreak between previous and current note/rest
+    if "y" in t[0].t:
+        return []  # discard spacer
+    detectBeamBreak(line, loc, t)  # adds beambreak to parse result t as side effect
+    return pObj("note", t)
+
+
+def restActn(line, loc, t):  # detect beambreak between previous and current note/rest
+    detectBeamBreak(line, loc, t)  # adds beambreak to parse result t as side effect
+    return pObj("rest", t)
+
+
+def errorWarn(line, loc, t):  # warning for misplaced symbols and skip them
+    if not t[0]:
+        return []  # only warn if catched string not empty
+    info("**misplaced symbol: %s" % t[0], warn=0)
+    lineCopy = line[:]
     if loc > 40:
-        lineCopy = line [loc - 40: loc + 40]
+        lineCopy = line[loc - 40 : loc + 40]
         loc = 40
-    info (lineCopy.replace ('\n', ' '), warn=0)
-    info (loc * '-' + '^', warn=0)
+    info(lineCopy.replace("\n", " "), warn=0)
+    info(loc * "-" + "^", warn=0)
     return []
 
-#-------------------------------------------------------------
-# transformations of a measure (called by parse action doMaat)
-#-------------------------------------------------------------
 
-def simplify (a, b):    # divide a and b by their greatest common divisor
+# -------------------------------------------------------------
+# transformations of a measure (called by parse action doMaat)
+# -------------------------------------------------------------
+
+
+def simplify(a, b):  # divide a and b by their greatest common divisor
     x, y = a, b
-    while b: a, b = b, a % b
+    while b:
+        a, b = b, a % b
     return x // a, y // a
 
-def doBroken (prev, brk, x):
-    if not prev: info ('error in broken rhythm: %s' % x); return    # no changes
-    nom1, den1 = prev.dur.t # duration of first note/chord
-    nom2, den2 = x.dur.t    # duration of second note/chord
-    if  brk == '>':
-        nom1, den1  = simplify (3 * nom1, 2 * den1)
-        nom2, den2  = simplify (1 * nom2, 2 * den2)
-    elif brk == '<':
-        nom1, den1  = simplify (1 * nom1, 2 * den1)
-        nom2, den2  = simplify (3 * nom2, 2 * den2)
-    elif brk == '>>':
-        nom1, den1  = simplify (7 * nom1, 4 * den1)
-        nom2, den2  = simplify (1 * nom2, 4 * den2)
-    elif brk == '<<':
-        nom1, den1  = simplify (1 * nom1, 4 * den1)
-        nom2, den2  = simplify (7 * nom2, 4 * den2)
-    else: return            # give up
-    prev.dur.t = nom1, den1 # change duration of previous note/chord
-    x.dur.t = nom2, den2    # and current note/chord
 
-def convertBroken (t):  # convert broken rhythms to normal note durations
-    prev = None # the last note/chord before the broken symbol
-    brk = ''    # the broken symbol
-    remove = [] # indexes to broken symbols (to be deleted) in measure
-    for i, x in enumerate (t):  # scan all elements in measure
-        if x.name == 'note' or x.name == 'chord' or x.name == 'rest':
-            if brk:                 # a broken symbol was encountered before
-                doBroken (prev, brk, x) # change duration previous note/chord/rest and current one
-                brk = ''
+def doBroken(prev, brk, x):
+    if not prev:
+        info("error in broken rhythm: %s" % x)
+        return  # no changes
+    nom1, den1 = prev.dur.t  # duration of first note/chord
+    nom2, den2 = x.dur.t  # duration of second note/chord
+    if brk == ">":
+        nom1, den1 = simplify(3 * nom1, 2 * den1)
+        nom2, den2 = simplify(1 * nom2, 2 * den2)
+    elif brk == "<":
+        nom1, den1 = simplify(1 * nom1, 2 * den1)
+        nom2, den2 = simplify(3 * nom2, 2 * den2)
+    elif brk == ">>":
+        nom1, den1 = simplify(7 * nom1, 4 * den1)
+        nom2, den2 = simplify(1 * nom2, 4 * den2)
+    elif brk == "<<":
+        nom1, den1 = simplify(1 * nom1, 4 * den1)
+        nom2, den2 = simplify(7 * nom2, 4 * den2)
+    else:
+        return  # give up
+    prev.dur.t = nom1, den1  # change duration of previous note/chord
+    x.dur.t = nom2, den2  # and current note/chord
+
+
+def convertBroken(t):  # convert broken rhythms to normal note durations
+    prev = None  # the last note/chord before the broken symbol
+    brk = ""  # the broken symbol
+    remove = []  # indexes to broken symbols (to be deleted) in measure
+    for i, x in enumerate(t):  # scan all elements in measure
+        if x.name == "note" or x.name == "chord" or x.name == "rest":
+            if brk:  # a broken symbol was encountered before
+                doBroken(
+                    prev, brk, x
+                )  # change duration previous note/chord/rest and current one
+                brk = ""
             else:
-                prev = x            # remember the last note/chord/rest
-        elif x.name == 'broken':
-            brk = x.t[0]            # remember the broken symbol (=string)
-            remove.insert (0, i)    # and its index, highest index first
-    for i in remove: del t[i]       # delete broken symbols from high to low
+                prev = x  # remember the last note/chord/rest
+        elif x.name == "broken":
+            brk = x.t[0]  # remember the broken symbol (=string)
+            remove.insert(0, i)  # and its index, highest index first
+    for i in remove:
+        del t[i]  # delete broken symbols from high to low
 
-def ptc2midi (n):       # convert parsed pitch attribute to a midi number
-    pt = getattr (n, 'pitch', '')
+
+def ptc2midi(n):  # convert parsed pitch attribute to a midi number
+    pt = getattr(n, "pitch", "")
     if pt:
         p = pt.t
-        if len (p) == 3: acc, step, oct = p
-        else:       acc = ''; step, oct = p
-        nUp = step.upper ()
-        oct = (4 if nUp == step else 5) + int (oct)
-        midi = oct * 12 + [0,2,4,5,7,9,11]['CDEFGAB'.index (nUp)] + {'^':1,'_':-1}.get (acc, 0) + 12
-    else: midi = 130    # all non pitch objects first
+        if len(p) == 3:
+            acc, step, oct = p
+        else:
+            acc = ""
+            step, oct = p
+        nUp = step.upper()
+        oct = (4 if nUp == step else 5) + int(oct)
+        midi = (
+            oct * 12
+            + [0, 2, 4, 5, 7, 9, 11]["CDEFGAB".index(nUp)]
+            + {"^": 1, "_": -1}.get(acc, 0)
+            + 12
+        )
+    else:
+        midi = 130  # all non pitch objects first
     return midi
 
-def convertChord (t):   # convert chord to sequence of notes in musicXml-style
+
+def convertChord(t):  # convert chord to sequence of notes in musicXml-style
     ins = []
-    for i, x in enumerate (t):
-        if x.name == 'chord':
-            if hasattr (x, 'rest') and not hasattr (x, 'note'): # chords containing only rests
-                if type (x.rest) == list_type: x.rest = x.rest[0] # more rests == one rest
-                ins.insert (0, (i, [x.rest]))   # just output a single rest, no chord
+    for i, x in enumerate(t):
+        if x.name == "chord":
+            if hasattr(x, "rest") and not hasattr(
+                x, "note"
+            ):  # chords containing only rests
+                if isinstance(x.rest, list_type):
+                    x.rest = x.rest[0]  # more rests == one rest
+                ins.insert(0, (i, [x.rest]))  # just output a single rest, no chord
                 continue
-            num1, den1 = x.dur.t                # chord duration
-            tie = getattr (x, 'tie', None)      # chord tie
-            slurs = getattr (x, 'slurs', [])    # slur endings
-            if type (x.note) != list_type: x.note = [x.note]    # when chord has only one note ...
-            elms = []; j = 0                    # sort chord notes, highest first
-            nss = sorted (x.objs, key = ptc2midi, reverse=1) if mxm.orderChords else x.objs
-            for nt in nss:   # all chord elements (note | decorations | rest | grace note)
-                if nt.name == 'note':
-                    num2, den2 = nt.dur.t           # note duration * chord duration
-                    nt.dur.t = simplify (num1 * num2, den1 * den2)
-                    if tie: nt.tie = tie            # tie on all chord notes
-                    if j == 0 and slurs: nt.slurs = slurs   # slur endings only on first chord note
-                    if j > 0: nt.chord = pObj ('chord', [1]) # label all but first as chord notes
-                    else:                           # remember all pitches of the chord in the first note
-                        pitches = [n.pitch for n in x.note] # to implement conversion of erroneous ties to slurs
-                        nt.pitches = pObj ('pitches', pitches)
+            num1, den1 = x.dur.t  # chord duration
+            tie = getattr(x, "tie", None)  # chord tie
+            slurs = getattr(x, "slurs", [])  # slur endings
+            if isinstance(x.note, list_type):
+                x.note = [x.note]  # when chord has only one note ...
+            elms = []
+            j = 0  # sort chord notes, highest first
+            nss = sorted(x.objs, key=ptc2midi, reverse=1) if mxm.orderChords else x.objs
+            for (
+                nt
+            ) in nss:  # all chord elements (note | decorations | rest | grace note)
+                if nt.name == "note":
+                    num2, den2 = nt.dur.t  # note duration * chord duration
+                    nt.dur.t = simplify(num1 * num2, den1 * den2)
+                    if tie:
+                        nt.tie = tie  # tie on all chord notes
+                    if j == 0 and slurs:
+                        nt.slurs = slurs  # slur endings only on first chord note
+                    if j > 0:
+                        nt.chord = pObj(
+                            "chord", [1]
+                        )  # label all but first as chord notes
+                    else:  # remember all pitches of the chord in the first note
+                        pitches = [
+                            n.pitch for n in x.note
+                        ]  # to implement conversion of erroneous ties to slurs
+                        nt.pitches = pObj("pitches", pitches)
                     j += 1
-                if nt.name not in ['dur','tie','slurs','rest']: elms.append (nt)
-            ins.insert (0, (i, elms))           # chord position, [note|decotation|grace note]
-    for i, notes in ins:                        # insert from high to low
-        for nt in reversed (notes):
-            t.insert (i+1, nt)                  # insert chord notes after chord
-        del t[i]                                # remove chord itself
+                if nt.name not in ["dur", "tie", "slurs", "rest"]:
+                    elms.append(nt)
+            ins.insert(0, (i, elms))  # chord position, [note|decotation|grace note]
+    for i, notes in ins:  # insert from high to low
+        for nt in reversed(notes):
+            t.insert(i + 1, nt)  # insert chord notes after chord
+        del t[i]  # remove chord itself
 
-def doMaat (t):             # t is a Group() result -> the measure is in t[0]
-    convertBroken (t[0])    # remove all broken rhythms and convert to normal durations
-    convertChord (t[0])     # replace chords by note sequences in musicXML style
 
-def doGrace (t):        # t is a Group() result -> the grace sequence is in t[0]
-    convertChord (t[0]) # a grace sequence may have chords
-    for nt in t[0]:     # flag all notes within the grace sequence
-        if nt.name == 'note': nt.grace = 1 # set grace attribute
-    return t[0]         # ungroup the parse result
-#--------------------
+def doMaat(t):  # t is a Group() result -> the measure is in t[0]
+    convertBroken(t[0])  # remove all broken rhythms and convert to normal durations
+    convertChord(t[0])  # replace chords by note sequences in musicXML style
+
+
+def doGrace(t):  # t is a Group() result -> the grace sequence is in t[0]
+    convertChord(t[0])  # a grace sequence may have chords
+    for nt in t[0]:  # flag all notes within the grace sequence
+        if nt.name == "note":
+            nt.grace = 1  # set grace attribute
+    return t[0]  # ungroup the parse result
+
+
+# --------------------
 # musicXML generation
-#----------------------------------
+# ----------------------------------
 
-def compChordTab ():    # avoid some typing work: returns mapping constant {ABC chordsyms -> musicXML kind}
-    maj, min, aug, dim, dom, ch7, ch6, ch9, ch11, ch13, hd = 'major minor augmented diminished dominant -seventh -sixth -ninth -11th -13th half-diminished'.split ()
-    triad   = zip ('ma Maj maj M mi min m aug dim o + -'.split (), [maj, maj, maj, maj, min, min, min, aug, dim, dim, aug, min])
-    seventh = zip ('7 ma7 Maj7 M7 maj7 mi7 min7 m7 dim7 o7 -7 aug7 +7 m7b5 mi7b5'.split (),
-                   [dom, maj+ch7, maj+ch7, maj+ch7, maj+ch7, min+ch7, min+ch7, min+ch7, dim+ch7, dim+ch7, min+ch7, aug+ch7, aug+ch7, hd, hd])
-    sixth   = zip ('6 ma6 M6 mi6 min6 m6'.split (), [maj+ch6, maj+ch6, maj+ch6, min+ch6, min+ch6, min+ch6])
-    ninth   = zip ('9 ma9 M9 maj9 Maj9 mi9 min9 m9'.split (), [dom+ch9, maj+ch9, maj+ch9, maj+ch9, maj+ch9, min+ch9, min+ch9, min+ch9])
-    elevn   = zip ('11 ma11 M11 maj11 Maj11 mi11 min11 m11'.split (), [dom+ch11, maj+ch11, maj+ch11, maj+ch11, maj+ch11, min+ch11, min+ch11, min+ch11])
-    thirt   = zip ('13 ma13 M13 maj13 Maj13 mi13 min13 m13'.split (), [dom+ch13, maj+ch13, maj+ch13, maj+ch13, maj+ch13, min+ch13, min+ch13, min+ch13])
-    sus     = zip ('sus sus4 sus2'.split (), ['suspended-fourth', 'suspended-fourth', 'suspended-second'])
-    return dict (list (triad) + list (seventh) + list (sixth) + list (ninth) + list (elevn) + list (thirt) + list (sus))
 
-def addElem (parent, child, level):
+def compChordTab():  # avoid some typing work: returns mapping constant {ABC chordsyms -> musicXML kind}
+    maj, min, aug, dim, dom, ch7, ch6, ch9, ch11, ch13, hd = (
+        "major minor augmented diminished dominant -seventh -sixth -ninth -11th -13th half-diminished".split()
+    )
+    triad = zip(
+        "ma Maj maj M mi min m aug dim o + -".split(),
+        [maj, maj, maj, maj, min, min, min, aug, dim, dim, aug, min],
+    )
+    seventh = zip(
+        "7 ma7 Maj7 M7 maj7 mi7 min7 m7 dim7 o7 -7 aug7 +7 m7b5 mi7b5".split(),
+        [
+            dom,
+            maj + ch7,
+            maj + ch7,
+            maj + ch7,
+            maj + ch7,
+            min + ch7,
+            min + ch7,
+            min + ch7,
+            dim + ch7,
+            dim + ch7,
+            min + ch7,
+            aug + ch7,
+            aug + ch7,
+            hd,
+            hd,
+        ],
+    )
+    sixth = zip(
+        "6 ma6 M6 mi6 min6 m6".split(),
+        [maj + ch6, maj + ch6, maj + ch6, min + ch6, min + ch6, min + ch6],
+    )
+    ninth = zip(
+        "9 ma9 M9 maj9 Maj9 mi9 min9 m9".split(),
+        [
+            dom + ch9,
+            maj + ch9,
+            maj + ch9,
+            maj + ch9,
+            maj + ch9,
+            min + ch9,
+            min + ch9,
+            min + ch9,
+        ],
+    )
+    elevn = zip(
+        "11 ma11 M11 maj11 Maj11 mi11 min11 m11".split(),
+        [
+            dom + ch11,
+            maj + ch11,
+            maj + ch11,
+            maj + ch11,
+            maj + ch11,
+            min + ch11,
+            min + ch11,
+            min + ch11,
+        ],
+    )
+    thirt = zip(
+        "13 ma13 M13 maj13 Maj13 mi13 min13 m13".split(),
+        [
+            dom + ch13,
+            maj + ch13,
+            maj + ch13,
+            maj + ch13,
+            maj + ch13,
+            min + ch13,
+            min + ch13,
+            min + ch13,
+        ],
+    )
+    sus = zip(
+        "sus sus4 sus2".split(),
+        ["suspended-fourth", "suspended-fourth", "suspended-second"],
+    )
+    return dict(
+        list(triad)
+        + list(seventh)
+        + list(sixth)
+        + list(ninth)
+        + list(elevn)
+        + list(thirt)
+        + list(sus)
+    )
+
+
+def addElem(parent, child, level):
     indent = 2
-    chldrn = list (parent)
+    chldrn = list(parent)
     if chldrn:
-        chldrn[-1].tail += indent * ' '
+        chldrn[-1].tail += indent * " "
     else:
-        parent.text = '\n' + level * indent * ' '
-    parent.append (child)
-    child.tail = '\n' + (level-1) * indent * ' '
+        parent.text = "\n" + level * indent * " "
+    parent.append(child)
+    child.tail = "\n" + (level - 1) * indent * " "
 
-def addElemT (parent, tag, text, level):
-    e = E.Element (tag)
+
+def addElemT(parent, tag, text, level):
+    e = E.Element(tag)
     e.text = text
-    addElem (parent, e, level)
+    addElem(parent, e, level)
     return e
-    
-def mkTmod (tmnum, tmden, lev):
-    tmod = E.Element ('time-modification')
-    addElemT (tmod, 'actual-notes', str (tmnum), lev + 1)
-    addElemT (tmod, 'normal-notes', str (tmden), lev + 1)
+
+
+def mkTmod(tmnum, tmden, lev):
+    tmod = E.Element("time-modification")
+    addElemT(tmod, "actual-notes", str(tmnum), lev + 1)
+    addElemT(tmod, "normal-notes", str(tmden), lev + 1)
     return tmod
 
-def addDirection (parent, elems, lev, gstaff, subelms=[], placement='below', cue_on=0):
-    dir = E.Element ('direction', placement=placement)
-    addElem (parent, dir, lev)
-    if type (elems) != list_type: elems = [(elems, subelms)]    # ugly hack to provide for multiple direction types
-    for elem, subelms in elems: # add direction types
-        typ = E.Element ('direction-type')
-        addElem (dir, typ, lev + 1)
-        addElem (typ, elem, lev + 2)
-        for subel in subelms: addElem (elem, subel, lev + 3)
-    if cue_on: addElem (dir, E.Element ('level', size='cue'), lev + 1)
-    if gstaff: addElemT (dir, 'staff', str (gstaff), lev + 1)
+
+def addDirection(parent, elems, lev, gstaff, subelms=[], placement="below", cue_on=0):
+    dir = E.Element("direction", placement=placement)
+    addElem(parent, dir, lev)
+    if isinstance(elems, list_type):
+        elems = [(elems, subelms)]  # ugly hack to provide for multiple direction types
+    for elem, subelms in elems:  # add direction types
+        typ = E.Element("direction-type")
+        addElem(dir, typ, lev + 1)
+        addElem(typ, elem, lev + 2)
+        for subel in subelms:
+            addElem(elem, subel, lev + 3)
+    if cue_on:
+        addElem(dir, E.Element("level", size="cue"), lev + 1)
+    if gstaff:
+        addElemT(dir, "staff", str(gstaff), lev + 1)
     return dir
 
-def removeElems (root_elem, parent_str, elem_str):
-    for p in root_elem.findall (parent_str):
-        e = p.find (elem_str)
-        if e != None: p.remove (e)
 
-def alignLyr (vce, lyrs):
-    empty_el = pObj ('leeg', '*')
-    for k, lyr in enumerate (lyrs): # lyr = one full line of lyrics
-        i = 0               # syl counter
-        for elem in vce:    # reiterate the voice block for each lyrics line
-            if elem.name == 'note' and not (hasattr (elem, 'chord') or hasattr (elem, 'grace')):
-                if i >= len (lyr): lr = empty_el
-                else: lr = lyr [i]
-                lr.t[0] = lr.t[0].replace ('%5d',']')
-                elem.objs.append (lr)
-                if lr.name != 'sbar': i += 1
-            if elem.name == 'rbar' and i < len (lyr) and lyr[i].name == 'sbar': i += 1
+def removeElems(root_elem, parent_str, elem_str):
+    for p in root_elem.findall(parent_str):
+        e = p.find(elem_str)
+        if e is not None:
+            p.remove(e)
+
+
+def alignLyr(vce, lyrs):
+    empty_el = pObj("leeg", "*")
+    for k, lyr in enumerate(lyrs):  # lyr = one full line of lyrics
+        i = 0  # syl counter
+        for elem in vce:  # reiterate the voice block for each lyrics line
+            if elem.name == "note" and not (
+                hasattr(elem, "chord") or hasattr(elem, "grace")
+            ):
+                if i >= len(lyr):
+                    lr = empty_el
+                else:
+                    lr = lyr[i]
+                lr.t[0] = lr.t[0].replace("%5d", "]")
+                elem.objs.append(lr)
+                if lr.name != "sbar":
+                    i += 1
+            if elem.name == "rbar" and i < len(lyr) and lyr[i].name == "sbar":
+                i += 1
     return vce
 
-slur_move = re.compile (r'(?<![!+])([}><][<>]?)(\)+)')  # (?<!...) means: not preceeded by ...
-mm_rest = re.compile (r'([XZ])(\d+)')
-bar_space = re.compile (r'([:|][ |\[\]]+[:|])')         # barlines with spaces
-def fixSlurs (x):   # repair slurs when after broken sign or grace-close
-    def f (mo):     # replace a multi-measure rest by single measure rests
-        n = int (mo.group (2))
-        return (n * (mo.group (1) + '|')) [:-1]
-    def g (mo):     # squash spaces in barline expressions
-        return mo.group (1).replace (' ','')
-    x = mm_rest.sub (f, x)
-    x = bar_space.sub (g, x)
-    return slur_move.sub (r'\2\1', x)
 
-def splitHeaderVoices (abctext):
-    escField = lambda x: '[' + x.replace (']',r'%5d') + ']' # hope nobody uses %5d in a field
-    r1 = re.compile (r'%.*$')           # comments
-    r2 = re.compile (r'^([A-Zw]:.*$)|\[[A-Zw]:[^]]*]$')     # information field, including lyrics
-    r3 = re.compile (r'^%%(?=[^%])')    # directive: ^%% folowed by not a %
-    xs, nx, mcont, fcont = [], 0, 0, 0  # result lines, X-encountered, music continuation, field continuation
-    mln = fln = ''                      # music line, field line
-    for x in abctext.splitlines ():
-        x = x.strip ()
-        if not x and nx == 1: break     # end of tune (empty line)
-        if x.startswith ('X:'):
-            if nx == 1: break           # second tune starts without an empty line !!
-            nx = 1                      # start first tune
-        x = r3.sub ('I:', x)            # replace %% -> I:
-        x2 = r1.sub ('', x)             # remove comment
-        while x2.endswith ('*') and not (x2.startswith ('w:') or x2.startswith ('+:') or 'percmap' in x2):
-            x2 = x2[:-1]                # remove old syntax for right adjusting
-        if not x2: continue             # empty line
-        if x2[:2] == 'W:':
-            field = x2 [2:].strip ()
-            ftype = mxm.metaMap.get ('W', 'W')  # respect the (user defined --meta) mapping of various ABC fields to XML meta data types
-            c = mxm.metadata.get (ftype, '')
-            mxm.metadata [ftype] = c + '\n' + field if c else field   # concatenate multiple info fields with new line as separator
-            continue                    # skip W: lyrics
-        if x2[:2] == '+:':              # field continuation
+slur_move = re.compile(
+    r"(?<![!+])([}><][<>]?)(\)+)"
+)  # (?<!...) means: not preceeded by ...
+mm_rest = re.compile(r"([XZ])(\d+)")
+bar_space = re.compile(r"([:|][ |\[\]]+[:|])")  # barlines with spaces
+
+
+def fixSlurs(x):  # repair slurs when after broken sign or grace-close
+    def f(mo):  # replace a multi-measure rest by single measure rests
+        n = int(mo.group(2))
+        return (n * (mo.group(1) + "|"))[:-1]
+
+    def g(mo):  # squash spaces in barline expressions
+        return mo.group(1).replace(" ", "")
+
+    x = mm_rest.sub(f, x)
+    x = bar_space.sub(g, x)
+    return slur_move.sub(r"\2\1", x)
+
+
+def splitHeaderVoices(abctext):
+    def escField(x):
+        return "[" + x.replace("]", r"%5d") + "]"  # hope nobody uses %5d in a field
+    r1 = re.compile(r"%.*$")  # comments
+    r2 = re.compile(
+        r"^([A-Zw]:.*$)|\[[A-Zw]:[^]]*]$"
+    )  # information field, including lyrics
+    r3 = re.compile(r"^%%(?=[^%])")  # directive: ^%% folowed by not a %
+    xs, nx, mcont, fcont = (
+        [],
+        0,
+        0,
+        0,
+    )  # result lines, X-encountered, music continuation, field continuation
+    mln = fln = ""  # music line, field line
+    for x in abctext.splitlines():
+        x = x.strip()
+        if not x and nx == 1:
+            break  # end of tune (empty line)
+        if x.startswith("X:"):
+            if nx == 1:
+                break  # second tune starts without an empty line !!
+            nx = 1  # start first tune
+        x = r3.sub("I:", x)  # replace %% -> I:
+        x2 = r1.sub("", x)  # remove comment
+        while x2.endswith("*") and not (
+            x2.startswith("w:") or x2.startswith("+:") or "percmap" in x2
+        ):
+            x2 = x2[:-1]  # remove old syntax for right adjusting
+        if not x2:
+            continue  # empty line
+        if x2[:2] == "W:":
+            field = x2[2:].strip()
+            ftype = mxm.metaMap.get(
+                "W", "W"
+            )  # respect the (user defined --meta) mapping of various ABC fields to XML meta data types
+            c = mxm.metadata.get(ftype, "")
+            mxm.metadata[ftype] = (
+                c + "\n" + field if c else field
+            )  # concatenate multiple info fields with new line as separator
+            continue  # skip W: lyrics
+        if x2[:2] == "+:":  # field continuation
             fln += x2[2:]
             continue
-        ro = r2.match (x2)              # single field on a line
-        if ro:                          # field -> inline_field, escape all ']'
-            if fcont:                   # old style \-info-continuation active
-                fcont = x2 [-1] == '\\' # possible further \-info-continuation
-                fln += re.sub (r'^.:(.*?)\\*$', r'\1', x2) # add continuation, remove .: and \
+        ro = r2.match(x2)  # single field on a line
+        if ro:  # field -> inline_field, escape all ']'
+            if fcont:  # old style \-info-continuation active
+                fcont = x2[-1] == "\\"  # possible further \-info-continuation
+                fln += re.sub(
+                    r"^.:(.*?)\\*$", r"\1", x2
+                )  # add continuation, remove .: and \
                 continue
-            if fln: mln += escField (fln)
-            if x2.startswith ('['): x2 = x2.strip ('[]')
-            fcont = x2 [-1] == '\\'     # first encounter of old style \-info-continuation
-            fln = x2.rstrip ('\\')      # remove continuation from field and inline brackets
-            continue
-        if nx == 1:                     # x2 is a new music line
-            fcont = 0                   # stop \-continuations (-> only adjacent \-info-continuations are joined)
             if fln:
-                mln +=  escField (fln)
-                fln = ''
+                mln += escField(fln)
+            if x2.startswith("["):
+                x2 = x2.strip("[]")
+            fcont = x2[-1] == "\\"  # first encounter of old style \-info-continuation
+            fln = x2.rstrip("\\")  # remove continuation from field and inline brackets
+            continue
+        if nx == 1:  # x2 is a new music line
+            fcont = 0  # stop \-continuations (-> only adjacent \-info-continuations are joined)
+            if fln:
+                mln += escField(fln)
+                fln = ""
             if mcont:
-                mcont = x2 [-1] == '\\' 
-                mln += x2.rstrip ('\\')
+                mcont = x2[-1] == "\\"
+                mln += x2.rstrip("\\")
             else:
-                if mln: xs.append (mln); mln = ''
-                mcont = x2 [-1] == '\\'
-                mln = x2.rstrip ('\\')
-            if not mcont: xs.append (mln); mln = ''
-    if fln: mln += escField (fln)
-    if mln: xs.append (mln)
+                if mln:
+                    xs.append(mln)
+                    mln = ""
+                mcont = x2[-1] == "\\"
+                mln = x2.rstrip("\\")
+            if not mcont:
+                xs.append(mln)
+                mln = ""
+    if fln:
+        mln += escField(fln)
+    if mln:
+        xs.append(mln)
 
-    hs = re.split (r'(\[K:[^]]*\])', xs [0])   # look for end of header K:
-    if len (hs) == 1: header = hs[0]; xs [0] = ''               # no K: present
-    else: header = hs [0] + hs [1]; xs [0] = ''.join (hs[2:])   # h[1] is the first K:
-    abctext = '\n'.join (xs)                    # the rest is body text
-    hfs, vfs = [], []
-    for x in header[1:-1].split (']['):
-        if x[0] == 'V': vfs.append (x)          # filter voice- and midi-definitions
-        elif x[:6] == 'I:MIDI': vfs.append (x)  # from the header to vfs
-        elif x[:9] == 'I:percmap': vfs.append (x)  # and also percmap
-        else: hfs.append (x)                    # all other fields stay in header
-    header = '[' + ']['.join (hfs) + ']'        # restore the header
-    abctext = ('[' + ']['.join (vfs) + ']' if vfs else '') + abctext    # prepend voice/midi from header before abctext
-
-    xs = abctext.split ('[V:')
-    if len (xs) == 1: abctext = '[V:1]' + abctext # abc has no voice defs at all
-    elif re.sub (r'\[[A-Z]:[^]]*\]', '', xs[0]).strip ():   # remove inline fields from starting text, if any
-        abctext = '[V:1]' + abctext     # abc with voices has no V: at start
-
-    r1 = re.compile (r'\[V:\s*(\S*)[ \]]') # get voice id from V: field (skip spaces betwee V: and ID)
-    vmap = {}                           # {voice id -> [voice abc string]}
-    vorder = {}                         # mark document order of voices
-    xs = re.split (r'(\[V:[^]]*\])', abctext)   # split on every V-field (V-fields included in split result list)
-    if len (xs) == 1: raise ValueError ('bugs ...')
+    hs = re.split(r"(\[K:[^]]*\])", xs[0])  # look for end of header K:
+    if len(hs) == 1:
+        header = hs[0]
+        xs[0] = ""  # no K: present
     else:
-        pm = re.findall (r'\[P:.\]', xs[0])         # all P:-marks after K: but before first V:
-        if pm: xs[2] = ''.join (pm) + xs[2]         # prepend P:-marks to the text of the first voice
-        header += re.sub (r'\[P:.\]', '', xs[0])    # clear all P:-marks from text between K: and first V: and put text in the header
+        header = hs[0] + hs[1]
+        xs[0] = "".join(hs[2:])  # h[1] is the first K:
+    abctext = "\n".join(xs)  # the rest is body text
+    hfs, vfs = [], []
+    for x in header[1:-1].split("]["):
+        if x[0] == "V":
+            vfs.append(x)  # filter voice- and midi-definitions
+        elif x[:6] == "I:MIDI":
+            vfs.append(x)  # from the header to vfs
+        elif x[:9] == "I:percmap":
+            vfs.append(x)  # and also percmap
+        else:
+            hfs.append(x)  # all other fields stay in header
+    header = "[" + "][".join(hfs) + "]"  # restore the header
+    abctext = (
+        "[" + "][".join(vfs) + "]" if vfs else ""
+    ) + abctext  # prepend voice/midi from header before abctext
+
+    xs = abctext.split("[V:")
+    if len(xs) == 1:
+        abctext = "[V:1]" + abctext  # abc has no voice defs at all
+    elif re.sub(
+        r"\[[A-Z]:[^]]*\]", "", xs[0]
+    ).strip():  # remove inline fields from starting text, if any
+        abctext = "[V:1]" + abctext  # abc with voices has no V: at start
+
+    r1 = re.compile(
+        r"\[V:\s*(\S*)[ \]]"
+    )  # get voice id from V: field (skip spaces betwee V: and ID)
+    vmap = {}  # {voice id -> [voice abc string]}
+    vorder = {}  # mark document order of voices
+    xs = re.split(
+        r"(\[V:[^]]*\])", abctext
+    )  # split on every V-field (V-fields included in split result list)
+    if len(xs) == 1:
+        raise ValueError("bugs ...")
+    else:
+        pm = re.findall(r"\[P:.\]", xs[0])  # all P:-marks after K: but before first V:
+        if pm:
+            xs[2] = (
+                "".join(pm) + xs[2]
+            )  # prepend P:-marks to the text of the first voice
+        header += re.sub(
+            r"\[P:.\]", "", xs[0]
+        )  # clear all P:-marks from text between K: and first V: and put text in the header
         i = 1
-        while i < len (xs):             # xs = ['', V-field, voice abc, V-field, voice abc, ...]
-            vce, abc = xs[i:i+2]
-            id = r1.search (vce).group (1)                  # get voice ID from V-field
-            if not id: id, vce = '1', '[V:1]'               # voice def has no ID
-            vmap[id] = vmap.get (id, []) + [vce, abc]       # collect abc-text for each voice id (include V-fields)
-            if id not in vorder: vorder [id] = i            # store document order of first occurrence of voice id
+        while i < len(xs):  # xs = ['', V-field, voice abc, V-field, voice abc, ...]
+            vce, abc = xs[i : i + 2]
+            id = r1.search(vce).group(1)  # get voice ID from V-field
+            if not id:
+                id, vce = "1", "[V:1]"  # voice def has no ID
+            vmap[id] = vmap.get(id, []) + [
+                vce,
+                abc,
+            ]  # collect abc-text for each voice id (include V-fields)
+            if id not in vorder:
+                vorder[id] = i  # store document order of first occurrence of voice id
             i += 2
     voices = []
-    ixs = sorted ([(i, id) for id, i in vorder.items ()])   # restore document order of voices
+    ixs = sorted(
+        [(i, id) for id, i in vorder.items()]
+    )  # restore document order of voices
     for i, id in ixs:
-        voice = ''.join (vmap [id])     # all abc of one voice
-        voice = fixSlurs (voice)        # put slurs right after the notes
-        voices.append ((id, voice))
+        voice = "".join(vmap[id])  # all abc of one voice
+        voice = fixSlurs(voice)  # put slurs right after the notes
+        voices.append((id, voice))
     return header, voices
 
-def mergeMeasure (m1, m2, slur_offset, voice_offset, rOpt, is_grand=0, is_overlay=0):
-    slurs = m2.findall ('note/notations/slur')
+
+def mergeMeasure(m1, m2, slur_offset, voice_offset, rOpt, is_grand=0, is_overlay=0):
+    slurs = m2.findall("note/notations/slur")
     for slr in slurs:
-        slrnum = int (slr.get ('number')) + slur_offset 
-        slr.set ('number', str (slrnum))    # make unique slurnums in m2
-    vs = m2.findall ('note/voice')          # set all voice number elements in m2
-    for v in vs: v.text  = str (voice_offset + int (v.text))
-    ls = m1.findall ('note/lyric')          # all lyric elements in m1
-    lnum_max = max ([int (l.get ('number')) for l in ls] + [0]) # highest lyric number in m1
-    ls = m2.findall ('note/lyric')          # update lyric elements in m2
+        slrnum = int(slr.get("number")) + slur_offset
+        slr.set("number", str(slrnum))  # make unique slurnums in m2
+    vs = m2.findall("note/voice")  # set all voice number elements in m2
+    for v in vs:
+        v.text = str(voice_offset + int(v.text))
+    ls = m1.findall("note/lyric")  # all lyric elements in m1
+    lnum_max = max(
+        [int(l.get("number")) for l in ls] + [0]
+    )  # highest lyric number in m1
+    ls = m2.findall("note/lyric")  # update lyric elements in m2
     for el in ls:
-        n = int (el.get ('number'))
-        el.set ('number', str (n + lnum_max))
-    ns = m1.findall ('note')    # determine the total duration of m1, subtract all backups
-    dur1 = sum (int (n.find ('duration').text) for n in ns
-                if n.find ('grace') == None and n.find ('chord') == None)
-    dur1 -= sum (int (b.text) for b in m1.findall ('backup/duration'))
+        n = int(el.get("number"))
+        el.set("number", str(n + lnum_max))
+    ns = m1.findall("note")  # determine the total duration of m1, subtract all backups
+    dur1 = sum(
+        int(n.find("duration").text)
+        for n in ns
+        if n.find("grace") is None and n.find("chord") is None
+    )
+    dur1 -= sum(int(b.text) for b in m1.findall("backup/duration"))
     repbar, nns, es = 0, 0, []  # nns = number of real notes in m2
-    for e in list (m2): # scan all elements of m2
-        if e.tag == 'attributes':
-            if not is_grand: continue # no attribute merging for normal voices
-            else: nns += 1      # but we do merge (clef) attributes for a grand staff
-        if e.tag == 'print': continue
-        if e.tag == 'note' and (rOpt or e.find ('rest') == None): nns += 1
-        if e.tag == 'barline' and e.find ('repeat') != None: repbar = e;
-        es.append (e)           # buffer elements to be merged
-    if nns > 0:                 # only merge if m2 contains any real notes
-        if dur1 > 0:            # only insert backup if duration of m1 > 0
-            b = E.Element ('backup')
-            addElem (m1, b, level=3)
-            addElemT (b, 'duration', str (dur1), level=4)
-        for e in es: addElem (m1, e, level=3)   # merge buffered elements of m2
-    elif is_overlay and repbar: addElem (m1, repbar, level=3)   # merge repeat in empty overlay
+    for e in list(m2):  # scan all elements of m2
+        if e.tag == "attributes":
+            if not is_grand:
+                continue  # no attribute merging for normal voices
+            else:
+                nns += 1  # but we do merge (clef) attributes for a grand staff
+        if e.tag == "print":
+            continue
+        if e.tag == "note" and (rOpt or e.find("rest") is None):
+            nns += 1
+        if e.tag == "barline" and e.find("repeat") is not None:
+            repbar = e
+        es.append(e)  # buffer elements to be merged
+    if nns > 0:  # only merge if m2 contains any real notes
+        if dur1 > 0:  # only insert backup if duration of m1 > 0
+            b = E.Element("backup")
+            addElem(m1, b, level=3)
+            addElemT(b, "duration", str(dur1), level=4)
+        for e in es:
+            addElem(m1, e, level=3)  # merge buffered elements of m2
+    elif is_overlay and repbar:
+        addElem(m1, repbar, level=3)  # merge repeat in empty overlay
 
-def mergePartList (parts, rOpt, is_grand=0):    # merge parts, make grand staff when is_grand true
 
-    def delAttrs (part):                # for the time being we only keep clef attributes
-        xs = [(m, e) for m in part.findall ('measure') for e in m.findall ('attributes')]
+def mergePartList(
+    parts, rOpt, is_grand=0
+):  # merge parts, make grand staff when is_grand true
+
+    def delAttrs(part):  # for the time being we only keep clef attributes
+        xs = [(m, e) for m in part.findall("measure") for e in m.findall("attributes")]
         for m, e in xs:
-            for c in list (e):
-                if c.tag == 'clef': continue    # keep clef attribute
-                if c.tag == 'staff-details': continue    # keep staff-details attribute
-                e.remove (c)                    # delete all other attrinutes for higher staff numbers
-            if len (list (e)) == 0: m.remove (e)    # remove empty attributes element
+            for c in list(e):
+                if c.tag == "clef":
+                    continue  # keep clef attribute
+                if c.tag == "staff-details":
+                    continue  # keep staff-details attribute
+                e.remove(c)  # delete all other attrinutes for higher staff numbers
+            if len(list(e)) == 0:
+                m.remove(e)  # remove empty attributes element
 
     p1 = parts[0]
     for p2 in parts[1:]:
-        if is_grand: delAttrs (p2)                          # delete all attributes except clef
-        for i in range (len (p1) + 1, len (p2) + 1):        # second part longer than first one
-            maat = E.Element ('measure', number = str(i))   # append empty measures
-            addElem (p1, maat, 2)
-        slurs = p1.findall ('measure/note/notations/slur')  # find highest slur num in first part
-        slur_max = max ([int (slr.get ('number')) for slr in slurs] + [0])
-        vs = p1.findall ('measure/note/voice')              # all voice number elements in first part
-        vnum_max = max ([int (v.text) for v in vs] + [0])   # highest voice number in first part
-        for im, m2 in enumerate (p2.findall ('measure')):   # merge all measures of p2 into p1
-            mergeMeasure (p1[im], m2, slur_max, vnum_max, rOpt, is_grand) # may change slur numbers in p1
+        if is_grand:
+            delAttrs(p2)  # delete all attributes except clef
+        for i in range(len(p1) + 1, len(p2) + 1):  # second part longer than first one
+            maat = E.Element("measure", number=str(i))  # append empty measures
+            addElem(p1, maat, 2)
+        slurs = p1.findall(
+            "measure/note/notations/slur"
+        )  # find highest slur num in first part
+        slur_max = max([int(slr.get("number")) for slr in slurs] + [0])
+        vs = p1.findall("measure/note/voice")  # all voice number elements in first part
+        vnum_max = max(
+            [int(v.text) for v in vs] + [0]
+        )  # highest voice number in first part
+        for im, m2 in enumerate(
+            p2.findall("measure")
+        ):  # merge all measures of p2 into p1
+            mergeMeasure(
+                p1[im], m2, slur_max, vnum_max, rOpt, is_grand
+            )  # may change slur numbers in p1
     return p1
 
-def mergeParts (parts, vids, staves, rOpt, is_grand=0):
-    if not staves: return parts, vids   # no voice mapping
+
+def mergeParts(parts, vids, staves, rOpt, is_grand=0):
+    if not staves:
+        return parts, vids  # no voice mapping
     partsnew, vidsnew = [], []
     for voice_ids in staves:
         pixs = []
         for vid in voice_ids:
-            if vid in vids: pixs.append (vids.index (vid))
-            else: info ('score partname %s does not exist' % vid)
+            if vid in vids:
+                pixs.append(vids.index(vid))
+            else:
+                info("score partname %s does not exist" % vid)
         if pixs:
             xparts = [parts[pix] for pix in pixs]
-            if len (xparts) > 1: mergedpart = mergePartList (xparts, rOpt, is_grand)
-            else:                mergedpart = xparts [0]
-            partsnew.append (mergedpart)
-            vidsnew.append (vids [pixs[0]])
+            if len(xparts) > 1:
+                mergedpart = mergePartList(xparts, rOpt, is_grand)
+            else:
+                mergedpart = xparts[0]
+            partsnew.append(mergedpart)
+            vidsnew.append(vids[pixs[0]])
     return partsnew, vidsnew
 
-def mergePartMeasure (part, msre, ovrlaynum, rOpt): # merge msre into last measure of part, only for overlays
-    slur_offset = 0;    # slur numbers determined by the slurstack size (as in a single voice)
-    last_msre = list (part)[-1] # last measure in part
-    mergeMeasure (last_msre, msre, slur_offset, ovrlaynum, rOpt, is_overlay=1) # voice offset = s.overlayVNum
 
-def pushSlur (boogStapel, stem):
-    if stem not in boogStapel: boogStapel [stem] = [] # initialize slurstack for stem
-    boognum = sum (map (len, boogStapel.values ())) + 1  # number of open slurs in all (overlay) voices
-    boogStapel [stem].append (boognum)
+def mergePartMeasure(
+    part, msre, ovrlaynum, rOpt
+):  # merge msre into last measure of part, only for overlays
+    slur_offset = (
+        0  # slur numbers determined by the slurstack size (as in a single voice)
+    )
+    last_msre = list(part)[-1]  # last measure in part
+    mergeMeasure(
+        last_msre, msre, slur_offset, ovrlaynum, rOpt, is_overlay=1
+    )  # voice offset = s.overlayVNum
+
+
+def pushSlur(boogStapel, stem):
+    if stem not in boogStapel:
+        boogStapel[stem] = []  # initialize slurstack for stem
+    boognum = (
+        sum(map(len, boogStapel.values())) + 1
+    )  # number of open slurs in all (overlay) voices
+    boogStapel[stem].append(boognum)
     return boognum
 
-def setFristVoiceNameFromGroup (vids, vdefs): # vids = [vid], vdef = {vid -> (name, subname, voicedef)}
+
+def setFristVoiceNameFromGroup(
+    vids, vdefs
+):  # vids = [vid], vdef = {vid -> (name, subname, voicedef)}
     vids = [v for v in vids if v in vdefs]  # only consider defined voices
-    if not vids: return vdefs
-    vid0 = vids [0]                         # first vid of the group
-    _, _, vdef0 = vdefs [vid0]              # keep de voice definition (vdef0) when renaming vid0
+    if not vids:
+        return vdefs
+    vid0 = vids[0]  # first vid of the group
+    _, _, vdef0 = vdefs[vid0]  # keep de voice definition (vdef0) when renaming vid0
     for vid in vids:
-        nm, snm, vdef = vdefs [vid]
-        if nm:                              # first non empty name encountered will become
-            vdefs [vid0] = nm, snm, vdef0   # name of merged group == name of first voice in group (vid0)
+        nm, snm, vdef = vdefs[vid]
+        if nm:  # first non empty name encountered will become
+            vdefs[vid0] = (
+                nm,
+                snm,
+                vdef0,
+            )  # name of merged group == name of first voice in group (vid0)
             break
     return vdefs
 
-def mkGrand (p, vdefs):             # transform parse subtree into list needed for s.grands
+
+def mkGrand(p, vdefs):  # transform parse subtree into list needed for s.grands
     xs = []
-    for i, x in enumerate (p.objs): # changing p.objs [i] alters the tree. changing x has no effect on the tree.
-        if type (x) == pObj:
-            us = mkGrand (x, vdefs) # first get transformation results of current pObj
-            if x.name == 'grand':   # x.objs contains ordered list of nested parse results within x
-                vids = [y.objs[0] for y in x.objs[1:]]  # the voice ids in the grand staff
-                nms = [vdefs [u][0] for u in vids if u in vdefs] # the names of those voices
-                accept = sum ([1 for nm in nms if nm]) == 1 # accept as grand staff when only one of the voices has a name
-                if accept or us[0] == '{*':
-                    xs.append (us[1:])      # append voice ids as a list (discard first item '{' or '{*')
-                    vdefs = setFristVoiceNameFromGroup (vids, vdefs)
-                    p.objs [i] = x.objs[1]  # replace voices by first one in the grand group (this modifies the parse tree)
+    for i, x in enumerate(
+        p.objs
+    ):  # changing p.objs [i] alters the tree. changing x has no effect on the tree.
+        if isinstance(x, pObj):
+            us = mkGrand(x, vdefs)  # first get transformation results of current pObj
+            if (
+                x.name == "grand"
+            ):  # x.objs contains ordered list of nested parse results within x
+                vids = [
+                    y.objs[0] for y in x.objs[1:]
+                ]  # the voice ids in the grand staff
+                nms = [
+                    vdefs[u][0] for u in vids if u in vdefs
+                ]  # the names of those voices
+                accept = (
+                    sum([1 for nm in nms if nm]) == 1
+                )  # accept as grand staff when only one of the voices has a name
+                if accept or us[0] == "{*":
+                    xs.append(
+                        us[1:]
+                    )  # append voice ids as a list (discard first item '{' or '{*')
+                    vdefs = setFristVoiceNameFromGroup(vids, vdefs)
+                    p.objs[i] = x.objs[
+                        1
+                    ]  # replace voices by first one in the grand group (this modifies the parse tree)
                 else:
-                    xs.extend (us[1:])      # extend current result with all voice ids of rejected grand staff
-            else: xs.extend (us)    # extend current result with transformed pObj
-        else: xs.append (p.t[0])    # append the non pObj (== voice id string)
-    return xs
-
-def mkStaves (p, vdefs):            # transform parse tree into list needed for s.staves
-    xs = []
-    for i, x in enumerate (p.objs): # structure and comments identical to mkGrand
-        if type (x) == pObj:
-            us = mkStaves (x, vdefs)
-            if x.name == 'voicegr':
-                xs.append (us)
-                vids = [y.objs[0] for y in x.objs]
-                vdefs = setFristVoiceNameFromGroup (vids, vdefs)
-                p.objs [i] = x.objs[0]
+                    xs.extend(
+                        us[1:]
+                    )  # extend current result with all voice ids of rejected grand staff
             else:
-                xs.extend (us)
+                xs.extend(us)  # extend current result with transformed pObj
         else:
-            if p.t[0] not in '{*':  xs.append (p.t[0])
+            xs.append(p.t[0])  # append the non pObj (== voice id string)
     return xs
 
-def mkGroups (p):                   # transform parse tree into list needed for s.groups
+
+def mkStaves(p, vdefs):  # transform parse tree into list needed for s.staves
+    xs = []
+    for i, x in enumerate(p.objs):  # structure and comments identical to mkGrand
+        if isinstance(x, pObj):
+            us = mkStaves(x, vdefs)
+            if x.name == "voicegr":
+                xs.append(us)
+                vids = [y.objs[0] for y in x.objs]
+                vdefs = setFristVoiceNameFromGroup(vids, vdefs)
+                p.objs[i] = x.objs[0]
+            else:
+                xs.extend(us)
+        else:
+            if p.t[0] not in "{*":
+                xs.append(p.t[0])
+    return xs
+
+
+def mkGroups(p):  # transform parse tree into list needed for s.groups
     xs = []
     for x in p.objs:
-        if type (x) == pObj:
-            if x.name == 'vid': xs.extend (mkGroups (x))
-            elif x.name == 'bracketgr': xs.extend (['['] + mkGroups (x) + [']'])
-            elif x.name == 'bracegr':   xs.extend (['{'] + mkGroups (x) + ['}'])
-            else: xs.extend (mkGroups (x) + ['}'])  # x.name == 'grand' == rejected grand staff
+        if isinstance(x, pObj):
+            if x.name == "vid":
+                xs.extend(mkGroups(x))
+            elif x.name == "bracketgr":
+                xs.extend(["["] + mkGroups(x) + ["]"])
+            elif x.name == "bracegr":
+                xs.extend(["{"] + mkGroups(x) + ["}"])
+            else:
+                xs.extend(
+                    mkGroups(x) + ["}"]
+                )  # x.name == 'grand' == rejected grand staff
         else:
-            xs.append (p.t[0])
+            xs.append(p.t[0])
     return xs
 
-def stepTrans (step, soct, clef):   # [A-G] (1...8)
-    if clef.startswith ('bass'):
-        nm7 = 'C,D,E,F,G,A,B'.split (',')
-        n = 14 + nm7.index (step) - 12  # two octaves extra to avoid negative numbers
-        step, soct = nm7 [n % 7], soct + n // 7 - 2  # subtract two octaves again
+
+def stepTrans(step, soct, clef):  # [A-G] (1...8)
+    if clef.startswith("bass"):
+        nm7 = "C,D,E,F,G,A,B".split(",")
+        n = 14 + nm7.index(step) - 12  # two octaves extra to avoid negative numbers
+        step, soct = nm7[n % 7], soct + n // 7 - 2  # subtract two octaves again
     return step, soct
 
-def reduceMids (parts, vidsnew, midiInst):       # remove redundant instruments from a part
-    for pid, part in zip (vidsnew, parts):
+
+def reduceMids(parts, vidsnew, midiInst):  # remove redundant instruments from a part
+    for pid, part in zip(vidsnew, parts):
         mids, repls, has_perc = {}, {}, 0
-        for ipid, ivid, ch, prg, vol, pan in sorted (list (midiInst.values ())):
-            if ipid != pid: continue                # only instruments from part pid
-            if ch == '10': has_perc = 1; continue   # only consider non percussion instruments
-            instId, inst = 'I%s-%s' % (ipid, ivid), (ch, prg)
-            if inst in mids:                        # midi instrument already defined in this part
-                repls [instId]  = mids [inst]       # remember to replace instId by inst (see below)
-                del midiInst [instId]               # instId is redundant
-            else: mids [inst] = instId              # collect unique instruments in this part
-        if len (mids) < 2 and not has_perc:         # only one instrument used -> no instrument tags needed in notes
-            removeElems (part, 'measure/note', 'instrument')    # no instrument tag needed for one- or no-instrument parts
+        for ipid, ivid, ch, prg, vol, pan in sorted(list(midiInst.values())):
+            if ipid != pid:
+                continue  # only instruments from part pid
+            if ch == "10":
+                has_perc = 1
+                continue  # only consider non percussion instruments
+            instId, inst = "I%s-%s" % (ipid, ivid), (ch, prg)
+            if inst in mids:  # midi instrument already defined in this part
+                repls[instId] = mids[
+                    inst
+                ]  # remember to replace instId by inst (see below)
+                del midiInst[instId]  # instId is redundant
+            else:
+                mids[inst] = instId  # collect unique instruments in this part
+        if (
+            len(mids) < 2 and not has_perc
+        ):  # only one instrument used -> no instrument tags needed in notes
+            removeElems(
+                part, "measure/note", "instrument"
+            )  # no instrument tag needed for one- or no-instrument parts
         else:
-            for e in part.findall ('measure/note/instrument'):
-                id = e.get ('id')                   # replace all redundant instrument Id's
-                if id in repls: e.set ('id', repls [id])
+            for e in part.findall("measure/note/instrument"):
+                id = e.get("id")  # replace all redundant instrument Id's
+                if id in repls:
+                    e.set("id", repls[id])
+
 
 class stringAlloc:
-    def __init__ (s):
-        s.snaarVrij = []    # [[(t1, t2) ...] for each string ]
-        s.snaarIx = []      # index in snaarVrij for each string
-        s.curstaff = -1     # staff being allocated
-    def beginZoek (s):      # reset snaarIx at start of each voice
+    def __init__(s):
+        s.snaarVrij = []  # [[(t1, t2) ...] for each string ]
+        s.snaarIx = []  # index in snaarVrij for each string
+        s.curstaff = -1  # staff being allocated
+
+    def beginZoek(s):  # reset snaarIx at start of each voice
         s.snaarIx = []
-        for i in range (len (s.snaarVrij)): s.snaarIx.append (0)
-    def setlines (s, stflines, stfnum):
-        if stfnum != s.curstaff:    # initialize for new staff
+        for i in range(len(s.snaarVrij)):
+            s.snaarIx.append(0)
+
+    def setlines(s, stflines, stfnum):
+        if stfnum != s.curstaff:  # initialize for new staff
             s.curstaff = stfnum
             s.snaarVrij = []
-            for i in range (stflines): s.snaarVrij.append ([])
-            s.beginZoek ()
-    def isVrij (s, snaar, t1, t2):  # see if string snaar is free between t1 and t2
-        xs = s.snaarVrij [snaar]
-        for i in range (s.snaarIx [snaar], len (xs)):
-            tb, te = xs [i]
-            if t1 >= te: continue   # te_prev < t1 <= te
-            if t1 >= tb: s.snaarIx [snaar] = i; return 0    # tb <= t1 < te
-            if t2 > tb: s.snaarIx [snaar] = i; return 0     # t1 < tb < t2
-            s.snaarIx [snaar] = i;  # remember position for next call
-            xs.insert (i, (t1,t2))  # te_prev < t1 < t2 < tb
+            for i in range(stflines):
+                s.snaarVrij.append([])
+            s.beginZoek()
+
+    def isVrij(s, snaar, t1, t2):  # see if string snaar is free between t1 and t2
+        xs = s.snaarVrij[snaar]
+        for i in range(s.snaarIx[snaar], len(xs)):
+            tb, te = xs[i]
+            if t1 >= te:
+                continue  # te_prev < t1 <= te
+            if t1 >= tb:
+                s.snaarIx[snaar] = i
+                return 0  # tb <= t1 < te
+            if t2 > tb:
+                s.snaarIx[snaar] = i
+                return 0  # t1 < tb < t2
+            s.snaarIx[snaar] = i  # remember position for next call
+            xs.insert(i, (t1, t2))  # te_prev < t1 < t2 < tb
             return 1
-        xs.append ((t1,t2))
-        s.snaarIx [snaar] = len (xs) - 1
+        xs.append((t1, t2))
+        s.snaarIx[snaar] = len(xs) - 1
         return 1
-    def bezet (s, snaar, t1, t2):   # force allocation of note (t1,t2) on string snaar
-        xs = s.snaarVrij [snaar]
-        for i, (tb, te) in enumerate (xs):
-            if t1 >= te: continue   # te_prev < t1 <= te
-            xs.insert (i, (t1, t2))
+
+    def bezet(s, snaar, t1, t2):  # force allocation of note (t1,t2) on string snaar
+        xs = s.snaarVrij[snaar]
+        for i, (tb, te) in enumerate(xs):
+            if t1 >= te:
+                continue  # te_prev < t1 <= te
+            xs.insert(i, (t1, t2))
             return
-        xs.append ((t1,t2))
+        xs.append((t1, t2))
+
 
 class MusicXml:
-    typeMap = {1:'long', 2:'breve', 4:'whole', 8:'half', 16:'quarter', 32:'eighth', 64:'16th', 128:'32nd', 256:'64th'}
-    dynaMap = {'p':1,'pp':1,'ppp':1,'pppp':1,'f':1,'ff':1,'fff':1,'ffff':1,'mp':1,'mf':1,'sfz':1}
-    tempoMap = {'larghissimo':40, 'moderato':104, 'adagissimo':44, 'allegretto':112, 'lentissimo':48, 'allegro':120, 'largo':56,
-            'vivace':168, 'adagio':59, 'vivo':180, 'lento':62, 'presto':192, 'larghetto':66, 'allegrissimo':208, 'adagietto':76,
-            'vivacissimo':220, 'andante':88, 'prestissimo':240, 'andantino':96}
-    wedgeMap = {'>(':1, '>)':1, '<(':1,'<)':1,'crescendo(':1,'crescendo)':1,'diminuendo(':1,'diminuendo)':1}
-    artMap = {'.':'staccato','>':'accent','accent':'accent','wedge':'staccatissimo','tenuto':'tenuto',
-              'breath':'breath-mark','marcato':'strong-accent','^':'strong-accent','slide':'scoop'}
-    ornMap = {'trill':'trill-mark','T':'trill-mark','turn':'turn','uppermordent':'inverted-mordent','lowermordent':'mordent',
-              'pralltriller':'inverted-mordent','mordent':'mordent','turn':'turn','invertedturn':'inverted-turn'}
-    tecMap = {'upbow':'up-bow', 'downbow':'down-bow', 'plus':'stopped','open':'open-string','snap':'snap-pizzicato',
-              'thumb':'thumb-position'}
-    capoMap = {'fine':('Fine','fine','yes'), 'D.S.':('D.S.','dalsegno','segno'), 'D.C.':('D.C.','dacapo','yes'),'dacapo':('D.C.','dacapo','yes'),
-               'dacoda':('To Coda','tocoda','coda'), 'coda':('coda','coda','coda'), 'segno':('segno','segno','segno')}
-    sharpness = ['Fb', 'Cb','Gb','Db','Ab','Eb','Bb','F','C','G','D','A', 'E', 'B', 'F#','C#','G#','D#','A#','E#','B#']
-    offTab = {'maj':8, 'm':11, 'min':11, 'mix':9, 'dor':10, 'phr':12, 'lyd':7, 'loc':13}
-    modTab = {'maj':'major', 'm':'minor', 'min':'minor', 'mix':'mixolydian', 'dor':'dorian', 'phr':'phrygian', 'lyd':'lydian', 'loc':'locrian'}
-    clefMap = { 'alto1':('C','1'), 'alto2':('C','2'), 'alto':('C','3'), 'alto4':('C','4'), 'tenor':('C','4'),
-                'bass3':('F','3'), 'bass':('F','4'), 'treble':('G','2'), 'perc':('percussion',''), 'none':('',''), 'tab':('TAB','5')}
-    clefLineMap = {'B':'treble', 'G':'alto1', 'E':'alto2', 'C':'alto', 'A':'tenor', 'F':'bass3', 'D':'bass'}
-    alterTab = {'=':'0', '_':'-1', '__':'-2', '^':'1', '^^':'2'}
-    accTab = {'=':'natural', '_':'flat', '__':'flat-flat', '^':'sharp', '^^':'sharp-sharp'}
-    chordTab = compChordTab ()
-    uSyms = {'~':'roll', 'H':'fermata','L':'>','M':'lowermordent','O':'coda',
-             'P':'uppermordent','S':'segno','T':'trill','u':'upbow','v':'downbow'}
-    pageFmtDef = [0.75,297,210,18,18,10,10] # the abcm2ps page formatting defaults for A4
-    metaTab = {'O':'origin', 'A':'area', 'Z':'transcription', 'N':'notes', 'G':'group', 'H':'history', 'R':'rhythm',
-                'B':'book', 'D':'discography', 'F':'fileurl', 'S':'source', 'P':'partmap', 'W':'lyrics'}
-    metaMap = {'C':'composer'}  # mapping of composer is fixed
-    metaTypes = {'composer':1,'lyricist':1,'poet':1,'arranger':1,'translator':1, 'rights':1} # valid MusicXML meta data types
-    tuningDef = 'E2,A2,D3,G3,B3,E4'.split (',') # default string tuning (guitar)
+    typeMap = {
+        1: "long",
+        2: "breve",
+        4: "whole",
+        8: "half",
+        16: "quarter",
+        32: "eighth",
+        64: "16th",
+        128: "32nd",
+        256: "64th",
+    }
+    dynaMap = {
+        "p": 1,
+        "pp": 1,
+        "ppp": 1,
+        "pppp": 1,
+        "f": 1,
+        "ff": 1,
+        "fff": 1,
+        "ffff": 1,
+        "mp": 1,
+        "mf": 1,
+        "sfz": 1,
+    }
+    tempoMap = {
+        "larghissimo": 40,
+        "moderato": 104,
+        "adagissimo": 44,
+        "allegretto": 112,
+        "lentissimo": 48,
+        "allegro": 120,
+        "largo": 56,
+        "vivace": 168,
+        "adagio": 59,
+        "vivo": 180,
+        "lento": 62,
+        "presto": 192,
+        "larghetto": 66,
+        "allegrissimo": 208,
+        "adagietto": 76,
+        "vivacissimo": 220,
+        "andante": 88,
+        "prestissimo": 240,
+        "andantino": 96,
+    }
+    wedgeMap = {
+        ">(": 1,
+        ">)": 1,
+        "<(": 1,
+        "<)": 1,
+        "crescendo(": 1,
+        "crescendo)": 1,
+        "diminuendo(": 1,
+        "diminuendo)": 1,
+    }
+    artMap = {
+        ".": "staccato",
+        ">": "accent",
+        "accent": "accent",
+        "wedge": "staccatissimo",
+        "tenuto": "tenuto",
+        "breath": "breath-mark",
+        "marcato": "strong-accent",
+        "^": "strong-accent",
+        "slide": "scoop",
+    }
+    ornMap = {
+        "trill": "trill-mark",
+        "T": "trill-mark",
+        "turn": "turn",
+        "uppermordent": "inverted-mordent",
+        "lowermordent": "mordent",
+        "pralltriller": "inverted-mordent",
+        "mordent": "mordent",
+        "turn": "turn",
+        "invertedturn": "inverted-turn",
+    }
+    tecMap = {
+        "upbow": "up-bow",
+        "downbow": "down-bow",
+        "plus": "stopped",
+        "open": "open-string",
+        "snap": "snap-pizzicato",
+        "thumb": "thumb-position",
+    }
+    capoMap = {
+        "fine": ("Fine", "fine", "yes"),
+        "D.S.": ("D.S.", "dalsegno", "segno"),
+        "D.C.": ("D.C.", "dacapo", "yes"),
+        "dacapo": ("D.C.", "dacapo", "yes"),
+        "dacoda": ("To Coda", "tocoda", "coda"),
+        "coda": ("coda", "coda", "coda"),
+        "segno": ("segno", "segno", "segno"),
+    }
+    sharpness = [
+        "Fb",
+        "Cb",
+        "Gb",
+        "Db",
+        "Ab",
+        "Eb",
+        "Bb",
+        "F",
+        "C",
+        "G",
+        "D",
+        "A",
+        "E",
+        "B",
+        "F#",
+        "C#",
+        "G#",
+        "D#",
+        "A#",
+        "E#",
+        "B#",
+    ]
+    offTab = {
+        "maj": 8,
+        "m": 11,
+        "min": 11,
+        "mix": 9,
+        "dor": 10,
+        "phr": 12,
+        "lyd": 7,
+        "loc": 13,
+    }
+    modTab = {
+        "maj": "major",
+        "m": "minor",
+        "min": "minor",
+        "mix": "mixolydian",
+        "dor": "dorian",
+        "phr": "phrygian",
+        "lyd": "lydian",
+        "loc": "locrian",
+    }
+    clefMap = {
+        "alto1": ("C", "1"),
+        "alto2": ("C", "2"),
+        "alto": ("C", "3"),
+        "alto4": ("C", "4"),
+        "tenor": ("C", "4"),
+        "bass3": ("F", "3"),
+        "bass": ("F", "4"),
+        "treble": ("G", "2"),
+        "perc": ("percussion", ""),
+        "none": ("", ""),
+        "tab": ("TAB", "5"),
+    }
+    clefLineMap = {
+        "B": "treble",
+        "G": "alto1",
+        "E": "alto2",
+        "C": "alto",
+        "A": "tenor",
+        "F": "bass3",
+        "D": "bass",
+    }
+    alterTab = {"=": "0", "_": "-1", "__": "-2", "^": "1", "^^": "2"}
+    accTab = {
+        "=": "natural",
+        "_": "flat",
+        "__": "flat-flat",
+        "^": "sharp",
+        "^^": "sharp-sharp",
+    }
+    chordTab = compChordTab()
+    uSyms = {
+        "~": "roll",
+        "H": "fermata",
+        "L": ">",
+        "M": "lowermordent",
+        "O": "coda",
+        "P": "uppermordent",
+        "S": "segno",
+        "T": "trill",
+        "u": "upbow",
+        "v": "downbow",
+    }
+    pageFmtDef = [
+        0.75,
+        297,
+        210,
+        18,
+        18,
+        10,
+        10,
+    ]  # the abcm2ps page formatting defaults for A4
+    metaTab = {
+        "O": "origin",
+        "A": "area",
+        "Z": "transcription",
+        "N": "notes",
+        "G": "group",
+        "H": "history",
+        "R": "rhythm",
+        "B": "book",
+        "D": "discography",
+        "F": "fileurl",
+        "S": "source",
+        "P": "partmap",
+        "W": "lyrics",
+    }
+    metaMap = {"C": "composer"}  # mapping of composer is fixed
+    metaTypes = {
+        "composer": 1,
+        "lyricist": 1,
+        "poet": 1,
+        "arranger": 1,
+        "translator": 1,
+        "rights": 1,
+    }  # valid MusicXML meta data types
+    tuningDef = "E2,A2,D3,G3,B3,E4".split(",")  # default string tuning (guitar)
 
-    def __init__ (s):
-        s.pageFmtCmd = []   # set by command line option -p
-        s.reset ()
-    def reset (s, fOpt=False):
-        s.divisions = 2520  # xml duration of 1/4 note, 2^3 * 3^2 * 5 * 7 => 5,7,9 tuplets
-        s.ties = {}         # {abc pitch tuple -> alteration} for all open ties
-        s.slurstack = {}    # stack of open slur numbers per (overlay) voice
-        s.slurbeg = []      # type of slurs to start (when slurs are detected at element-level)
-        s.tmnum = 0         # time modification, numerator
-        s.tmden = 0         # time modification, denominator
-        s.ntup = 0          # number of tuplet notes remaining
-        s.trem = 0          # number of bars for tremolo
-        s.intrem = 0        # mark tremolo sequence (for duration doubling)
-        s.tupnts = []       # all tuplet modifiers with corresp. durations: [(duration, modifier), ...]
-        s.irrtup = 0        # 1 if an irregular tuplet
-        s.ntype = ''        # the normal-type of a tuplet (== duration type of a normal tuplet note)
-        s.unitL =  (1, 8)   # default unit length
-        s.unitLcur = (1, 8) # unit length of current voice
-        s.keyAlts = {}      # alterations implied by key
-        s.msreAlts = {}     # temporarily alterations
-        s.curVolta = ''     # open volta bracket
-        s.title = ''        # title of music
-        s.creator = {}      # {creator-type -> creator string}
-        s.metadata = {}     # {metadata-type -> string}
-        s.lyrdash = {}      # {lyric number -> 1 if dash between syllables}
-        s.usrSyms = s.uSyms # user defined symbols
-        s.prevNote = None   # xml element of previous beamed note to correct beams (start, continue)
-        s.prevLyric = {}    # xml element of previous lyric to add/correct extend type (start, continue)
-        s.grcbbrk = False   # remember any bbrk in a grace sequence
-        s.linebrk = 0       # 1 if next measure should start with a line break
-        s.nextdecos = []    # decorations for the next note
-        s.prevmsre = None   # the previous measure
-        s.supports_tag = 0  # issue supports-tag in xml file when abc uses explicit linebreaks
-        s.staveDefs = []    # collected %%staves or %%score instructions from score
-        s.staves = []       # staves = [[voice names to be merged into one stave]]
-        s.groups = []       # list of merged part names with interspersed {[ and }]
-        s.grands = []       # [[vid1, vid2, ..], ...] voiceIds to be merged in a grand staff
-        s.gStaffNums = {}   # map each voice id in a grand staff to a staff number
-        s.gNstaves = {}     # map each voice id in a grand staff to total number of staves
-        s.pageFmtAbc = []   # formatting from abc directives
-        s.mdur = (4,4)      # duration of one measure
-        s.gtrans = 0        # octave transposition (by clef)
-        s.midprg = ['', '', '', ''] # MIDI channel nr, program nr, volume, panning for the current part
-        s.vid = ''          # abc voice id for the current voice
-        s.pid = ''          # xml part id for the current voice
-        s.gcue_on = 0       # insert <cue/> tag in each note
-        s.percVoice = 0     # 1 if percussion enabled
-        s.percMap = {}      # (part-id, abc_pitch, xml-octave) -> (abc staff step, midi note number, xml notehead)
-        s.pMapFound = 0     # at least one I:percmap has been found
-        s.vcepid = {}       # voice_id -> part_id
-        s.midiInst = {}     # inst_id -> (part_id, voice_id, channel, midi_number), remember instruments used
-        s.capo = 0          # fret position of the capodastro
-        s.tunmid = []       # midi numbers of strings
-        s.tunTup = []       # ordered midi numbers of strings [(midi_num, string_num), ...] (midi_num from high to low)
-        s.fOpt = fOpt       # force string/fret allocations for tab staves
-        s.orderChords = 0   # order notes in a chord
-        s.chordDecos = {}   # decos that should be distributed to all chord notes for xml
-        ch10 = 'acoustic-bass-drum,35;bass-drum-1,36;side-stick,37;acoustic-snare,38;hand-clap,39;electric-snare,40;low-floor-tom,41;closed-hi-hat,42;high-floor-tom,43;pedal-hi-hat,44;low-tom,45;open-hi-hat,46;low-mid-tom,47;hi-mid-tom,48;crash-cymbal-1,49;high-tom,50;ride-cymbal-1,51;chinese-cymbal,52;ride-bell,53;tambourine,54;splash-cymbal,55;cowbell,56;crash-cymbal-2,57;vibraslap,58;ride-cymbal-2,59;hi-bongo,60;low-bongo,61;mute-hi-conga,62;open-hi-conga,63;low-conga,64;high-timbale,65;low-timbale,66;high-agogo,67;low-agogo,68;cabasa,69;maracas,70;short-whistle,71;long-whistle,72;short-guiro,73;long-guiro,74;claves,75;hi-wood-block,76;low-wood-block,77;mute-cuica,78;open-cuica,79;mute-triangle,80;open-triangle,81'
-        s.percsnd = [x.split (',') for x in ch10.split (';')]   # {name -> midi number} of standard channel 10 sound names
-        s.gTime = (0,0)     # (XML begin time, XML end time) in divisions
-        s.tabStaff = ''     # == pid (part ID) for a tab staff
+    def __init__(s):
+        s.pageFmtCmd = []  # set by command line option -p
+        s.reset()
 
-    def mkPitch (s, acc, note, oct, lev):
-        if s.percVoice: # percussion map switched off by perc=off (see doClef)
-            octq = int (oct) + s.gtrans     # honour the octave= transposition when querying percmap
-            tup = s.percMap.get ((s.pid, acc+note, octq), s.percMap.get (('', acc+note, octq), 0))
-            if tup: step, soct, midi, notehead = tup
-            else: step, soct = note, octq
-            octnum = (4 if step.upper() == step else 5) + int (soct)
-            if not tup: # add percussion map for unmapped notes in this part
-                midi = str (octnum * 12 + [0,2,4,5,7,9,11]['CDEFGAB'.index (step.upper())] + {'^':1,'_':-1}.get (acc, 0) + 12)
-                notehead = {'^':'x', '_':'circle-x'}.get (acc, 'normal')
-                if s.pMapFound: info ('no I:percmap for: %s%s in part %s, voice %s' % (acc+note, -oct*',' if oct<0 else oct*"'", s.pid, s.vid))
-                s.percMap [(s.pid, acc+note, octq)] =  (note, octq, midi, notehead)
-            else:       # correct step value for clef
-                step, octnum = stepTrans (step.upper (), octnum, s.curClef)
-            pitch = E.Element ('unpitched')
-            addElemT (pitch, 'display-step', step.upper (), lev + 1)
-            addElemT (pitch, 'display-octave', str (octnum), lev + 1)
-            return pitch, '', midi, notehead
-        nUp = note.upper ()
-        octnum = (4 if nUp == note else 5) + int (oct) + s.gtrans
-        pitch = E.Element ('pitch')
-        addElemT (pitch, 'step', nUp, lev + 1)
-        alter = ''
+    def reset(s, fOpt=False):
+        s.divisions = (
+            2520  # xml duration of 1/4 note, 2^3 * 3^2 * 5 * 7 => 5,7,9 tuplets
+        )
+        s.ties = {}  # {abc pitch tuple -> alteration} for all open ties
+        s.slurstack = {}  # stack of open slur numbers per (overlay) voice
+        s.slurbeg = (
+            []
+        )  # type of slurs to start (when slurs are detected at element-level)
+        s.tmnum = 0  # time modification, numerator
+        s.tmden = 0  # time modification, denominator
+        s.ntup = 0  # number of tuplet notes remaining
+        s.trem = 0  # number of bars for tremolo
+        s.intrem = 0  # mark tremolo sequence (for duration doubling)
+        s.tupnts = (
+            []
+        )  # all tuplet modifiers with corresp. durations: [(duration, modifier), ...]
+        s.irrtup = 0  # 1 if an irregular tuplet
+        s.ntype = (
+            ""  # the normal-type of a tuplet (== duration type of a normal tuplet note)
+        )
+        s.unitL = (1, 8)  # default unit length
+        s.unitLcur = (1, 8)  # unit length of current voice
+        s.keyAlts = {}  # alterations implied by key
+        s.msreAlts = {}  # temporarily alterations
+        s.curVolta = ""  # open volta bracket
+        s.title = ""  # title of music
+        s.creator = {}  # {creator-type -> creator string}
+        s.metadata = {}  # {metadata-type -> string}
+        s.lyrdash = {}  # {lyric number -> 1 if dash between syllables}
+        s.usrSyms = s.uSyms  # user defined symbols
+        s.prevNote = None  # xml element of previous beamed note to correct beams (start, continue)
+        s.prevLyric = (
+            {}
+        )  # xml element of previous lyric to add/correct extend type (start, continue)
+        s.grcbbrk = False  # remember any bbrk in a grace sequence
+        s.linebrk = 0  # 1 if next measure should start with a line break
+        s.nextdecos = []  # decorations for the next note
+        s.prevmsre = None  # the previous measure
+        s.supports_tag = (
+            0  # issue supports-tag in xml file when abc uses explicit linebreaks
+        )
+        s.staveDefs = []  # collected %%staves or %%score instructions from score
+        s.staves = []  # staves = [[voice names to be merged into one stave]]
+        s.groups = []  # list of merged part names with interspersed {[ and }]
+        s.grands = []  # [[vid1, vid2, ..], ...] voiceIds to be merged in a grand staff
+        s.gStaffNums = {}  # map each voice id in a grand staff to a staff number
+        s.gNstaves = {}  # map each voice id in a grand staff to total number of staves
+        s.pageFmtAbc = []  # formatting from abc directives
+        s.mdur = (4, 4)  # duration of one measure
+        s.gtrans = 0  # octave transposition (by clef)
+        s.midprg = [
+            "",
+            "",
+            "",
+            "",
+        ]  # MIDI channel nr, program nr, volume, panning for the current part
+        s.vid = ""  # abc voice id for the current voice
+        s.pid = ""  # xml part id for the current voice
+        s.gcue_on = 0  # insert <cue/> tag in each note
+        s.percVoice = 0  # 1 if percussion enabled
+        s.percMap = (
+            {}
+        )  # (part-id, abc_pitch, xml-octave) -> (abc staff step, midi note number, xml notehead)
+        s.pMapFound = 0  # at least one I:percmap has been found
+        s.vcepid = {}  # voice_id -> part_id
+        s.midiInst = (
+            {}
+        )  # inst_id -> (part_id, voice_id, channel, midi_number), remember instruments used
+        s.capo = 0  # fret position of the capodastro
+        s.tunmid = []  # midi numbers of strings
+        s.tunTup = (
+            []
+        )  # ordered midi numbers of strings [(midi_num, string_num), ...] (midi_num from high to low)
+        s.fOpt = fOpt  # force string/fret allocations for tab staves
+        s.orderChords = 0  # order notes in a chord
+        s.chordDecos = {}  # decos that should be distributed to all chord notes for xml
+        ch10 = "acoustic-bass-drum,35;bass-drum-1,36;side-stick,37;acoustic-snare,38;hand-clap,39;electric-snare,40;low-floor-tom,41;closed-hi-hat,42;high-floor-tom,43;pedal-hi-hat,44;low-tom,45;open-hi-hat,46;low-mid-tom,47;hi-mid-tom,48;crash-cymbal-1,49;high-tom,50;ride-cymbal-1,51;chinese-cymbal,52;ride-bell,53;tambourine,54;splash-cymbal,55;cowbell,56;crash-cymbal-2,57;vibraslap,58;ride-cymbal-2,59;hi-bongo,60;low-bongo,61;mute-hi-conga,62;open-hi-conga,63;low-conga,64;high-timbale,65;low-timbale,66;high-agogo,67;low-agogo,68;cabasa,69;maracas,70;short-whistle,71;long-whistle,72;short-guiro,73;long-guiro,74;claves,75;hi-wood-block,76;low-wood-block,77;mute-cuica,78;open-cuica,79;mute-triangle,80;open-triangle,81"
+        s.percsnd = [
+            x.split(",") for x in ch10.split(";")
+        ]  # {name -> midi number} of standard channel 10 sound names
+        s.gTime = (0, 0)  # (XML begin time, XML end time) in divisions
+        s.tabStaff = ""  # == pid (part ID) for a tab staff
+
+    def mkPitch(s, acc, note, oct, lev):
+        if s.percVoice:  # percussion map switched off by perc=off (see doClef)
+            octq = (
+                int(oct) + s.gtrans
+            )  # honour the octave= transposition when querying percmap
+            tup = s.percMap.get(
+                (s.pid, acc + note, octq), s.percMap.get(("", acc + note, octq), 0)
+            )
+            if tup:
+                step, soct, midi, notehead = tup
+            else:
+                step, soct = note, octq
+            octnum = (4 if step.upper() == step else 5) + int(soct)
+            if not tup:  # add percussion map for unmapped notes in this part
+                midi = str(
+                    octnum * 12
+                    + [0, 2, 4, 5, 7, 9, 11]["CDEFGAB".index(step.upper())]
+                    + {"^": 1, "_": -1}.get(acc, 0)
+                    + 12
+                )
+                notehead = {"^": "x", "_": "circle-x"}.get(acc, "normal")
+                if s.pMapFound:
+                    info(
+                        "no I:percmap for: %s%s in part %s, voice %s"
+                        % (
+                            acc + note,
+                            -oct * "," if oct < 0 else oct * "'",
+                            s.pid,
+                            s.vid,
+                        )
+                    )
+                s.percMap[(s.pid, acc + note, octq)] = (note, octq, midi, notehead)
+            else:  # correct step value for clef
+                step, octnum = stepTrans(step.upper(), octnum, s.curClef)
+            pitch = E.Element("unpitched")
+            addElemT(pitch, "display-step", step.upper(), lev + 1)
+            addElemT(pitch, "display-octave", str(octnum), lev + 1)
+            return pitch, "", midi, notehead
+        nUp = note.upper()
+        octnum = (4 if nUp == note else 5) + int(oct) + s.gtrans
+        pitch = E.Element("pitch")
+        addElemT(pitch, "step", nUp, lev + 1)
+        alter = ""
         if (note, oct) in s.ties:
-            tied_alter, _, vnum, _ = s.ties [(note,oct)]            # vnum = overlay voice number when tie started
-            if vnum == s.overlayVnum: alter = tied_alter            # tied note in the same overlay -> same alteration
+            tied_alter, _, vnum, _ = s.ties[
+                (note, oct)
+            ]  # vnum = overlay voice number when tie started
+            if vnum == s.overlayVnum:
+                alter = tied_alter  # tied note in the same overlay -> same alteration
         elif acc:
-            s.msreAlts [(nUp, octnum)] = s.alterTab [acc]
-            alter = s.alterTab [acc]                                # explicit notated alteration
-        elif (nUp, octnum) in s.msreAlts:   alter = s.msreAlts [(nUp, octnum)]  # temporary alteration
-        elif nUp in s.keyAlts:              alter = s.keyAlts [nUp] # alteration implied by the key
-        if alter: addElemT (pitch, 'alter', alter, lev + 1)
-        addElemT (pitch, 'octave', str (octnum), lev + 1)
-        return pitch, alter, '', ''
+            s.msreAlts[(nUp, octnum)] = s.alterTab[acc]
+            alter = s.alterTab[acc]  # explicit notated alteration
+        elif (nUp, octnum) in s.msreAlts:
+            alter = s.msreAlts[(nUp, octnum)]  # temporary alteration
+        elif nUp in s.keyAlts:
+            alter = s.keyAlts[nUp]  # alteration implied by the key
+        if alter:
+            addElemT(pitch, "alter", alter, lev + 1)
+        addElemT(pitch, "octave", str(octnum), lev + 1)
+        return pitch, alter, "", ""
 
-    def getNoteDecos (s, n):
-        decos = s.nextdecos             # decorations encountered so far
-        ndeco = getattr (n, 'deco', 0)  # possible decorations of notes of a chord
-        if ndeco:                       # add decorations, translate used defined symbols
-            decos += [s.usrSyms.get (d, d).strip ('!+') for d in ndeco.t]
+    def getNoteDecos(s, n):
+        decos = s.nextdecos  # decorations encountered so far
+        ndeco = getattr(n, "deco", 0)  # possible decorations of notes of a chord
+        if ndeco:  # add decorations, translate used defined symbols
+            decos += [s.usrSyms.get(d, d).strip("!+") for d in ndeco.t]
         s.nextdecos = []
-        if s.tabStaff == s.pid and s.fOpt and n.name != 'rest':  # force fret/string allocation if explicit string decoration is missing
-            if [d for d in decos if d in '0123456789'] == []: decos.append ('0')
+        if (
+            s.tabStaff == s.pid and s.fOpt and n.name != "rest"
+        ):  # force fret/string allocation if explicit string decoration is missing
+            if [d for d in decos if d in "0123456789"] == []:
+                decos.append("0")
         return decos
 
-    def mkNote (s, n, lev):
-        isgrace = getattr (n, 'grace', '')
-        ischord = getattr (n, 'chord', '')
+    def mkNote(s, n, lev):
+        isgrace = getattr(n, "grace", "")
+        ischord = getattr(n, "chord", "")
         if s.ntup >= 0 and not isgrace and not ischord:
-            s.ntup -= 1                 # count tuplet notes only on non-chord, non grace notes
+            s.ntup -= 1  # count tuplet notes only on non-chord, non grace notes
             if s.ntup == -1 and s.trem <= 0:
-                s.intrem = 0            # tremolo pair ends at first note that is not a new tremolo pair (s.trem > 0)
-        nnum, nden = n.dur.t            # abc dutation of note
-        if s.intrem: nnum += nnum       # double duration of tremolo duplets
-        if nden == 0: nden = 1          # occurs with illegal ABC like: "A2 1". Now interpreted as A2/1
-        num, den = simplify (nnum * s.unitLcur[0], nden * s.unitLcur[1])  # normalised with unit length
-        if den > 64:    # limit denominator to 64
-            num = int (round (64 * float (num) / den))  # scale note to num/64
-            num, den  = simplify (max ([num, 1]), 64)   # smallest num == 1
-            info ('duration too small: rounded to %d/%d' % (num, den))
-        if n.name == 'rest' and ('Z' in n.t or 'X' in n.t):
-              num, den = s.mdur         # duration of one measure
-        noMsrRest = not (n.name == 'rest' and (num, den) == s.mdur) # not a measure rest
-        dvs = (4 * s.divisions * num) // den    # divisions is xml-duration of 1/4
-        rdvs = dvs                      # real duration (will be 0 for chord/grace)
-        num, den = simplify (num, den * 4)      # scale by 1/4 for s.typeMap
+                s.intrem = 0  # tremolo pair ends at first note that is not a new tremolo pair (s.trem > 0)
+        nnum, nden = n.dur.t  # abc dutation of note
+        if s.intrem:
+            nnum += nnum  # double duration of tremolo duplets
+        if nden == 0:
+            nden = 1  # occurs with illegal ABC like: "A2 1". Now interpreted as A2/1
+        num, den = simplify(
+            nnum * s.unitLcur[0], nden * s.unitLcur[1]
+        )  # normalised with unit length
+        if den > 64:  # limit denominator to 64
+            num = int(round(64 * float(num) / den))  # scale note to num/64
+            num, den = simplify(max([num, 1]), 64)  # smallest num == 1
+            info("duration too small: rounded to %d/%d" % (num, den))
+        if n.name == "rest" and ("Z" in n.t or "X" in n.t):
+            num, den = s.mdur  # duration of one measure
+        noMsrRest = not (
+            n.name == "rest" and (num, den) == s.mdur
+        )  # not a measure rest
+        dvs = (4 * s.divisions * num) // den  # divisions is xml-duration of 1/4
+        rdvs = dvs  # real duration (will be 0 for chord/grace)
+        num, den = simplify(num, den * 4)  # scale by 1/4 for s.typeMap
         ndot = 0
-        if num == 3 and noMsrRest: ndot = 1; den = den // 2 # look for dotted notes
-        if num == 7 and noMsrRest: ndot = 2; den = den // 4
-        nt = E.Element ('note')
-        if isgrace:                     # a grace note (and possibly a chord note)
-            grace = E.Element ('grace')
-            if s.acciatura: grace.set ('slash', 'yes'); s.acciatura = 0
-            addElem (nt, grace, lev + 1)
-            dvs = rdvs = 0              # no (real) duration for a grace note
-            if den <= 16: den = 32      # not longer than 1/8 for a grace note
-        if s.gcue_on:                   # insert cue tag
-            cue = E.Element ('cue')
-            addElem (nt, cue, lev + 1)
-        if ischord:                     # a chord note
-            chord = E.Element ('chord')
-            addElem (nt, chord, lev + 1)
-            rdvs = 0                    # chord notes no real duration
-        if den not in s.typeMap:        # take the nearest smaller legal duration
-            info ('illegal duration %d/%d' % (nnum, nden))
-            den = min (x for x in s.typeMap.keys () if x > den)
-        xmltype = str (s.typeMap [den]) # xml needs the note type in addition to duration
-        acc, step, oct = '', 'C', '0'   # abc-notated pitch elements (accidental, pitch step, octave)
-        alter, midi, notehead = '', '', ''      # xml alteration
-        if n.name == 'rest':
-            if 'x' in n.t or 'X' in n.t: nt.set ('print-object', 'no')
-            rest = E.Element ('rest')
-            if not noMsrRest: rest.set ('measure', 'yes')
-            addElem (nt, rest, lev + 1)
+        if num == 3 and noMsrRest:
+            ndot = 1
+            den = den // 2  # look for dotted notes
+        if num == 7 and noMsrRest:
+            ndot = 2
+            den = den // 4
+        nt = E.Element("note")
+        if isgrace:  # a grace note (and possibly a chord note)
+            grace = E.Element("grace")
+            if s.acciatura:
+                grace.set("slash", "yes")
+                s.acciatura = 0
+            addElem(nt, grace, lev + 1)
+            dvs = rdvs = 0  # no (real) duration for a grace note
+            if den <= 16:
+                den = 32  # not longer than 1/8 for a grace note
+        if s.gcue_on:  # insert cue tag
+            cue = E.Element("cue")
+            addElem(nt, cue, lev + 1)
+        if ischord:  # a chord note
+            chord = E.Element("chord")
+            addElem(nt, chord, lev + 1)
+            rdvs = 0  # chord notes no real duration
+        if den not in s.typeMap:  # take the nearest smaller legal duration
+            info("illegal duration %d/%d" % (nnum, nden))
+            den = min(x for x in s.typeMap.keys() if x > den)
+        xmltype = str(s.typeMap[den])  # xml needs the note type in addition to duration
+        acc, step, oct = (
+            "",
+            "C",
+            "0",
+        )  # abc-notated pitch elements (accidental, pitch step, octave)
+        alter, midi, notehead = "", "", ""  # xml alteration
+        if n.name == "rest":
+            if "x" in n.t or "X" in n.t:
+                nt.set("print-object", "no")
+            rest = E.Element("rest")
+            if not noMsrRest:
+                rest.set("measure", "yes")
+            addElem(nt, rest, lev + 1)
         else:
-            p = n.pitch.t           # get pitch elements from parsed tokens
-            if len (p) == 3:    acc, step, oct = p
-            else:               step, oct = p
-            pitch, alter, midi, notehead = s.mkPitch (acc, step, oct, lev + 1)
-            if midi: acc = ''       # erase accidental for percussion notes
-            addElem (nt, pitch, lev + 1)
-        if s.ntup >= 0:                 # modify duration for tuplet notes
+            p = n.pitch.t  # get pitch elements from parsed tokens
+            if len(p) == 3:
+                acc, step, oct = p
+            else:
+                step, oct = p
+            pitch, alter, midi, notehead = s.mkPitch(acc, step, oct, lev + 1)
+            if midi:
+                acc = ""  # erase accidental for percussion notes
+            addElem(nt, pitch, lev + 1)
+        if s.ntup >= 0:  # modify duration for tuplet notes
             dvs = dvs * s.tmden // s.tmnum
         if dvs:
-            addElemT (nt, 'duration', str (dvs), lev + 1)   # skip when dvs == 0, requirement of musicXML
-            if not ischord: s.gTime = s.gTime [1], s.gTime [1] + dvs
-        ptup = (step, oct)              # pitch tuple without alteration to check for ties
-        tstop = ptup in s.ties and s.ties[ptup][2] == s.overlayVnum  # open tie on this pitch tuple in this overlay
+            addElemT(
+                nt, "duration", str(dvs), lev + 1
+            )  # skip when dvs == 0, requirement of musicXML
+            if not ischord:
+                s.gTime = s.gTime[1], s.gTime[1] + dvs
+        ptup = (step, oct)  # pitch tuple without alteration to check for ties
+        tstop = (
+            ptup in s.ties and s.ties[ptup][2] == s.overlayVnum
+        )  # open tie on this pitch tuple in this overlay
         if tstop:
-            tie = E.Element ('tie', type='stop')
-            addElem (nt, tie, lev + 1)
-        if getattr (n, 'tie', 0):
-            tie = E.Element ('tie', type='start')
-            addElem (nt, tie, lev + 1)
-        if (s.midprg != ['', '', '', ''] or midi) and n.name != 'rest': # only add when %%midi was present or percussion
-            instId = 'I%s-%s' % (s.pid, 'X' + midi if midi else s.vid)
-            chan, midi = ('10', midi) if midi else s.midprg [:2]
-            inst = E.Element ('instrument', id=instId)  # instrument id for midi
-            addElem (nt, inst, lev + 1)
-            if instId not in s.midiInst: s.midiInst [instId] = (s.pid, s.vid, chan, midi, s.midprg [2], s.midprg [3]) # for instrument list in mkScorePart
-        addElemT (nt, 'voice', '1', lev + 1)    # default voice, for merging later
-        if noMsrRest: addElemT (nt, 'type', xmltype, lev + 1) # add note type if not a measure rest
-        for i in range (ndot):          # add dots
-            dot = E.Element ('dot')
-            addElem (nt, dot, lev + 1)
-        decos = s.getNoteDecos (n)      # get decorations for this note
-        if acc and not tstop:           # only add accidental if note not tied
-            e = E.Element ('accidental')
-            if 'courtesy' in decos:
-                e.set ('parentheses', 'yes')
-                decos.remove ('courtesy')
-            e.text = s.accTab [acc]
-            addElem (nt, e, lev + 1)
-        tupnotation = ''                # start/stop notation element for tuplets
-        if s.ntup >= 0:                 # add time modification element for tuplet notes
-            tmod = mkTmod (s.tmnum, s.tmden, lev + 1)
-            addElem (nt, tmod, lev + 1)
-            if s.ntup > 0 and not s.tupnts: tupnotation = 'start'
-            s.tupnts.append ((rdvs, tmod))      # remember all tuplet modifiers with corresp. durations
-            if s.ntup == 0:             # last tuplet note (and possible chord notes there after)
-                if rdvs: tupnotation = 'stop'   # only insert notation in the real note (rdvs > 0)
-                s.cmpNormType (rdvs, lev + 1)   # compute and/or add normal-type elements (-> s.ntype)
+            tie = E.Element("tie", type="stop")
+            addElem(nt, tie, lev + 1)
+        if getattr(n, "tie", 0):
+            tie = E.Element("tie", type="start")
+            addElem(nt, tie, lev + 1)
+        if (
+            s.midprg != ["", "", "", ""] or midi
+        ) and n.name != "rest":  # only add when %%midi was present or percussion
+            instId = "I%s-%s" % (s.pid, "X" + midi if midi else s.vid)
+            chan, midi = ("10", midi) if midi else s.midprg[:2]
+            inst = E.Element("instrument", id=instId)  # instrument id for midi
+            addElem(nt, inst, lev + 1)
+            if instId not in s.midiInst:
+                s.midiInst[instId] = (
+                    s.pid,
+                    s.vid,
+                    chan,
+                    midi,
+                    s.midprg[2],
+                    s.midprg[3],
+                )  # for instrument list in mkScorePart
+        addElemT(nt, "voice", "1", lev + 1)  # default voice, for merging later
+        if noMsrRest:
+            addElemT(
+                nt, "type", xmltype, lev + 1
+            )  # add note type if not a measure rest
+        for i in range(ndot):  # add dots
+            dot = E.Element("dot")
+            addElem(nt, dot, lev + 1)
+        decos = s.getNoteDecos(n)  # get decorations for this note
+        if acc and not tstop:  # only add accidental if note not tied
+            e = E.Element("accidental")
+            if "courtesy" in decos:
+                e.set("parentheses", "yes")
+                decos.remove("courtesy")
+            e.text = s.accTab[acc]
+            addElem(nt, e, lev + 1)
+        tupnotation = ""  # start/stop notation element for tuplets
+        if s.ntup >= 0:  # add time modification element for tuplet notes
+            tmod = mkTmod(s.tmnum, s.tmden, lev + 1)
+            addElem(nt, tmod, lev + 1)
+            if s.ntup > 0 and not s.tupnts:
+                tupnotation = "start"
+            s.tupnts.append(
+                (rdvs, tmod)
+            )  # remember all tuplet modifiers with corresp. durations
+            if s.ntup == 0:  # last tuplet note (and possible chord notes there after)
+                if rdvs:
+                    tupnotation = (
+                        "stop"  # only insert notation in the real note (rdvs > 0)
+                    )
+                s.cmpNormType(
+                    rdvs, lev + 1
+                )  # compute and/or add normal-type elements (-> s.ntype)
         hasStem = 1
-        if not ischord: s.chordDecos = {}       # clear on non chord note
-        if 'stemless' in decos or (s.nostems and n.name != 'rest') or 'stemless' in s.chordDecos:
+        if not ischord:
+            s.chordDecos = {}  # clear on non chord note
+        if (
+            "stemless" in decos
+            or (s.nostems and n.name != "rest")
+            or "stemless" in s.chordDecos
+        ):
             hasStem = 0
-            addElemT (nt, 'stem', 'none', lev + 1)
-            if 'stemless' in decos: decos.remove ('stemless')   # do not handle in doNotations
-            if hasattr (n, 'pitches'): s.chordDecos ['stemless'] = 1    # set on first chord note
+            addElemT(nt, "stem", "none", lev + 1)
+            if "stemless" in decos:
+                decos.remove("stemless")  # do not handle in doNotations
+            if hasattr(n, "pitches"):
+                s.chordDecos["stemless"] = 1  # set on first chord note
         if notehead:
-            nh = addElemT (nt, 'notehead', re.sub (r'[+-]$', '', notehead), lev + 1)
-            if notehead[-1] in '+-': nh.set ('filled', 'yes' if notehead[-1] == '+' else 'no')
-        gstaff = s.gStaffNums.get (s.vid, 0)    # staff number of the current voice
-        if gstaff: addElemT (nt, 'staff', str (gstaff), lev + 1)
-        if hasStem: s.doBeams (n, nt, den, lev + 1)   # no stems -> no beams in a tab staff
-        s.doNotations (n, decos, ptup, alter, tupnotation, tstop, nt, lev + 1)
-        if n.objs: s.doLyr (n, nt, lev + 1)
-        else: s.prevLyric = {}   # clear on note without lyrics
+            nh = addElemT(nt, "notehead", re.sub(r"[+-]$", "", notehead), lev + 1)
+            if notehead[-1] in "+-":
+                nh.set("filled", "yes" if notehead[-1] == "+" else "no")
+        gstaff = s.gStaffNums.get(s.vid, 0)  # staff number of the current voice
+        if gstaff:
+            addElemT(nt, "staff", str(gstaff), lev + 1)
+        if hasStem:
+            s.doBeams(n, nt, den, lev + 1)  # no stems -> no beams in a tab staff
+        s.doNotations(n, decos, ptup, alter, tupnotation, tstop, nt, lev + 1)
+        if n.objs:
+            s.doLyr(n, nt, lev + 1)
+        else:
+            s.prevLyric = {}  # clear on note without lyrics
         return nt
 
-    def cmpNormType (s, rdvs, lev): # compute the normal-type of a tuplet (only needed for Finale)
-        if rdvs:    # the last real tuplet note (chord notes can still follow afterwards with rdvs == 0)
+    def cmpNormType(
+        s, rdvs, lev
+    ):  # compute the normal-type of a tuplet (only needed for Finale)
+        if (
+            rdvs
+        ):  # the last real tuplet note (chord notes can still follow afterwards with rdvs == 0)
             durs = [dur for dur, tmod in s.tupnts if dur > 0]
-            ndur = sum (durs) // s.tmnum    # duration of the normal type
-            s.irrtup = any ((dur != ndur) for dur in durs)  # irregular tuplet
+            ndur = sum(durs) // s.tmnum  # duration of the normal type
+            s.irrtup = any((dur != ndur) for dur in durs)  # irregular tuplet
             tix = 16 * s.divisions // ndur  # index in typeMap of normal-type duration
             if tix in s.typeMap:
-                s.ntype = str (s.typeMap [tix]) # the normal-type
-            else: s.irrtup = 0          # give up, no normal type possible
-        if s.irrtup:                    # only add normal-type for irregular tuplets
+                s.ntype = str(s.typeMap[tix])  # the normal-type
+            else:
+                s.irrtup = 0  # give up, no normal type possible
+        if s.irrtup:  # only add normal-type for irregular tuplets
             for dur, tmod in s.tupnts:  # add normal-type to all modifiers
-                addElemT (tmod, 'normal-type', s.ntype, lev + 1)
-        s.tupnts = []                   # reset the tuplet buffer
+                addElemT(tmod, "normal-type", s.ntype, lev + 1)
+        s.tupnts = []  # reset the tuplet buffer
 
-    def doNotations (s, n, decos, ptup, alter, tupnotation, tstop, nt, lev):
-        slurs = getattr (n, 'slurs', 0) # slur ends
-        pts = getattr (n, 'pitches', [])            # all chord notes available in the first note
-        ov = s.overlayVnum                          # current overlay voice number (0 for the main voice)
-        if pts:                                     # make list of pitches in chord: [(pitch, octave), ..]
-            if type (pts.pitch) == pObj: pts = [pts.pitch]      # chord with one note
-            else: pts = [tuple (p.t[-2:]) for p in pts.pitch]   # normal chord
-        for pt, (tie_alter, nts, vnum, ntelm) in sorted (list (s.ties.items ())):  # scan all open ties and delete illegal ones
-            if vnum != s.overlayVnum: continue      # tie belongs to different overlay
-            if pts and pt in pts: continue          # pitch tuple of tie exists in chord
-            if getattr (n, 'chord', 0): continue    # skip chord notes
-            if pt == ptup: continue                 # skip correct single note tie
-            if getattr (n, 'grace', 0): continue    # skip grace notes
-            info ('tie between different pitches: %s%s converted to slur' % pt)
-            del s.ties [pt]                         # remove the note from pending ties
-            e = [t for t in ntelm.findall ('tie') if t.get ('type') == 'start'][0]  # get the tie start element
-            ntelm.remove (e)                        # delete start tie element
-            e = [t for t in nts.findall ('tied') if t.get ('type') == 'start'][0]   # get the tied start element
-            e.tag = 'slur'                          # convert tie into slur
-            slurnum = pushSlur (s.slurstack, ov)
-            e.set ('number', str (slurnum))
-            if slurs: slurs.t.append (')')          # close slur on this note
-            else: slurs = pObj ('slurs', [')'])
-        tstart = getattr (n, 'tie', 0)  # start a new tie
-        if not (tstop or tstart or decos or slurs or s.slurbeg or tupnotation or s.trem): return nt
-        nots = E.Element ('notations')  # notation element needed
+    def doNotations(s, n, decos, ptup, alter, tupnotation, tstop, nt, lev):
+        slurs = getattr(n, "slurs", 0)  # slur ends
+        pts = getattr(n, "pitches", [])  # all chord notes available in the first note
+        ov = s.overlayVnum  # current overlay voice number (0 for the main voice)
+        if pts:  # make list of pitches in chord: [(pitch, octave), ..]
+            if isinstance(pts.pitch, pObj):
+                pts = [pts.pitch]  # chord with one note
+            else:
+                pts = [tuple(p.t[-2:]) for p in pts.pitch]  # normal chord
+        for pt, (tie_alter, nts, vnum, ntelm) in sorted(
+            list(s.ties.items())
+        ):  # scan all open ties and delete illegal ones
+            if vnum != s.overlayVnum:
+                continue  # tie belongs to different overlay
+            if pts and pt in pts:
+                continue  # pitch tuple of tie exists in chord
+            if getattr(n, "chord", 0):
+                continue  # skip chord notes
+            if pt == ptup:
+                continue  # skip correct single note tie
+            if getattr(n, "grace", 0):
+                continue  # skip grace notes
+            info("tie between different pitches: %s%s converted to slur" % pt)
+            del s.ties[pt]  # remove the note from pending ties
+            e = [t for t in ntelm.findall("tie") if t.get("type") == "start"][
+                0
+            ]  # get the tie start element
+            ntelm.remove(e)  # delete start tie element
+            e = [t for t in nts.findall("tied") if t.get("type") == "start"][
+                0
+            ]  # get the tied start element
+            e.tag = "slur"  # convert tie into slur
+            slurnum = pushSlur(s.slurstack, ov)
+            e.set("number", str(slurnum))
+            if slurs:
+                slurs.t.append(")")  # close slur on this note
+            else:
+                slurs = pObj("slurs", [")"])
+        tstart = getattr(n, "tie", 0)  # start a new tie
+        if not (
+            tstop or tstart or decos or slurs or s.slurbeg or tupnotation or s.trem
+        ):
+            return nt
+        nots = E.Element("notations")  # notation element needed
         if s.trem:  # +/- => tuple tremolo sequence / single note tremolo
-            if s.trem < 0: tupnotation = 'single'; s.trem = -s.trem
-            if not tupnotation: return  # only add notation at first or last note of a tremolo sequence
-            orn = E.Element ('ornaments')
-            trm = E.Element ('tremolo', type=tupnotation)   # type = start, stop or single
-            trm.text = str (s.trem)     # the number of bars in a tremolo note
-            addElem (nots, orn, lev + 1)
-            addElem (orn, trm, lev + 2)
-            if tupnotation == 'stop' or tupnotation == 'single': s.trem = 0
-        elif tupnotation:       # add tuplet type
-            tup = E.Element ('tuplet', type=tupnotation)
-            if tupnotation == 'start': tup.set ('bracket', 'yes')
-            addElem (nots, tup, lev + 1)
-        if tstop:               # stop tie
-            del s.ties[ptup]    # remove flag
-            tie = E.Element ('tied', type='stop')
-            addElem (nots, tie, lev + 1)
-        if tstart:              # start a tie
-            s.ties[ptup] = (alter, nots, s.overlayVnum, nt) # remember pitch tuple to stop tie and apply same alteration
-            tie = E.Element ('tied', type='start')
-            if tstart.t[0] == '.-': tie.set ('line-type', 'dotted')
-            addElem (nots, tie, lev + 1)
-        if decos:               # look for slurs and decorations
-            slurMap = { '(':1, '.(':1, '(,':1, "('":1, '.(,':1, ".('":1 }
-            arts = []           # collect articulations
-            for d in decos:     # do all slurs and decos
-                if d in slurMap: s.slurbeg.append (d); continue # slurs made in while loop at the end
-                elif d == 'fermata' or d == 'H':
-                    ntn = E.Element ('fermata', type='upright')
-                elif d == 'arpeggio':
-                    ntn = E.Element ('arpeggiate', number='1')
-                elif d in ['~(', '~)']:
-                    if d[1] == '(': tp = 'start'; s.glisnum += 1; gn = s.glisnum
-                    else:           tp = 'stop'; gn = s.glisnum; s.glisnum -= 1
-                    if s.glisnum < 0: s.glisnum = 0; continue   # stop without previous start
-                    ntn = E.Element ('glissando', {'line-type':'wavy', 'number':'%d' % gn, 'type':tp})
-                elif d in ['-(', '-)']:
-                    if d[1] == '(': tp = 'start'; s.slidenum += 1; gn = s.slidenum
-                    else:           tp = 'stop'; gn = s.slidenum; s.slidenum -= 1
-                    if s.slidenum < 0: s.slidenum = 0; continue   # stop without previous start
-                    ntn = E.Element ('slide', {'line-type':'solid', 'number':'%d' % gn, 'type':tp})
-                else: arts.append (d); continue
-                addElem (nots, ntn, lev + 1)
-            if arts:        # do only note articulations and collect staff annotations in xmldecos
-                rest = s.doArticulations (nt, nots, arts, lev + 1)
-                if rest: info ('unhandled note decorations: %s' % rest)
-        if slurs:           # these are only slur endings
-            for d in slurs.t:           # slurs to be closed on this note
-                if not s.slurstack.get (ov, 0): break    # no more open old slurs for this (overlay) voice
-                slurnum = s.slurstack [ov].pop ()
-                slur = E.Element ('slur', number='%d' % slurnum, type='stop')
-                addElem (nots, slur, lev + 1)
-        while s.slurbeg:    # create slurs beginning on this note
-            stp = s.slurbeg.pop (0)
-            slurnum = pushSlur (s.slurstack, ov)
-            ntn = E.Element ('slur', number='%d' % slurnum, type='start')
-            if '.' in stp: ntn.set ('line-type', 'dotted')
-            if ',' in stp: ntn.set ('placement', 'below')
-            if "'" in stp: ntn.set ('placement', 'above')
-            addElem (nots, ntn, lev + 1)            
-        if list (nots) != []:    # only add notations if not empty
-            addElem (nt, nots, lev)
+            if s.trem < 0:
+                tupnotation = "single"
+                s.trem = -s.trem
+            if not tupnotation:
+                return  # only add notation at first or last note of a tremolo sequence
+            orn = E.Element("ornaments")
+            trm = E.Element("tremolo", type=tupnotation)  # type = start, stop or single
+            trm.text = str(s.trem)  # the number of bars in a tremolo note
+            addElem(nots, orn, lev + 1)
+            addElem(orn, trm, lev + 2)
+            if tupnotation == "stop" or tupnotation == "single":
+                s.trem = 0
+        elif tupnotation:  # add tuplet type
+            tup = E.Element("tuplet", type=tupnotation)
+            if tupnotation == "start":
+                tup.set("bracket", "yes")
+            addElem(nots, tup, lev + 1)
+        if tstop:  # stop tie
+            del s.ties[ptup]  # remove flag
+            tie = E.Element("tied", type="stop")
+            addElem(nots, tie, lev + 1)
+        if tstart:  # start a tie
+            s.ties[ptup] = (
+                alter,
+                nots,
+                s.overlayVnum,
+                nt,
+            )  # remember pitch tuple to stop tie and apply same alteration
+            tie = E.Element("tied", type="start")
+            if tstart.t[0] == ".-":
+                tie.set("line-type", "dotted")
+            addElem(nots, tie, lev + 1)
+        if decos:  # look for slurs and decorations
+            slurMap = {"(": 1, ".(": 1, "(,": 1, "('": 1, ".(,": 1, ".('": 1}
+            arts = []  # collect articulations
+            for d in decos:  # do all slurs and decos
+                if d in slurMap:
+                    s.slurbeg.append(d)
+                    continue  # slurs made in while loop at the end
+                elif d == "fermata" or d == "H":
+                    ntn = E.Element("fermata", type="upright")
+                elif d == "arpeggio":
+                    ntn = E.Element("arpeggiate", number="1")
+                elif d in ["~(", "~)"]:
+                    if d[1] == "(":
+                        tp = "start"
+                        s.glisnum += 1
+                        gn = s.glisnum
+                    else:
+                        tp = "stop"
+                        gn = s.glisnum
+                        s.glisnum -= 1
+                    if s.glisnum < 0:
+                        s.glisnum = 0
+                        continue  # stop without previous start
+                    ntn = E.Element(
+                        "glissando",
+                        {"line-type": "wavy", "number": "%d" % gn, "type": tp},
+                    )
+                elif d in ["-(", "-)"]:
+                    if d[1] == "(":
+                        tp = "start"
+                        s.slidenum += 1
+                        gn = s.slidenum
+                    else:
+                        tp = "stop"
+                        gn = s.slidenum
+                        s.slidenum -= 1
+                    if s.slidenum < 0:
+                        s.slidenum = 0
+                        continue  # stop without previous start
+                    ntn = E.Element(
+                        "slide", {"line-type": "solid", "number": "%d" % gn, "type": tp}
+                    )
+                else:
+                    arts.append(d)
+                    continue
+                addElem(nots, ntn, lev + 1)
+            if (
+                arts
+            ):  # do only note articulations and collect staff annotations in xmldecos
+                rest = s.doArticulations(nt, nots, arts, lev + 1)
+                if rest:
+                    info("unhandled note decorations: %s" % rest)
+        if slurs:  # these are only slur endings
+            for d in slurs.t:  # slurs to be closed on this note
+                if not s.slurstack.get(ov, 0):
+                    break  # no more open old slurs for this (overlay) voice
+                slurnum = s.slurstack[ov].pop()
+                slur = E.Element("slur", number="%d" % slurnum, type="stop")
+                addElem(nots, slur, lev + 1)
+        while s.slurbeg:  # create slurs beginning on this note
+            stp = s.slurbeg.pop(0)
+            slurnum = pushSlur(s.slurstack, ov)
+            ntn = E.Element("slur", number="%d" % slurnum, type="start")
+            if "." in stp:
+                ntn.set("line-type", "dotted")
+            if "," in stp:
+                ntn.set("placement", "below")
+            if "'" in stp:
+                ntn.set("placement", "above")
+            addElem(nots, ntn, lev + 1)
+        if list(nots) != []:  # only add notations if not empty
+            addElem(nt, nots, lev)
 
-    def doArticulations (s, nt, nots, arts, lev):
+    def doArticulations(s, nt, nots, arts, lev):
         decos = []
         for a in arts:
             if a in s.artMap:
-                art = E.Element ('articulations')
-                addElem (nots, art, lev)
-                addElem (art, E.Element (s.artMap[a]), lev + 1)
+                art = E.Element("articulations")
+                addElem(nots, art, lev)
+                addElem(art, E.Element(s.artMap[a]), lev + 1)
             elif a in s.ornMap:
-                orn = E.Element ('ornaments')
-                addElem (nots, orn, lev)
-                addElem (orn, E.Element (s.ornMap[a]), lev + 1)
-            elif a in ['trill(','trill)']:
-                orn = E.Element ('ornaments')
-                addElem (nots, orn, lev)
-                type = 'start' if a.endswith ('(') else 'stop'
-                if type == 'start': addElem (orn, E.Element ('trill-mark'), lev + 1)                
-                addElem (orn, E.Element ('wavy-line', type=type), lev + 1)                
+                orn = E.Element("ornaments")
+                addElem(nots, orn, lev)
+                addElem(orn, E.Element(s.ornMap[a]), lev + 1)
+            elif a in ["trill(", "trill)"]:
+                orn = E.Element("ornaments")
+                addElem(nots, orn, lev)
+                type = "start" if a.endswith("(") else "stop"
+                if type == "start":
+                    addElem(orn, E.Element("trill-mark"), lev + 1)
+                addElem(orn, E.Element("wavy-line", type=type), lev + 1)
             elif a in s.tecMap:
-                tec = E.Element ('technical')
-                addElem (nots, tec, lev)
-                addElem (tec, E.Element (s.tecMap[a]), lev + 1)
-            elif a in '0123456':
-                tec = E.Element ('technical')
-                addElem (nots, tec, lev)
-                if s.tabStaff == s.pid:             # current voice belongs to a tabStaff
-                    alt = int (nt.findtext ('pitch/alter') or 0)    # find midi number of current note
-                    step = nt.findtext ('pitch/step')
-                    oct = int (nt.findtext ('pitch/octave'))
-                    midi = oct * 12 + [0,2,4,5,7,9,11]['CDEFGAB'.index (step)] + alt + 12
-                    if a == '0':                    # no string annotation: find one
-                        firstFit = ''
-                        for smid, istr in s.tunTup: # midi numbers of open strings from high to low
-                            if midi >= smid:        # highest open string where this note can be played
-                                isvrij = s.strAlloc.isVrij (istr - 1, s.gTime [0], s.gTime [1])
-                                a = str (istr)      # string number
-                                if not firstFit: firstFit = a
-                                if isvrij: break
-                        if not isvrij:              # no free string, take the first fit (lowest fret)
+                tec = E.Element("technical")
+                addElem(nots, tec, lev)
+                addElem(tec, E.Element(s.tecMap[a]), lev + 1)
+            elif a in "0123456":
+                tec = E.Element("technical")
+                addElem(nots, tec, lev)
+                if s.tabStaff == s.pid:  # current voice belongs to a tabStaff
+                    alt = int(
+                        nt.findtext("pitch/alter") or 0
+                    )  # find midi number of current note
+                    step = nt.findtext("pitch/step")
+                    oct = int(nt.findtext("pitch/octave"))
+                    midi = (
+                        oct * 12
+                        + [0, 2, 4, 5, 7, 9, 11]["CDEFGAB".index(step)]
+                        + alt
+                        + 12
+                    )
+                    if a == "0":  # no string annotation: find one
+                        firstFit = ""
+                        for (
+                            smid,
+                            istr,
+                        ) in s.tunTup:  # midi numbers of open strings from high to low
+                            if (
+                                midi >= smid
+                            ):  # highest open string where this note can be played
+                                isvrij = s.strAlloc.isVrij(
+                                    istr - 1, s.gTime[0], s.gTime[1]
+                                )
+                                a = str(istr)  # string number
+                                if not firstFit:
+                                    firstFit = a
+                                if isvrij:
+                                    break
+                        if (
+                            not isvrij
+                        ):  # no free string, take the first fit (lowest fret)
                             a = firstFit
-                            s.strAlloc.bezet (int (a) - 1, s.gTime [0], s.gTime [1])
-                    else:                           # force annotated string number 
-                        s.strAlloc.bezet (int (a) - 1, s.gTime [0], s.gTime [1])
-                    bmidi = s.tunmid [int (a) - 1]  # midi number of allocated string (with capodastro)
-                    fret =  midi - bmidi            # fret position (respecting capodastro)
+                            s.strAlloc.bezet(int(a) - 1, s.gTime[0], s.gTime[1])
+                    else:  # force annotated string number
+                        s.strAlloc.bezet(int(a) - 1, s.gTime[0], s.gTime[1])
+                    bmidi = s.tunmid[
+                        int(a) - 1
+                    ]  # midi number of allocated string (with capodastro)
+                    fret = midi - bmidi  # fret position (respecting capodastro)
                     if fret < 25 and fret >= 0:
-                        addElemT (tec, 'fret', str (fret), lev + 1)
+                        addElemT(tec, "fret", str(fret), lev + 1)
                     else:
-                        altp = 'b' if alt == -1 else '#' if alt == 1 else ''
-                        info ('fret %d out of range, note %s%d on string %s' % (fret, step+altp, oct, a))
-                    addElemT (tec, 'string', a, lev + 1)
+                        altp = "b" if alt == -1 else "#" if alt == 1 else ""
+                        info(
+                            "fret %d out of range, note %s%d on string %s"
+                            % (fret, step + altp, oct, a)
+                        )
+                    addElemT(tec, "string", a, lev + 1)
                 else:
-                    addElemT (tec, 'fingering', a, lev + 1)
-            else: decos.append (a)  # return staff annotations
+                    addElemT(tec, "fingering", a, lev + 1)
+            else:
+                decos.append(a)  # return staff annotations
         return decos
 
-    def doLyr (s, n, nt, lev):
-        for i, lyrobj in enumerate (n.objs):
-            lyrel = E.Element ('lyric', number = str (i + 1))
-            if lyrobj.name == 'syl':
-                dash = len (lyrobj.t) == 2
+    def doLyr(s, n, nt, lev):
+        for i, lyrobj in enumerate(n.objs):
+            lyrel = E.Element("lyric", number=str(i + 1))
+            if lyrobj.name == "syl":
+                dash = len(lyrobj.t) == 2
                 if dash:
-                    if i in s.lyrdash:  type = 'middle'
-                    else:               type = 'begin'; s.lyrdash [i] = 1
+                    if i in s.lyrdash:
+                        type = "middle"
+                    else:
+                        type = "begin"
+                        s.lyrdash[i] = 1
                 else:
-                    if i in s.lyrdash:  type = 'end';   del s.lyrdash [i]
-                    else:               type = 'single'
-                addElemT (lyrel, 'syllabic', type, lev + 1)
-                txt = lyrobj.t[0]                       # the syllabe
-                txt = re.sub (r'(?<!\\)~', ' ', txt)    # replace ~ by space when not escaped (preceded by \)
-                txt = re.sub (r'\\(.)', r'\1', txt)     # replace all escaped characters by themselves (for the time being)
-                addElemT (lyrel, 'text', txt, lev + 1)
-            elif lyrobj.name == 'ext' and i in s.prevLyric:
-                pext = s.prevLyric [i].find ('extend')  # identify previous extend
-                if pext == None:
-                    ext = E.Element ('extend', type = 'start')
-                    addElem (s.prevLyric [i], ext, lev + 1)
-                elif pext.get('type') == 'stop':        # subsequent extend: stop -> continue
-                    pext.set ('type', 'continue')
-                ext = E.Element ('extend', type = 'stop')   # always stop on current extend
-                addElem (lyrel, ext, lev + 1)
-            elif lyrobj.name == 'ext': info ('lyric extend error'); continue
-            else: continue          # skip other lyric elements or errors
-            addElem (nt, lyrel, lev)
-            s.prevLyric [i] = lyrel # for extension (melisma) on the next note
+                    if i in s.lyrdash:
+                        type = "end"
+                        del s.lyrdash[i]
+                    else:
+                        type = "single"
+                addElemT(lyrel, "syllabic", type, lev + 1)
+                txt = lyrobj.t[0]  # the syllabe
+                txt = re.sub(
+                    r"(?<!\\)~", " ", txt
+                )  # replace ~ by space when not escaped (preceded by \)
+                txt = re.sub(
+                    r"\\(.)", r"\1", txt
+                )  # replace all escaped characters by themselves (for the time being)
+                addElemT(lyrel, "text", txt, lev + 1)
+            elif lyrobj.name == "ext" and i in s.prevLyric:
+                pext = s.prevLyric[i].find("extend")  # identify previous extend
+                if pext is None:
+                    ext = E.Element("extend", type="start")
+                    addElem(s.prevLyric[i], ext, lev + 1)
+                elif pext.get("type") == "stop":  # subsequent extend: stop -> continue
+                    pext.set("type", "continue")
+                ext = E.Element("extend", type="stop")  # always stop on current extend
+                addElem(lyrel, ext, lev + 1)
+            elif lyrobj.name == "ext":
+                info("lyric extend error")
+                continue
+            else:
+                continue  # skip other lyric elements or errors
+            addElem(nt, lyrel, lev)
+            s.prevLyric[i] = lyrel  # for extension (melisma) on the next note
 
-    def doBeams (s, n, nt, den, lev):
-        if hasattr (n, 'chord') or hasattr (n, 'grace'):
-            s.grcbbrk = s.grcbbrk or n.bbrk.t[0]    # remember if there was any bbrk in or before a grace sequence
+    def doBeams(s, n, nt, den, lev):
+        if hasattr(n, "chord") or hasattr(n, "grace"):
+            s.grcbbrk = (
+                s.grcbbrk or n.bbrk.t[0]
+            )  # remember if there was any bbrk in or before a grace sequence
             return
         bbrk = s.grcbbrk or n.bbrk.t[0] or den < 32
         s.grcbbrk = False
-        if not s.prevNote:  pbm = None
-        else:               pbm = s.prevNote.find ('beam')
-        bm = E.Element ('beam', number='1')
-        bm.text = 'begin'
-        if pbm != None:
+        if not s.prevNote:
+            pbm = None
+        else:
+            pbm = s.prevNote.find("beam")
+        bm = E.Element("beam", number="1")
+        bm.text = "begin"
+        if pbm is not None:
             if bbrk:
-                if pbm.text == 'begin':
-                    s.prevNote.remove (pbm)
-                elif pbm.text == 'continue':
-                    pbm.text = 'end'
+                if pbm.text == "begin":
+                    s.prevNote.remove(pbm)
+                elif pbm.text == "continue":
+                    pbm.text = "end"
                 s.prevNote = None
-            else: bm.text = 'continue'
-        if den >= 32 and n.name != 'rest':
-            addElem (nt, bm, lev)
+            else:
+                bm.text = "continue"
+        if den >= 32 and n.name != "rest":
+            addElem(nt, bm, lev)
             s.prevNote = nt
 
-    def stopBeams (s):
-        if not s.prevNote: return
-        pbm = s.prevNote.find ('beam')
-        if pbm != None:
-            if pbm.text == 'begin':
-                s.prevNote.remove (pbm)
-            elif pbm.text == 'continue':
-                pbm.text = 'end'
+    def stopBeams(s):
+        if not s.prevNote:
+            return
+        pbm = s.prevNote.find("beam")
+        if pbm is not None:
+            if pbm.text == "begin":
+                s.prevNote.remove(pbm)
+            elif pbm.text == "continue":
+                pbm.text = "end"
         s.prevNote = None
 
-    def staffDecos (s, decos, maat, lev):
-        gstaff = s.gStaffNums.get (s.vid, 0)        # staff number of the current voice        
+    def staffDecos(s, decos, maat, lev):
+        gstaff = s.gStaffNums.get(s.vid, 0)  # staff number of the current voice
         for d in decos:
-            d = s.usrSyms.get (d, d).strip ('!+')   # try to replace user defined symbol
+            d = s.usrSyms.get(d, d).strip("!+")  # try to replace user defined symbol
             if d in s.dynaMap:
-                dynel = E.Element ('dynamics')
-                addDirection (maat, dynel, lev, gstaff, [E.Element (d)], 'below', s.gcue_on)
+                dynel = E.Element("dynamics")
+                addDirection(
+                    maat, dynel, lev, gstaff, [E.Element(d)], "below", s.gcue_on
+                )
             elif d in s.wedgeMap:  # wedge
-                if ')' in d: type = 'stop'
-                else: type = 'crescendo' if '<' in d or 'crescendo' in d else 'diminuendo'
-                addDirection (maat, E.Element ('wedge', type=type), lev, gstaff)
-            elif d.startswith ('8v'):
-                if 'a' in d: type, plce = 'down', 'above'
-                else:        type, plce = 'up', 'below'
-                if ')' in d: type = 'stop'
-                addDirection (maat, E.Element ('octave-shift', type=type, size='8'), lev, gstaff, placement=plce)
-            elif d in (['ped','ped-up']):
-                type = 'stop' if d.endswith ('up') else 'start'
-                addDirection (maat, E.Element ('pedal', type=type), lev, gstaff)
-            elif d in ['coda', 'segno']:
-                text, attr, val = s.capoMap [d]
-                dir = addDirection (maat, E.Element (text), lev, gstaff, placement='above')
-                sound = E.Element ('sound'); sound.set (attr, val)
-                addElem (dir, sound, lev + 1)
+                if ")" in d:
+                    type = "stop"
+                else:
+                    type = "crescendo" if "<" in d or "crescendo" in d else "diminuendo"
+                addDirection(maat, E.Element("wedge", type=type), lev, gstaff)
+            elif d.startswith("8v"):
+                if "a" in d:
+                    type, plce = "down", "above"
+                else:
+                    type, plce = "up", "below"
+                if ")" in d:
+                    type = "stop"
+                addDirection(
+                    maat,
+                    E.Element("octave-shift", type=type, size="8"),
+                    lev,
+                    gstaff,
+                    placement=plce,
+                )
+            elif d in (["ped", "ped-up"]):
+                type = "stop" if d.endswith("up") else "start"
+                addDirection(maat, E.Element("pedal", type=type), lev, gstaff)
+            elif d in ["coda", "segno"]:
+                text, attr, val = s.capoMap[d]
+                dir = addDirection(
+                    maat, E.Element(text), lev, gstaff, placement="above"
+                )
+                sound = E.Element("sound")
+                sound.set(attr, val)
+                addElem(dir, sound, lev + 1)
             elif d in s.capoMap:
-                text, attr, val = s.capoMap [d]
-                words = E.Element ('words'); words.text = text
-                dir = addDirection (maat, words, lev, gstaff, placement='above')
-                sound = E.Element ('sound'); sound.set (attr, val)
-                addElem (dir, sound, lev + 1)
-            elif d == '(' or d == '.(': s.slurbeg.append (d)   # start slur on next note
-            elif d in ['/-','//-','///-','////-']:  # duplet tremolo sequence
-                s.tmnum, s.tmden, s.ntup, s.trem, s.intrem = 2, 1, 2, len (d) - 1, 1
-            elif d in ['/','//','///']: s.trem = - len (d)  # single note tremolo
-            elif d == 'rbstop': s.rbStop = 1;   # sluit een open volta aan het eind van de maat
-            else: s.nextdecos.append (d)    # keep annotation for the next note
-
-    def doFields (s, maat, fieldmap, lev):
-        def instDir (midelm, midnum, dirtxt):
-            instId = 'I%s-%s' % (s.pid, s.vid)
-            words = E.Element ('words'); words.text = dirtxt % midnum
-            snd = E.Element ('sound')
-            mi = E.Element ('midi-instrument', id=instId)
-            dir = addDirection (maat, words, lev, gstaff, placement='above')
-            addElem (dir, snd, lev + 1)
-            addElem (snd, mi, lev + 2)
-            addElemT (mi, midelm, midnum, lev + 3)
-        def addTrans (n):
-            e = E.Element ('transpose')
-            addElemT (e, 'chromatic', n, lev + 2)  # n == signed number string given after transpose
-            atts.append ((9, e))
-        def doClef (field):
-            if re.search (r'perc|map', field):  # percussion clef or new style perc=on or map=perc
-                r = re.search (r'(perc|map)\s*=\s*(\S*)', field)
-                s.percVoice = 0 if r and r.group (2) not in ['on','true','perc'] else 1
-                field = re.sub (r'(perc|map)\s*=\s*(\S*)', '', field)   # erase the perc= for proper clef matching
-            clef, gtrans = 0, 0
-            clefn = re.search (r'alto1|alto2|alto4|alto|tenor|bass3|bass|treble|perc|none|tab', field)
-            clefm = re.search (r"(?:^m=| m=|middle=)([A-Ga-g])([,']*)", field)
-            trans_oct2 = re.search (r'octave=([-+]?\d)', field)
-            trans = re.search (r'(?:^t=| t=|transpose=)(-?[\d]+)', field)
-            trans_oct = re.search (r'([+-^_])(8|15)', field)
-            cue_onoff = re.search (r'cue=(on|off)', field)
-            strings = re.search (r"strings=(\S+)", field)
-            stafflines = re.search (r'stafflines=\s*(\d)', field)
-            capo = re.search (r'capo=(\d+)', field)
-            if clefn:
-                clef = clefn.group ()
-            if clefm:
-                note, octstr = clefm.groups ()
-                nUp = note.upper ()
-                octnum = (4 if nUp == note else 5) + (len (octstr) if "'" in octstr else -len (octstr))
-                gtrans = (3 if nUp in 'AFD' else 4) - octnum 
-                if clef not in ['perc', 'none']: clef = s.clefLineMap [nUp]
-            if clef:
-                s.gtrans = gtrans   # only change global tranposition when a clef is really defined
-                if clef != 'none': s.curClef = clef       # keep track of current abc clef (for percmap)
-                sign, line = s.clefMap [clef]
-                if not sign: return
-                c = E.Element ('clef')
-                if gstaff: c.set ('number', str (gstaff))   # only add staff number when defined
-                addElemT (c, 'sign', sign, lev + 2)
-                if line: addElemT (c, 'line', line, lev + 2)
-                if trans_oct:
-                    n = trans_oct.group (1) in '-_' and -1 or 1
-                    if trans_oct.group (2) == '15': n *= 2  # 8 => 1 octave, 15 => 2 octaves
-                    addElemT (c, 'clef-octave-change', str (n), lev + 2) # transpose print out
-                    if trans_oct.group (1) in '+-': s.gtrans += n   # also transpose all pitches with one octave
-                atts.append ((7, c))
-            if trans_oct2:  # octave= can also be in a K: field
-                n = int (trans_oct2.group (1))
-                s.gtrans = gtrans + n
-            if trans != None:   # add transposition in semitones
-                e = E.Element ('transpose')
-                addElemT (e, 'chromatic', str (trans.group (1)), lev + 3)
-                atts.append ((9, e))
-            if cue_onoff: s.gcue_on = cue_onoff.group (1) == 'on'
-            nlines = 0
-            if clef == 'tab':
-                s.tabStaff = s.pid
-                if capo: s.capo = int (capo.group (1))
-                if strings: s.tuning = strings.group (1).split (',')
-                s.tunmid = [int (boct) * 12 + [0,2,4,5,7,9,11]['CDEFGAB'.index (bstep)] + 12 + s.capo for bstep, boct in s.tuning]
-                s.tunTup = sorted (zip (s.tunmid, range (len (s.tunmid), 0, -1)), reverse=1)
-                s.tunmid.reverse ()
-                nlines = str (len (s.tuning))
-                s.strAlloc.setlines (len (s.tuning), s.pid)
-                s.nostems = 'nostems' in field  # tab clef without stems
-                s.diafret = 'diafret' in field  # tab with diatonic fretting
-            if stafflines or nlines:
-                e = E.Element ('staff-details')
-                if gstaff: e.set ('number', str (gstaff))   # only add staff number when defined
-                if not nlines: nlines = stafflines.group (1)
-                addElemT (e, 'staff-lines', nlines, lev + 2)
-                if clef == 'tab':
-                    for line, t in enumerate (s.tuning):
-                        st = E.Element ('staff-tuning', line=str(line+1))
-                        addElemT (st, 'tuning-step', t[0], lev + 3)
-                        addElemT (st, 'tuning-octave', t[1], lev + 3)
-                        addElem (e, st, lev + 2)
-                if s.capo: addElemT (e, 'capo', str (s.capo), lev + 2)
-                atts.append ((8, e))
-        s.diafret = 0           # chromatic fretting is default
-        atts = []               # collect xml attribute elements [(order-number, xml-element), ..]
-        gstaff = s.gStaffNums.get (s.vid, 0)    # staff number of the current voice
-        for ftype, field in fieldmap.items ():
-            if not field:       # skip empty fields
-                continue
-            if ftype == 'Div':  # not an abc field, but handled as if
-                d = E.Element ('divisions')
-                d.text = field
-                atts.append ((1, d))
-            elif ftype == 'gstaff':  # make grand staff
-                e = E.Element ('staves')
-                e.text = str (field)
-                atts.append ((4, e))
-            elif ftype == 'M':
-                if field == 'none': continue
-                if field == 'C': field = '4/4'
-                elif field == 'C|': field = '2/2'
-                t = E.Element ('time')
-                if '/' not in field:
-                    info ('M:%s not recognized, 4/4 assumed' % field)
-                    field = '4/4'
-                beats, btype = field.split ('/')[:2]
-                try: s.mdur = simplify (eval (beats), int (btype))  # measure duration for Z and X rests (eval allows M:2+3/4)
-                except:
-                    info ('error in M:%s, 4/4 assumed' % field)
-                    s.mdur = (4,4)
-                    beats, btype = '4','4'
-                addElemT (t, 'beats', beats, lev + 2)
-                addElemT (t, 'beat-type', btype, lev + 2)
-                atts.append ((3, t))
-            elif ftype == 'K':
-                accs = ['F','C','G','D','A','E','B']    # == s.sharpness [7:14]
-                mode = ''
-                key = re.match (r'\s*([A-G][#b]?)\s*([a-zA-Z]*)', field)
-                alts = re.search (r'\s((\s?[=^_][A-Ga-g])+)', ' ' + field)  # avoid matching middle=G and m=G
-                if key:
-                    key, mode = key.groups ()
-                    mode = mode.lower ()[:3] # only first three chars, no case
-                    if mode not in s.offTab: mode = 'maj'
-                    fifths = s.sharpness.index (key) - s.offTab [mode]
-                    if fifths >= 0: s.keyAlts = dict (zip (accs[:fifths], fifths * ['1']))
-                    else:           s.keyAlts = dict (zip (accs[fifths:], -fifths * ['-1']))
-                elif field.startswith ('none') or field == '':  # the default key
-                    fifths = 0
-                    mode = 'maj'
-                if alts:
-                    alts = re.findall (r'[=^_][A-Ga-g]', alts.group(1)) # list of explicit alterations
-                    alts = [(x[1], s.alterTab [x[0]]) for x in alts]    # [step, alter]
-                    for step, alter in alts:                # correct permanent alterations for this key
-                        s.keyAlts [step.upper ()] = alter
-                    k = E.Element ('key')
-                    koctave = []
-                    lowerCaseSteps = [step.upper () for step, alter in alts if step.islower ()]
-                    for step, alter in sorted (list (s.keyAlts.items ())):
-                        if alter == '0':                    # skip neutrals
-                            del s.keyAlts [step.upper ()]   # otherwise you get neutral signs on normal notes
-                            continue
-                        addElemT (k, 'key-step', step.upper (), lev + 2)
-                        addElemT (k, 'key-alter', alter, lev + 2)
-                        koctave.append ('5' if step in lowerCaseSteps else '4')
-                    if koctave:                     # only key signature if not empty
-                        for oct in koctave:
-                            e = E.Element ('key-octave', number=oct)
-                            addElem (k, e, lev + 2)
-                        atts.append ((2, k))
-                elif mode:
-                    k = E.Element ('key')
-                    addElemT (k, 'fifths', str (fifths), lev + 2)
-                    addElemT (k, 'mode', s.modTab [mode], lev + 2)
-                    atts.append ((2, k))
-                doClef (field)
-            elif ftype == 'L':
-                try: s.unitLcur = lmap (int, field.split ('/'))
-                except: s.unitLcur = (1,8)
-                if len (s.unitLcur) == 1 or s.unitLcur[1] not in s.typeMap:
-                    info ('L:%s is not allowed, 1/8 assumed' % field)
-                    s.unitLcur = 1,8
-            elif ftype == 'V':
-                doClef (field)
-            elif ftype == 'I':
-                s.doField_I (ftype, field, instDir, addTrans)
-            elif ftype == 'Q':
-                s.doTempo (maat, field, lev)
-            elif ftype == 'P':  # ad hoc translation of P: into a staff text direction
-                words = E.Element ('rehearsal')
-                words.set ('font-weight', 'bold')
-                words.text = field
-                addDirection (maat, words, lev, gstaff, placement='above')
-            elif ftype in 'TCOAZNGHRBDFSU':
-                info ('**illegal header field in body: %s, content: %s' % (ftype, field))
+                text, attr, val = s.capoMap[d]
+                words = E.Element("words")
+                words.text = text
+                dir = addDirection(maat, words, lev, gstaff, placement="above")
+                sound = E.Element("sound")
+                sound.set(attr, val)
+                addElem(dir, sound, lev + 1)
+            elif d == "(" or d == ".(":
+                s.slurbeg.append(d)  # start slur on next note
+            elif d in ["/-", "//-", "///-", "////-"]:  # duplet tremolo sequence
+                s.tmnum, s.tmden, s.ntup, s.trem, s.intrem = 2, 1, 2, len(d) - 1, 1
+            elif d in ["/", "//", "///"]:
+                s.trem = -len(d)  # single note tremolo
+            elif d == "rbstop":
+                s.rbStop = 1  # sluit een open volta aan het eind van de maat
             else:
-                info ('unhandled field: %s, content: %s' % (ftype, field))
+                s.nextdecos.append(d)  # keep annotation for the next note
+
+    def doFields(s, maat, fieldmap, lev):
+        def instDir(midelm, midnum, dirtxt):
+            instId = "I%s-%s" % (s.pid, s.vid)
+            words = E.Element("words")
+            words.text = dirtxt % midnum
+            snd = E.Element("sound")
+            mi = E.Element("midi-instrument", id=instId)
+            dir = addDirection(maat, words, lev, gstaff, placement="above")
+            addElem(dir, snd, lev + 1)
+            addElem(snd, mi, lev + 2)
+            addElemT(mi, midelm, midnum, lev + 3)
+
+        def addTrans(n):
+            e = E.Element("transpose")
+            addElemT(
+                e, "chromatic", n, lev + 2
+            )  # n == signed number string given after transpose
+            atts.append((9, e))
+
+        def doClef(field):
+            if re.search(
+                r"perc|map", field
+            ):  # percussion clef or new style perc=on or map=perc
+                r = re.search(r"(perc|map)\s*=\s*(\S*)", field)
+                s.percVoice = 0 if r and r.group(2) not in ["on", "true", "perc"] else 1
+                field = re.sub(
+                    r"(perc|map)\s*=\s*(\S*)", "", field
+                )  # erase the perc= for proper clef matching
+            clef, gtrans = 0, 0
+            clefn = re.search(
+                r"alto1|alto2|alto4|alto|tenor|bass3|bass|treble|perc|none|tab", field
+            )
+            clefm = re.search(r"(?:^m=| m=|middle=)([A-Ga-g])([,']*)", field)
+            trans_oct2 = re.search(r"octave=([-+]?\d)", field)
+            trans = re.search(r"(?:^t=| t=|transpose=)(-?[\d]+)", field)
+            trans_oct = re.search(r"([+-^_])(8|15)", field)
+            cue_onoff = re.search(r"cue=(on|off)", field)
+            strings = re.search(r"strings=(\S+)", field)
+            stafflines = re.search(r"stafflines=\s*(\d)", field)
+            capo = re.search(r"capo=(\d+)", field)
+            if clefn:
+                clef = clefn.group()
+            if clefm:
+                note, octstr = clefm.groups()
+                nUp = note.upper()
+                octnum = (4 if nUp == note else 5) + (
+                    len(octstr) if "'" in octstr else -len(octstr)
+                )
+                gtrans = (3 if nUp in "AFD" else 4) - octnum
+                if clef not in ["perc", "none"]:
+                    clef = s.clefLineMap[nUp]
+            if clef:
+                s.gtrans = gtrans  # only change global tranposition when a clef is really defined
+                if clef != "none":
+                    s.curClef = clef  # keep track of current abc clef (for percmap)
+                sign, line = s.clefMap[clef]
+                if not sign:
+                    return
+                c = E.Element("clef")
+                if gstaff:
+                    c.set("number", str(gstaff))  # only add staff number when defined
+                addElemT(c, "sign", sign, lev + 2)
+                if line:
+                    addElemT(c, "line", line, lev + 2)
+                if trans_oct:
+                    n = trans_oct.group(1) in "-_" and -1 or 1
+                    if trans_oct.group(2) == "15":
+                        n *= 2  # 8 => 1 octave, 15 => 2 octaves
+                    addElemT(
+                        c, "clef-octave-change", str(n), lev + 2
+                    )  # transpose print out
+                    if trans_oct.group(1) in "+-":
+                        s.gtrans += n  # also transpose all pitches with one octave
+                atts.append((7, c))
+            if trans_oct2:  # octave= can also be in a K: field
+                n = int(trans_oct2.group(1))
+                s.gtrans = gtrans + n
+            if trans is not None:  # add transposition in semitones
+                e = E.Element("transpose")
+                addElemT(e, "chromatic", str(trans.group(1)), lev + 3)
+                atts.append((9, e))
+            if cue_onoff:
+                s.gcue_on = cue_onoff.group(1) == "on"
+            nlines = 0
+            if clef == "tab":
+                s.tabStaff = s.pid
+                if capo:
+                    s.capo = int(capo.group(1))
+                if strings:
+                    s.tuning = strings.group(1).split(",")
+                s.tunmid = [
+                    int(boct) * 12
+                    + [0, 2, 4, 5, 7, 9, 11]["CDEFGAB".index(bstep)]
+                    + 12
+                    + s.capo
+                    for bstep, boct in s.tuning
+                ]
+                s.tunTup = sorted(zip(s.tunmid, range(len(s.tunmid), 0, -1)), reverse=1)
+                s.tunmid.reverse()
+                nlines = str(len(s.tuning))
+                s.strAlloc.setlines(len(s.tuning), s.pid)
+                s.nostems = "nostems" in field  # tab clef without stems
+                s.diafret = "diafret" in field  # tab with diatonic fretting
+            if stafflines or nlines:
+                e = E.Element("staff-details")
+                if gstaff:
+                    e.set("number", str(gstaff))  # only add staff number when defined
+                if not nlines:
+                    nlines = stafflines.group(1)
+                addElemT(e, "staff-lines", nlines, lev + 2)
+                if clef == "tab":
+                    for line, t in enumerate(s.tuning):
+                        st = E.Element("staff-tuning", line=str(line + 1))
+                        addElemT(st, "tuning-step", t[0], lev + 3)
+                        addElemT(st, "tuning-octave", t[1], lev + 3)
+                        addElem(e, st, lev + 2)
+                if s.capo:
+                    addElemT(e, "capo", str(s.capo), lev + 2)
+                atts.append((8, e))
+
+        s.diafret = 0  # chromatic fretting is default
+        atts = []  # collect xml attribute elements [(order-number, xml-element), ..]
+        gstaff = s.gStaffNums.get(s.vid, 0)  # staff number of the current voice
+        for ftype, field in fieldmap.items():
+            if not field:  # skip empty fields
+                continue
+            if ftype == "Div":  # not an abc field, but handled as if
+                d = E.Element("divisions")
+                d.text = field
+                atts.append((1, d))
+            elif ftype == "gstaff":  # make grand staff
+                e = E.Element("staves")
+                e.text = str(field)
+                atts.append((4, e))
+            elif ftype == "M":
+                if field == "none":
+                    continue
+                if field == "C":
+                    field = "4/4"
+                elif field == "C|":
+                    field = "2/2"
+                t = E.Element("time")
+                if "/" not in field:
+                    info("M:%s not recognized, 4/4 assumed" % field)
+                    field = "4/4"
+                beats, btype = field.split("/")[:2]
+                try:
+                    s.mdur = simplify(
+                        eval(beats), int(btype)
+                    )  # measure duration for Z and X rests (eval allows M:2+3/4)
+                except Exception:
+                    info("error in M:%s, 4/4 assumed" % field)
+                    s.mdur = (4, 4)
+                    beats, btype = "4", "4"
+                addElemT(t, "beats", beats, lev + 2)
+                addElemT(t, "beat-type", btype, lev + 2)
+                atts.append((3, t))
+            elif ftype == "K":
+                accs = ["F", "C", "G", "D", "A", "E", "B"]  # == s.sharpness [7:14]
+                mode = ""
+                key = re.match(r"\s*([A-G][#b]?)\s*([a-zA-Z]*)", field)
+                alts = re.search(
+                    r"\s((\s?[=^_][A-Ga-g])+)", " " + field
+                )  # avoid matching middle=G and m=G
+                if key:
+                    key, mode = key.groups()
+                    mode = mode.lower()[:3]  # only first three chars, no case
+                    if mode not in s.offTab:
+                        mode = "maj"
+                    fifths = s.sharpness.index(key) - s.offTab[mode]
+                    if fifths >= 0:
+                        s.keyAlts = dict(zip(accs[:fifths], fifths * ["1"]))
+                    else:
+                        s.keyAlts = dict(zip(accs[fifths:], -fifths * ["-1"]))
+                elif field.startswith("none") or field == "":  # the default key
+                    fifths = 0
+                    mode = "maj"
+                if alts:
+                    alts = re.findall(
+                        r"[=^_][A-Ga-g]", alts.group(1)
+                    )  # list of explicit alterations
+                    alts = [(x[1], s.alterTab[x[0]]) for x in alts]  # [step, alter]
+                    for (
+                        step,
+                        alter,
+                    ) in alts:  # correct permanent alterations for this key
+                        s.keyAlts[step.upper()] = alter
+                    k = E.Element("key")
+                    koctave = []
+                    lowerCaseSteps = [
+                        step.upper() for step, alter in alts if step.islower()
+                    ]
+                    for step, alter in sorted(list(s.keyAlts.items())):
+                        if alter == "0":  # skip neutrals
+                            del s.keyAlts[
+                                step.upper()
+                            ]  # otherwise you get neutral signs on normal notes
+                            continue
+                        addElemT(k, "key-step", step.upper(), lev + 2)
+                        addElemT(k, "key-alter", alter, lev + 2)
+                        koctave.append("5" if step in lowerCaseSteps else "4")
+                    if koctave:  # only key signature if not empty
+                        for oct in koctave:
+                            e = E.Element("key-octave", number=oct)
+                            addElem(k, e, lev + 2)
+                        atts.append((2, k))
+                elif mode:
+                    k = E.Element("key")
+                    addElemT(k, "fifths", str(fifths), lev + 2)
+                    addElemT(k, "mode", s.modTab[mode], lev + 2)
+                    atts.append((2, k))
+                doClef(field)
+            elif ftype == "L":
+                try:
+                    s.unitLcur = lmap(int, field.split("/"))
+                except Exception:
+                    s.unitLcur = (1, 8)
+                if len(s.unitLcur) == 1 or s.unitLcur[1] not in s.typeMap:
+                    info("L:%s is not allowed, 1/8 assumed" % field)
+                    s.unitLcur = 1, 8
+            elif ftype == "V":
+                doClef(field)
+            elif ftype == "I":
+                s.doField_I(ftype, field, instDir, addTrans)
+            elif ftype == "Q":
+                s.doTempo(maat, field, lev)
+            elif ftype == "P":  # ad hoc translation of P: into a staff text direction
+                words = E.Element("rehearsal")
+                words.set("font-weight", "bold")
+                words.text = field
+                addDirection(maat, words, lev, gstaff, placement="above")
+            elif ftype in "TCOAZNGHRBDFSU":
+                info("**illegal header field in body: %s, content: %s" % (ftype, field))
+            else:
+                info("unhandled field: %s, content: %s" % (ftype, field))
 
         if atts:
-            att = E.Element ('attributes')      # insert sub elements in the order required by musicXML
-            addElem (maat, att, lev)
-            for _, att_elem in sorted (atts, key=lambda x: x[0]):   # ordering !
-                addElem (att, att_elem, lev + 1)
+            att = E.Element(
+                "attributes"
+            )  # insert sub elements in the order required by musicXML
+            addElem(maat, att, lev)
+            for _, att_elem in sorted(atts, key=lambda x: x[0]):  # ordering !
+                addElem(att, att_elem, lev + 1)
         if s.diafret:
-            other = E.Element ('other-direction'); other.text = 'diatonic fretting'
-            addDirection (maat, other, lev, 0)
+            other = E.Element("other-direction")
+            other.text = "diatonic fretting"
+            addDirection(maat, other, lev, 0)
 
-    def doTempo (s, maat, field, lev):
-        gstaff = s.gStaffNums.get (s.vid, 0)    # staff number of the current voice
-        t = re.search (r'(\d)/(\d\d?)\s*=\s*(\d[.\d]*)|(\d[.\d]*)', field)
-        rtxt = re.search (r'"([^"]*)"', field) # look for text in Q: field
-        if not t and not rtxt: return
+    def doTempo(s, maat, field, lev):
+        gstaff = s.gStaffNums.get(s.vid, 0)  # staff number of the current voice
+        t = re.search(r"(\d)/(\d\d?)\s*=\s*(\d[.\d]*)|(\d[.\d]*)", field)
+        rtxt = re.search(r'"([^"]*)"', field)  # look for text in Q: field
+        if not t and not rtxt:
+            return
         elems = []  # [(element, sub-elements)] will be added as direction-types
         if rtxt:
-            num, den, upm = 1, 4, s.tempoMap.get (rtxt.group (1).lower ().strip (), 120)
-            words = E.Element ('words'); words.text = rtxt.group (1)
-            elems.append ((words, []))
+            num, den, upm = 1, 4, s.tempoMap.get(rtxt.group(1).lower().strip(), 120)
+            words = E.Element("words")
+            words.text = rtxt.group(1)
+            elems.append((words, []))
         if t:
             try:
-                if t.group (4): num, den, upm = 1, s.unitLcur[1] , float (t.group (4))  # old syntax Q:120
-                else:           num, den, upm = int (t.group (1)), int (t.group (2)), float (t.group (3))
-            except: info ('conversion error: %s' % field); return
-            num, den = simplify (num, den);
+                if t.group(4):
+                    num, den, upm = (
+                        1,
+                        s.unitLcur[1],
+                        float(t.group(4)),
+                    )  # old syntax Q:120
+                else:
+                    num, den, upm = int(t.group(1)), int(t.group(2)), float(t.group(3))
+            except Exception:
+                info("conversion error: %s" % field)
+                return
+            num, den = simplify(num, den)
             dotted, den_not = (1, den // 2) if num == 3 else (0, den)
-            metro = E.Element ('metronome')
-            u = E.Element ('beat-unit'); u.text = s.typeMap.get (4 * den_not, 'quarter')
-            pm = E.Element ('per-minute'); pm.text = ('%.2f' % upm).rstrip ('0').rstrip ('.')
-            subelms = [u, E.Element ('beat-unit-dot'), pm] if dotted else [u, pm]
-            elems.append ((metro, subelms))
-        dir = addDirection (maat, elems, lev, gstaff, [], placement='above')
-        if num != 1 and num != 3: info ('in Q: numerator in %d/%d not supported' % (num, den))
-        qpm = 4. * num * upm / den
-        sound = E.Element ('sound'); sound.set ('tempo', '%.2f' % qpm)
-        addElem (dir, sound, lev + 1)
+            metro = E.Element("metronome")
+            u = E.Element("beat-unit")
+            u.text = s.typeMap.get(4 * den_not, "quarter")
+            pm = E.Element("per-minute")
+            pm.text = ("%.2f" % upm).rstrip("0").rstrip(".")
+            subelms = [u, E.Element("beat-unit-dot"), pm] if dotted else [u, pm]
+            elems.append((metro, subelms))
+        dir = addDirection(maat, elems, lev, gstaff, [], placement="above")
+        if num != 1 and num != 3:
+            info("in Q: numerator in %d/%d not supported" % (num, den))
+        qpm = 4.0 * num * upm / den
+        sound = E.Element("sound")
+        sound.set("tempo", "%.2f" % qpm)
+        addElem(dir, sound, lev + 1)
 
-    def mkBarline (s, maat, loc, lev, style='', dir='', ending=''):
-        b = E.Element ('barline', location=loc)
+    def mkBarline(s, maat, loc, lev, style="", dir="", ending=""):
+        b = E.Element("barline", location=loc)
         if style:
-            addElemT (b, 'bar-style', style, lev + 1)
-        if s.curVolta:    # first stop a current volta
-            end = E.Element ('ending', number=s.curVolta, type='stop')
-            s.curVolta = ''
-            if loc == 'left':   # stop should always go to a right barline
-                bp = E.Element ('barline', location='right')
-                addElem (bp, end, lev + 1)
-                addElem (s.prevmsre, bp, lev)   # prevmsre has no right barline! (ending would have stopped there)
+            addElemT(b, "bar-style", style, lev + 1)
+        if s.curVolta:  # first stop a current volta
+            end = E.Element("ending", number=s.curVolta, type="stop")
+            s.curVolta = ""
+            if loc == "left":  # stop should always go to a right barline
+                bp = E.Element("barline", location="right")
+                addElem(bp, end, lev + 1)
+                addElem(
+                    s.prevmsre, bp, lev
+                )  # prevmsre has no right barline! (ending would have stopped there)
             else:
-                addElem (b, end, lev + 1)
+                addElem(b, end, lev + 1)
         if ending:
-            ending = ending.replace ('-',',')   # MusicXML only accepts comma's
-            endtxt = ''
-            if ending.startswith ('"'):     # ending is a quoted string
-                endtxt = ending.strip ('"')
-                ending = '33'               # any number that is not likely to occur elsewhere
-            end = E.Element ('ending', number=ending, type='start')
-            if endtxt: end.text = endtxt    # text appears in score in stead of number attribute
-            addElem (b, end, lev + 1)
+            ending = ending.replace("-", ",")  # MusicXML only accepts comma's
+            endtxt = ""
+            if ending.startswith('"'):  # ending is a quoted string
+                endtxt = ending.strip('"')
+                ending = "33"  # any number that is not likely to occur elsewhere
+            end = E.Element("ending", number=ending, type="start")
+            if endtxt:
+                end.text = endtxt  # text appears in score in stead of number attribute
+            addElem(b, end, lev + 1)
             s.curVolta = ending
         if dir:
-            r = E.Element ('repeat', direction=dir)
-            addElem (b, r, lev + 1)
-        addElem (maat, b, lev)
+            r = E.Element("repeat", direction=dir)
+            addElem(b, r, lev + 1)
+        addElem(maat, b, lev)
 
-    def doChordSym (s, maat, sym, lev):
-        alterMap = {'#':'1','=':'0','b':'-1'}
+    def doChordSym(s, maat, sym, lev):
+        alterMap = {"#": "1", "=": "0", "b": "-1"}
         rnt = sym.root.t
-        chord = E.Element ('harmony')
-        addElem (maat, chord, lev)
-        root = E.Element ('root')
-        addElem (chord, root, lev + 1)
-        addElemT (root, 'root-step', rnt[0], lev + 2)
-        if len (rnt) == 2: addElemT (root, 'root-alter', alterMap [rnt[1]], lev + 2)
-        kind = s.chordTab.get (sym.kind.t[0], 'major') if sym.kind.t else 'major'
-        addElemT (chord, 'kind', kind, lev + 1)
-        if hasattr (sym, 'bass'):
+        chord = E.Element("harmony")
+        addElem(maat, chord, lev)
+        root = E.Element("root")
+        addElem(chord, root, lev + 1)
+        addElemT(root, "root-step", rnt[0], lev + 2)
+        if len(rnt) == 2:
+            addElemT(root, "root-alter", alterMap[rnt[1]], lev + 2)
+        kind = s.chordTab.get(sym.kind.t[0], "major") if sym.kind.t else "major"
+        addElemT(chord, "kind", kind, lev + 1)
+        if hasattr(sym, "bass"):
             bnt = sym.bass.t
-            bass = E.Element ('bass')
-            addElem (chord, bass, lev + 1)
-            addElemT (bass, 'bass-step', bnt[0], lev + 2)
-            if len (bnt) == 2: addElemT (bass, 'bass-alter', alterMap [bnt[1]], lev + 2)
-        degs = getattr (sym, 'degree', '')
+            bass = E.Element("bass")
+            addElem(chord, bass, lev + 1)
+            addElemT(bass, "bass-step", bnt[0], lev + 2)
+            if len(bnt) == 2:
+                addElemT(bass, "bass-alter", alterMap[bnt[1]], lev + 2)
+        degs = getattr(sym, "degree", "")
         if degs:
-            if type (degs) != list_type: degs = [degs]
+            if isinstance(degs, list_type):
+                degs = [degs]
             for deg in degs:
                 deg = deg.t[0]
-                if deg[0] == '#':   alter = '1';  deg = deg[1:]
-                elif deg[0] == 'b': alter = '-1'; deg = deg[1:]
-                else:               alter = '0';  deg = deg
-                degree = E.Element ('degree')
-                addElem (chord, degree, lev + 1)
-                addElemT (degree, 'degree-value', deg, lev + 2)
-                addElemT (degree, 'degree-alter', alter, lev + 2)
-                addElemT (degree, 'degree-type', 'add', lev + 2)
+                if deg[0] == "#":
+                    alter = "1"
+                    deg = deg[1:]
+                elif deg[0] == "b":
+                    alter = "-1"
+                    deg = deg[1:]
+                else:
+                    alter = "0"
+                    deg = deg
+                degree = E.Element("degree")
+                addElem(chord, degree, lev + 1)
+                addElemT(degree, "degree-value", deg, lev + 2)
+                addElemT(degree, "degree-alter", alter, lev + 2)
+                addElemT(degree, "degree-type", "add", lev + 2)
 
-    def mkMeasure (s, i, t, lev, fieldmap={}):
+    def mkMeasure(s, i, t, lev, fieldmap={}):
         s.msreAlts = {}
         s.ntup, s.trem, s.intrem = -1, 0, 0
-        s.acciatura = 0 # next grace element gets acciatura attribute
-        s.rbStop = 0    # sluit een open volta aan het eind van de maat
+        s.acciatura = 0  # next grace element gets acciatura attribute
+        s.rbStop = 0  # sluit een open volta aan het eind van de maat
         overlay = 0
-        maat = E.Element ('measure', number = str(i))
-        if fieldmap: s.doFields (maat, fieldmap, lev + 1)
-        if s.linebrk:   # there was a line break in the previous measure
-            e = E.Element ('print')
-            e.set ('new-system', 'yes')
-            addElem (maat, e, lev + 1)
+        maat = E.Element("measure", number=str(i))
+        if fieldmap:
+            s.doFields(maat, fieldmap, lev + 1)
+        if s.linebrk:  # there was a line break in the previous measure
+            e = E.Element("print")
+            e.set("new-system", "yes")
+            addElem(maat, e, lev + 1)
             s.linebrk = 0
-        for it, x in enumerate (t):
-            if x.name == 'note' or x.name == 'rest':
-                if x.dur.t[0] == 0:  # a leading zero was used for stemmless in abcm2ps, we only support !stemless!
-                    x.dur.t = tuple ([1, x.dur.t[1]])
-                note = s.mkNote (x, lev + 1)
-                addElem (maat, note, lev + 1)
-            elif x.name == 'lbar':
+        for it, x in enumerate(t):
+            if x.name == "note" or x.name == "rest":
+                if (
+                    x.dur.t[0] == 0
+                ):  # a leading zero was used for stemmless in abcm2ps, we only support !stemless!
+                    x.dur.t = tuple([1, x.dur.t[1]])
+                note = s.mkNote(x, lev + 1)
+                addElem(maat, note, lev + 1)
+            elif x.name == "lbar":
                 bar = x.t[0]
-                if bar == '|' or bar == '[|': pass # skip redundant bar
-                elif ':' in bar:    # forward repeat
-                    volta = x.t[1] if len (x.t) == 2  else ''
-                    s.mkBarline (maat, 'left', lev + 1, style='heavy-light', dir='forward', ending=volta)
-                else:               # bar must be a volta number
-                    s.mkBarline (maat, 'left', lev + 1, ending=bar)
-            elif x.name == 'rbar':
+                if bar == "|" or bar == "[|":
+                    pass  # skip redundant bar
+                elif ":" in bar:  # forward repeat
+                    volta = x.t[1] if len(x.t) == 2 else ""
+                    s.mkBarline(
+                        maat,
+                        "left",
+                        lev + 1,
+                        style="heavy-light",
+                        dir="forward",
+                        ending=volta,
+                    )
+                else:  # bar must be a volta number
+                    s.mkBarline(maat, "left", lev + 1, ending=bar)
+            elif x.name == "rbar":
                 bar = x.t[0]
-                if bar == '.|':
-                    s.mkBarline (maat, 'right', lev + 1, style='dotted')
-                elif ':' in bar:  # backward repeat
-                    s.mkBarline (maat, 'right', lev + 1, style='light-heavy', dir='backward')
-                elif bar == '||':
-                    s.mkBarline (maat, 'right', lev + 1, style='light-light')
-                elif bar == '[|]' or bar == '[]':
-                    s.mkBarline (maat, 'right', lev + 1, style='none')
-                elif '[' in bar or ']' in bar:
-                    s.mkBarline (maat, 'right', lev + 1, style='light-heavy')
-                elif bar == '|' and s.rbStop:   # normale barline hoeft niet, behalve om een volta te stoppen
-                    s.mkBarline (maat, 'right', lev + 1, style='regular')
-                elif bar[0] == '&': overlay = 1
-            elif x.name == 'tup':
-                if   len (x.t) == 3: n, into, nts = x.t
-                elif len (x.t) == 2: n, into, nts = x.t + [0]
-                else:                n, into, nts = x.t[0], 0, 0
-                if into == 0: into = 3 if n in [2,4,8] else 2
-                if nts == 0: nts = n
-                s.tmnum, s.tmden, s.ntup = n, into, nts
-            elif x.name == 'deco':
-                s.staffDecos (x.t, maat, lev + 1)   # output staff decos, postpone note decos to next note
-            elif x.name == 'text':
-                pos, text = x.t[:2]
-                place = 'above' if pos == '^' else 'below'
-                words = E.Element ('words')
-                words.text = text
-                gstaff = s.gStaffNums.get (s.vid, 0)    # staff number of the current voice
-                addDirection (maat, words, lev + 1, gstaff, placement=place)
-            elif x.name == 'inline':
-                fieldtype, fieldval = x.t[0], ' '.join (x.t[1:])
-                s.doFields (maat, {fieldtype:fieldval}, lev + 1)
-            elif x.name == 'accia': s.acciatura = 1
-            elif x.name == 'linebrk':
-                s.supports_tag = 1
-                if it > 0 and t[it -1].name == 'lbar':  # we are at start of measure
-                    e = E.Element ('print')             # output linebreak now
-                    e.set ('new-system', 'yes')
-                    addElem (maat, e, lev + 1)
+                if bar == ".|":
+                    s.mkBarline(maat, "right", lev + 1, style="dotted")
+                elif ":" in bar:  # backward repeat
+                    s.mkBarline(
+                        maat, "right", lev + 1, style="light-heavy", dir="backward"
+                    )
+                elif bar == "||":
+                    s.mkBarline(maat, "right", lev + 1, style="light-light")
+                elif bar == "[|]" or bar == "[]":
+                    s.mkBarline(maat, "right", lev + 1, style="none")
+                elif "[" in bar or "]" in bar:
+                    s.mkBarline(maat, "right", lev + 1, style="light-heavy")
+                elif (
+                    bar == "|" and s.rbStop
+                ):  # normale barline hoeft niet, behalve om een volta te stoppen
+                    s.mkBarline(maat, "right", lev + 1, style="regular")
+                elif bar[0] == "&":
+                    overlay = 1
+            elif x.name == "tup":
+                if len(x.t) == 3:
+                    n, into, nts = x.t
+                elif len(x.t) == 2:
+                    n, into, nts = x.t + [0]
                 else:
-                    s.linebrk = 1   # output linebreak at start of next measure
-            elif x.name == 'chordsym':
-                s.doChordSym (maat, x, lev + 1)
-        s.stopBeams ()
+                    n, into, nts = x.t[0], 0, 0
+                if into == 0:
+                    into = 3 if n in [2, 4, 8] else 2
+                if nts == 0:
+                    nts = n
+                s.tmnum, s.tmden, s.ntup = n, into, nts
+            elif x.name == "deco":
+                s.staffDecos(
+                    x.t, maat, lev + 1
+                )  # output staff decos, postpone note decos to next note
+            elif x.name == "text":
+                pos, text = x.t[:2]
+                place = "above" if pos == "^" else "below"
+                words = E.Element("words")
+                words.text = text
+                gstaff = s.gStaffNums.get(s.vid, 0)  # staff number of the current voice
+                addDirection(maat, words, lev + 1, gstaff, placement=place)
+            elif x.name == "inline":
+                fieldtype, fieldval = x.t[0], " ".join(x.t[1:])
+                s.doFields(maat, {fieldtype: fieldval}, lev + 1)
+            elif x.name == "accia":
+                s.acciatura = 1
+            elif x.name == "linebrk":
+                s.supports_tag = 1
+                if it > 0 and t[it - 1].name == "lbar":  # we are at start of measure
+                    e = E.Element("print")  # output linebreak now
+                    e.set("new-system", "yes")
+                    addElem(maat, e, lev + 1)
+                else:
+                    s.linebrk = 1  # output linebreak at start of next measure
+            elif x.name == "chordsym":
+                s.doChordSym(maat, x, lev + 1)
+        s.stopBeams()
         s.prevmsre = maat
         return maat, overlay
 
-    def mkPart (s, maten, id, lev, attrs, nstaves, rOpt):
+    def mkPart(s, maten, id, lev, attrs, nstaves, rOpt):
         s.slurstack = {}
-        s.glisnum = 0;          # xml number attribute for glissandos
-        s.slidenum = 0;         # xml number attribute for slides
-        s.unitLcur = s.unitL    # set the default unit length at begin of each voice
-        s.curVolta = ''
+        s.glisnum = 0  # xml number attribute for glissandos
+        s.slidenum = 0  # xml number attribute for slides
+        s.unitLcur = s.unitL  # set the default unit length at begin of each voice
+        s.curVolta = ""
         s.lyrdash = {}
         s.linebrk = 0
-        s.midprg = ['', '', '', ''] # MIDI channel nr, program nr, volume, panning for the current part
-        s.gcue_on = 0           # reset cue note marker for each new voice
-        s.gtrans = 0            # reset octave transposition (by clef)
-        s.percVoice = 0         # 1 if percussion clef encountered
-        s.curClef = ''          # current abc clef (for percmap)
-        s.nostems = 0           # for the tab clef
+        s.midprg = [
+            "",
+            "",
+            "",
+            "",
+        ]  # MIDI channel nr, program nr, volume, panning for the current part
+        s.gcue_on = 0  # reset cue note marker for each new voice
+        s.gtrans = 0  # reset octave transposition (by clef)
+        s.percVoice = 0  # 1 if percussion clef encountered
+        s.curClef = ""  # current abc clef (for percmap)
+        s.nostems = 0  # for the tab clef
         s.tuning = s.tuningDef  # reset string tuning to default
-        part = E.Element ('part', id=id)
-        s.overlayVnum = 0       # overlay voice number to relate ties that extend from one overlayed measure to the next
-        gstaff = s.gStaffNums.get (s.vid, 0)    # staff number of the current voice
-        attrs_cpy = attrs.copy ()   # don't change attrs itself in next line
-        if gstaff == 1: attrs_cpy ['gstaff'] = nstaves  # make a grand staff
-        if 'perc' in attrs_cpy.get ('V', ''): del attrs_cpy ['K'] # remove key from percussion voice
-        msre, overlay = s.mkMeasure (1, maten[0], lev + 1, attrs_cpy)
-        addElem (part, msre, lev + 1)
-        for i, maat in enumerate (maten[1:]):
+        part = E.Element("part", id=id)
+        s.overlayVnum = 0  # overlay voice number to relate ties that extend from one overlayed measure to the next
+        gstaff = s.gStaffNums.get(s.vid, 0)  # staff number of the current voice
+        attrs_cpy = attrs.copy()  # don't change attrs itself in next line
+        if gstaff == 1:
+            attrs_cpy["gstaff"] = nstaves  # make a grand staff
+        if "perc" in attrs_cpy.get("V", ""):
+            del attrs_cpy["K"]  # remove key from percussion voice
+        msre, overlay = s.mkMeasure(1, maten[0], lev + 1, attrs_cpy)
+        addElem(part, msre, lev + 1)
+        for i, maat in enumerate(maten[1:]):
             s.overlayVnum = s.overlayVnum + 1 if overlay else 0
-            msre, next_overlay = s.mkMeasure (i+2, maat, lev + 1)
-            if overlay: mergePartMeasure (part, msre, s.overlayVnum, rOpt)
-            else:       addElem (part, msre, lev + 1)
+            msre, next_overlay = s.mkMeasure(i + 2, maat, lev + 1)
+            if overlay:
+                mergePartMeasure(part, msre, s.overlayVnum, rOpt)
+            else:
+                addElem(part, msre, lev + 1)
             overlay = next_overlay
         return part
 
-    def mkScorePart (s, id, vids_p, partAttr, lev):
-        def mkInst (instId, vid, midchan, midprog, midnot, vol, pan, lev):
-            si = E.Element ('score-instrument', id=instId)
-            pnm = partAttr.get (vid, [''])[0]   # part name if present
-            addElemT (si, 'instrument-name', pnm or 'dummy', lev + 2)   # MuseScore needs a name
-            mi = E.Element ('midi-instrument', id=instId)
-            if midchan: addElemT (mi, 'midi-channel', midchan, lev + 2)
-            if midprog: addElemT (mi, 'midi-program', str (int (midprog) + 1), lev + 2) # compatible with abc2midi
-            if midnot:  addElemT (mi, 'midi-unpitched', str (int (midnot) + 1), lev + 2)
-            if vol: addElemT (mi, 'volume', '%.2f' % (int (vol) / 1.27), lev + 2)
-            if pan: addElemT (mi, 'pan', '%.2f' % (int (pan) / 127. * 180 - 90), lev + 2)
+    def mkScorePart(s, id, vids_p, partAttr, lev):
+        def mkInst(instId, vid, midchan, midprog, midnot, vol, pan, lev):
+            si = E.Element("score-instrument", id=instId)
+            pnm = partAttr.get(vid, [""])[0]  # part name if present
+            addElemT(
+                si, "instrument-name", pnm or "dummy", lev + 2
+            )  # MuseScore needs a name
+            mi = E.Element("midi-instrument", id=instId)
+            if midchan:
+                addElemT(mi, "midi-channel", midchan, lev + 2)
+            if midprog:
+                addElemT(
+                    mi, "midi-program", str(int(midprog) + 1), lev + 2
+                )  # compatible with abc2midi
+            if midnot:
+                addElemT(mi, "midi-unpitched", str(int(midnot) + 1), lev + 2)
+            if vol:
+                addElemT(mi, "volume", "%.2f" % (int(vol) / 1.27), lev + 2)
+            if pan:
+                addElemT(mi, "pan", "%.2f" % (int(pan) / 127.0 * 180 - 90), lev + 2)
             return (si, mi)
-        naam, subnm, midprg = partAttr [id]
-        sp = E.Element ('score-part', id='P'+id)
-        nm = E.Element ('part-name')
+
+        naam, subnm, midprg = partAttr[id]
+        sp = E.Element("score-part", id="P" + id)
+        nm = E.Element("part-name")
         nm.text = naam
-        addElem (sp, nm, lev + 1)
-        snm = E.Element ('part-abbreviation')
+        addElem(sp, nm, lev + 1)
+        snm = E.Element("part-abbreviation")
         snm.text = subnm
-        if subnm: addElem (sp, snm, lev + 1)    # only add if subname was given
+        if subnm:
+            addElem(sp, snm, lev + 1)  # only add if subname was given
         inst = []
-        for instId, (pid, vid, chan, midprg, vol, pan) in sorted (s.midiInst.items ()):
-            midprg, midnot = ('0', midprg) if chan == '10' else (midprg, '')
-            if pid == id: inst.append (mkInst (instId, vid, chan, midprg, midnot, vol, pan, lev))
-        for si, mi in inst: addElem (sp, si, lev + 1)
-        for si, mi in inst: addElem (sp, mi, lev + 1)
+        for instId, (pid, vid, chan, midprg, vol, pan) in sorted(s.midiInst.items()):
+            midprg, midnot = ("0", midprg) if chan == "10" else (midprg, "")
+            if pid == id:
+                inst.append(mkInst(instId, vid, chan, midprg, midnot, vol, pan, lev))
+        for si, mi in inst:
+            addElem(sp, si, lev + 1)
+        for si, mi in inst:
+            addElem(sp, mi, lev + 1)
         return sp
 
-    def mkPartlist (s, vids, partAttr, lev):
-        def addPartGroup (sym, num):
-            pg = E.Element ('part-group', number=str (num), type='start')
-            addElem (partlist, pg, lev + 1)
-            addElemT (pg, 'group-symbol', sym, lev + 2)
-            addElemT (pg, 'group-barline', 'yes', lev + 2)
-        partlist = E.Element ('part-list')
-        g_num = 0       # xml group number
-        for g in (s.groups or vids):    # brace/bracket or abc_voice_id
-            if   g == '[': g_num += 1; addPartGroup ('bracket', g_num)
-            elif g == '{': g_num += 1; addPartGroup ('brace', g_num)
-            elif g in '}]':
-                pg = E.Element ('part-group', number=str (g_num), type='stop')
-                addElem (partlist, pg, lev + 1)
+    def mkPartlist(s, vids, partAttr, lev):
+        def addPartGroup(sym, num):
+            pg = E.Element("part-group", number=str(num), type="start")
+            addElem(partlist, pg, lev + 1)
+            addElemT(pg, "group-symbol", sym, lev + 2)
+            addElemT(pg, "group-barline", "yes", lev + 2)
+
+        partlist = E.Element("part-list")
+        g_num = 0  # xml group number
+        for g in s.groups or vids:  # brace/bracket or abc_voice_id
+            if g == "[":
+                g_num += 1
+                addPartGroup("bracket", g_num)
+            elif g == "{":
+                g_num += 1
+                addPartGroup("brace", g_num)
+            elif g in "}]":
+                pg = E.Element("part-group", number=str(g_num), type="stop")
+                addElem(partlist, pg, lev + 1)
                 g_num -= 1
-            else:   # g = abc_voice_id
-                if g not in vids: continue  # error in %%score
-                sp = s.mkScorePart (g, vids, partAttr, lev + 1)
-                addElem (partlist, sp, lev + 1)
+            else:  # g = abc_voice_id
+                if g not in vids:
+                    continue  # error in %%score
+                sp = s.mkScorePart(g, vids, partAttr, lev + 1)
+                addElem(partlist, sp, lev + 1)
         return partlist
 
-    def doField_I (s, type, x, instDir, addTrans):
-        def instChange (midchan, midprog):  # instDir -> doFields
-            if midchan and midchan != s.midprg [0]: instDir ('midi-channel', midchan, 'chan: %s')
-            if midprog and midprog != s.midprg [1]: instDir ('midi-program', str (int (midprog) + 1), 'prog: %s')
-        def readPfmt (x, n): # read ABC page formatting constant
-            if not s.pageFmtAbc: s.pageFmtAbc = s.pageFmtDef    # set the default values on first change
-            ro = re.search (r'[^.\d]*([\d.]+)\s*(cm|in|pt)?', x)    # float followed by unit
+    def doField_I(s, type, x, instDir, addTrans):
+        def instChange(midchan, midprog):  # instDir -> doFields
+            if midchan and midchan != s.midprg[0]:
+                instDir("midi-channel", midchan, "chan: %s")
+            if midprog and midprog != s.midprg[1]:
+                instDir("midi-program", str(int(midprog) + 1), "prog: %s")
+
+        def readPfmt(x, n):  # read ABC page formatting constant
+            if not s.pageFmtAbc:
+                s.pageFmtAbc = s.pageFmtDef  # set the default values on first change
+            ro = re.search(
+                r"[^.\d]*([\d.]+)\s*(cm|in|pt)?", x
+            )  # float followed by unit
             if ro:
-                x, unit = ro.groups ()  # unit == None when not present
-                u = {'cm':10., 'in':25.4, 'pt':25.4/72} [unit] if unit else 1.
-                s.pageFmtAbc [n] = float (x) * u   # convert ABC values to millimeters
-            else: info ('error in page format: %s' % x)
-        def readPercMap (x):    # parse I:percmap <abc_note> <step> <MIDI> <notehead>
-            def getMidNum (sndnm):          # find midi number of GM drum sound name
-                pnms = sndnm.split ('-')    # sound name parts (from I:percmap)
-                ps = s.percsnd [:]          # copy of the instruments
-                _f = lambda ip, xs, pnm: ip < len (xs) and xs[ip].find (pnm) > -1   # part xs[ip] and pnm match
-                for ip, pnm in enumerate (pnms):    # match all percmap sound name parts
-                    ps = [(nm, mnum) for nm, mnum in ps if _f (ip, nm.split ('-'), pnm) ]   # filter instruments
-                    if len (ps) <= 1: break # no match or one instrument left
-                if len (ps) == 0: info ('drum sound: %s not found' % sndnm); return '38'
-                return ps [0][1]            # midi number of (first) instrument found
-            def midiVal (acc, step, oct):   # abc note -> midi note number
-                oct = (4 if step.upper() == step else 5) + int (oct)
-                return oct * 12 + [0,2,4,5,7,9,11]['CDEFGAB'.index (step.upper())] + {'^':1,'_':-1,'=':0}.get (acc, 0) + 12
-            p0, p1, p2, p3, p4 = abc_percmap.parseString (x).asList ()  # percmap, abc-note, display-step, midi, note-head
-            acc, astep, aoct = p1
-            nstep, noct = (astep, aoct) if p2 == '*' else p2
-            if p3 == '*':                           midi = str (midiVal (acc, astep, aoct))
-            elif isinstance (p3, list_type):        midi = str (midiVal (p3[0], p3[1], p3[2]))
-            elif isinstance (p3, int_type):         midi = str (p3)
-            else:                                   midi = getMidNum (p3.lower ())
-            head = re.sub (r'(.)-([^x])', r'\1 \2', p4) # convert abc note head names to xml
-            s.percMap [(s.pid, acc + astep, aoct)] = (nstep, noct, midi, head)
-        if x.startswith ('score') or x.startswith ('staves'):
-            s.staveDefs += [x]          # collect all voice mappings
-        elif x.startswith ('staffwidth'): info ('skipped I-field: %s' % x)
-        elif x.startswith ('staff'):    # set new staff number of the current voice
-            r1 = re.search (r'staff *([+-]?)(\d)', x)
-            if r1:
-                sign = r1.group (1)
-                num = int (r1.group (2))
-                gstaff = s.gStaffNums.get (s.vid, 0)    # staff number of the current voice
-                if sign:                                # relative staff number
-                    num = (sign == '-') and gstaff - num or gstaff + num
-                else:                                   # absolute abc staff number
-                    try: vabc = s.staves [num - 1][0]   # vid of (first voice of) abc-staff num
-                    except: vabc = 0; info ('abc staff %s does not exist' % num)
-                    num = s.gStaffNumsOrg.get (vabc, 0) # xml staff number of abc-staff num
-                if gstaff and num > 0 and num <= s.gNstaves [s.vid]:
-                    s.gStaffNums [s.vid] = num
-                else: info ('could not relocate to staff: %s' % r1.group ())
-            else: info ('not a valid staff redirection: %s' % x)
-        elif x.startswith ('scale'): readPfmt (x, 0)
-        elif x.startswith ('pageheight'): readPfmt (x, 1)
-        elif x.startswith ('pagewidth'): readPfmt (x, 2)
-        elif x.startswith ('leftmargin'): readPfmt (x, 3)
-        elif x.startswith ('rightmargin'): readPfmt (x, 4)
-        elif x.startswith ('topmargin'): readPfmt (x, 5)
-        elif x.startswith ('botmargin'): readPfmt (x, 6)
-        elif x.startswith ('MIDI') or x.startswith ('midi'):
-            r1 = re.search (r'program *(\d*) +(\d+)', x)
-            r2 = re.search (r'channel *(\d+)', x)
-            r3 = re.search (r"drummap\s+([_=^]*)([A-Ga-g])([,']*)\s+(\d+)", x)
-            r4 = re.search (r'control *(\d+) +(\d+)', x)
-            ch_nw, prg_nw, vol_nw, pan_nw = '', '', '', ''
-            if r1: ch_nw, prg_nw = r1.groups () # channel nr or '', program nr
-            if r2: ch_nw = r2.group (1)         # channel nr only
-            if r4:
-                cnum, cval = r4.groups ()       # controller number, controller value
-                if cnum == '7': vol_nw = cval
-                if cnum == '10': pan_nw = cval
-            if r1 or r2 or r4:
-                ch  = ch_nw  or s.midprg [0]
-                prg = prg_nw or s.midprg [1]
-                vol = vol_nw or s.midprg [2]
-                pan = pan_nw or s.midprg [3]
-                instId = 'I%s-%s' % (s.pid, s.vid)              # only look for real instruments, no percussion
-                if instId in s.midiInst: instChange (ch, prg)   # instChance -> doFields
-                s.midprg = [ch, prg, vol, pan]  # mknote: new instrument -> s.midiInst
-            if r3:      # translate drummap to percmap
-                acc, step, oct, midi = r3.groups ()
-                oct = -len (oct) if ',' in x else len (oct)
-                notehead = 'x' if acc == '^' else 'circle-x' if acc == '_' else 'normal'
-                s.percMap [(s.pid, acc + step, oct)] = (step, oct, midi, notehead)
-            r = re.search (r'transpose[^-\d]*(-?\d+)', x)
-            if r: addTrans (r.group (1))        # addTrans -> doFields
-        elif x.startswith ('percmap'): readPercMap (x); s.pMapFound = 1
-        else: info ('skipped I-field: %s' % x)
-
-    def parseStaveDef (s, vdefs):
-        for vid in vdefs: s.vcepid [vid] = vid              # default: each voice becomes an xml part
-        if not s.staveDefs: return vdefs
-        for x in s.staveDefs [1:]: info ('%%%%%s dropped, multiple stave mappings not supported' % x)
-        x = s.staveDefs [0]                                 # only the first %%score is honoured
-        score = abc_scoredef.parseString (x) [0]
-        f = lambda x: type (x) == uni_type and [x] or x
-        s.staves = lmap (f, mkStaves (score, vdefs))        # [[vid] for each staff]
-        s.grands = lmap (f, mkGrand (score, vdefs))         # [staff-id], staff-id == [vid][0]
-        s.groups = mkGroups (score)
-        vce_groups = [vids for vids in s.staves if len (vids) > 1]  # all voice groups
-        d = {}                                              # for each voice group: map first voice id -> all merged voice ids
-        for vgr in vce_groups: d [vgr[0]] = vgr
-        for gstaff in s.grands:                             # for all grand staves
-            if len (gstaff) == 1: continue                  # skip single parts
-            for v, stf_num in zip (gstaff, range (1, len (gstaff) + 1)):
-                for vx in d.get (v, [v]):                   # allocate staff numbers
-                    s.gStaffNums [vx] = stf_num             # to all constituant voices
-                    s.gNstaves [vx] = len (gstaff)          # also remember total number of staves
-        s.gStaffNumsOrg = s.gStaffNums.copy ()              # keep original allocation for abc -> xml staff map
-        for xmlpart in s.grands:
-            pid = xmlpart [0]                               # part id == first staff id == first voice id
-            vces = [v for stf in xmlpart for v in d.get (stf, [stf])]
-            for v in vces: s.vcepid [v] = pid
-        return vdefs
-
-    def voiceNamesAndMaps (s, ps):  # get voice names and mappings
-        vdefs = {}
-        for vid, vcedef, vce in ps: # vcedef == emtpy or first pObj == voice definition
-            pname, psubnm = '', ''  # part name and abbreviation
-            if not vcedef:          # simple abc without voice definitions
-                vdefs [vid] =  pname, psubnm, ''
-            else:                   # abc with voice definitions
-                if vid != vcedef.t[1]: info ('voice ids unequal: %s (reg-ex) != %s (grammar)' % (vid, vcedef.t[1]))
-                rn = re.search (r'(?:name|nm)="([^"]*)"', vcedef.t[2])
-                if rn: pname = rn.group (1)
-                rn = re.search (r'(?:subname|snm|sname)="([^"]*)"', vcedef.t[2])
-                if rn: psubnm = rn.group (1)
-                vcedef.t[2] = vcedef.t[2].replace ('"%s"' % pname, '""').replace ('"%s"' % psubnm, '""')   # clear voice name to avoid false clef matches later on
-                vdefs [vid] =  pname, psubnm, vcedef.t[2]
-            xs = [pObj.t[1] for maat in vce for pObj in maat if pObj.name == 'inline']  # all inline statements in vce
-            s.staveDefs += [x.replace ('%5d',']') for x in xs if x.startswith ('score') or x.startswith ('staves')] # filter %%score and %%staves
-        return vdefs
-
-    def doHeaderField (s, fld, attrmap):
-        type, value = fld.t[0], fld.t[1].replace ('%5d',']')    # restore closing brackets (see splitHeaderVoices)
-        if not value:    # skip empty field
-            return
-        if type == 'M':
-            attrmap [type] = value
-        elif type == 'L':
-            try: s.unitL = lmap (int, fld.t[1].split ('/'))
-            except:
-                info ('illegal unit length:%s, 1/8 assumed' % fld.t[1])
-                s.unitL = 1,8
-            if len (s.unitL) == 1 or s.unitL[1] not in s.typeMap:
-                info ('L:%s is not allowed, 1/8 assumed' % fld.t[1])
-                s.unitL = 1,8
-        elif type == 'K':
-            attrmap[type] = value
-        elif type == 'T':
-            s.title = s.title + '\n' + value if s.title else value
-        elif type == 'U':
-            sym = fld.t[2].strip ('!+')
-            s.usrSyms [value] = sym
-        elif type == 'I':
-            s.doField_I (type, value, lambda x,y,z:0, lambda x:0)
-        elif type == 'Q':
-            attrmap[type] = value
-        elif type in 'CRZNOAGHBDFSP':           # part maps are treated as meta data
-            type = s.metaMap.get (type, type)   # respect the (user defined --meta) mapping of various ABC fields to XML meta data types
-            c = s.metadata.get (type, '')
-            s.metadata [type] = c + '\n' + value if c else value    # concatenate multiple info fields with new line as separator
-        else:
-            info ('skipped header: %s' % fld)
-
-    def mkIdentification (s, score, lev):
-        if s.title:
-            xs = s.title.split ('\n')   # the first T: line goes to work-title
-            ys = '\n'.join (xs [1:])    # place subsequent T: lines into work-number
-            w = E.Element ('work')
-            addElem (score, w, lev + 1)
-            if ys: addElemT (w, 'work-number', ys, lev + 2)
-            addElemT (w, 'work-title', xs[0], lev + 2)
-        ident = E.Element ('identification')
-        addElem (score, ident, lev + 1)
-        for mtype, mval in s.metadata.items ():
-            if mtype in s.metaTypes and mtype != 'rights':    # all metaTypes are MusicXML creator types
-                c = E.Element ('creator', type=mtype)
-                c.text = mval
-                addElem (ident, c, lev + 2)
-        if 'rights' in s.metadata:
-            c = addElemT (ident, 'rights', s.metadata ['rights'], lev + 2)
-        encoding = E.Element ('encoding')
-        addElem (ident, encoding, lev + 2)
-        encoder = E.Element ('encoder')
-        encoder.text = 'abc2xml version %d' % VERSION
-        addElem (encoding, encoder, lev + 3)
-        if s.supports_tag:  # avoids interference of auto-flowing and explicit linebreaks
-            suports = E.Element ('supports', attribute="new-system", element="print", type="yes", value="yes")
-            addElem (encoding, suports, lev + 3)
-        encodingDate = E.Element ('encoding-date')
-        encodingDate.text = str (datetime.date.today ())
-        addElem (encoding, encodingDate, lev + 3)
-        s.addMeta (ident, lev + 2)
-
-    def mkDefaults (s, score, lev):
-        if s.pageFmtCmd: s.pageFmtAbc = s.pageFmtCmd
-        if not s.pageFmtAbc: return # do not output the defaults if none is desired
-        abcScale, h, w, l, r, t, b = s.pageFmtAbc
-        space = abcScale * 2.117    # 2.117 = 6pt = space between staff lines for scale = 1.0 in abcm2ps
-        mils = 4 * space    # staff height in millimeters
-        scale = 40. / mils  # tenth's per millimeter
-        dflts = E.Element ('defaults')
-        addElem (score, dflts, lev)
-        scaling = E.Element ('scaling')
-        addElem (dflts, scaling, lev + 1)
-        addElemT (scaling, 'millimeters', '%g' % mils, lev + 2)
-        addElemT (scaling, 'tenths', '40', lev + 2)
-        layout = E.Element ('page-layout')
-        addElem (dflts, layout, lev + 1)
-        addElemT (layout, 'page-height', '%g' % (h * scale), lev + 2)
-        addElemT (layout, 'page-width', '%g' % (w * scale), lev + 2)
-        margins = E.Element ('page-margins', type='both')
-        addElem (layout, margins, lev + 2)
-        addElemT (margins, 'left-margin', '%g' % (l * scale), lev + 3)
-        addElemT (margins, 'right-margin', '%g' % (r * scale), lev + 3)
-        addElemT (margins, 'top-margin', '%g' % (t * scale), lev + 3)
-        addElemT (margins, 'bottom-margin', '%g' % (b * scale), lev + 3)
-
-    def addMeta (s, parent, lev):
-        misc = E.Element ('miscellaneous')
-        mf = 0
-        for mtype, mval in sorted (s.metadata.items ()):
-            if mtype == 'S':
-                addElemT (parent, 'source', mval, lev)
-            elif mtype in s.metaTypes: continue  # mapped meta data has already been output (in creator elements)
+                x, unit = ro.groups()  # unit == None when not present
+                u = {"cm": 10.0, "in": 25.4, "pt": 25.4 / 72}[unit] if unit else 1.0
+                s.pageFmtAbc[n] = float(x) * u  # convert ABC values to millimeters
             else:
-                mf = E.Element ('miscellaneous-field', name=s.metaTab [mtype])
-                mf.text = mval
-                addElem (misc, mf, lev + 1)
-        if mf != 0: addElem (parent, misc, lev)
+                info("error in page format: %s" % x)
 
-    def parse (s, abc_string, rOpt=False, bOpt=False, fOpt=False):
-        abctext = abc_string.replace ('[I:staff ','[I:staff')  # avoid false beam breaks
-        s.reset (fOpt)
-        header, voices = splitHeaderVoices (abctext)
+        def readPercMap(x):  # parse I:percmap <abc_note> <step> <MIDI> <notehead>
+            def getMidNum(sndnm):  # find midi number of GM drum sound name
+                pnms = sndnm.split("-")  # sound name parts (from I:percmap)
+                ps = s.percsnd[:]  # copy of the instruments
+                
+                def _f(ip, xs, pnm):
+                    return ip < len(xs) and xs[ip].find(pnm) > -1  # part xs[ip] and pnm match
+                for ip, pnm in enumerate(pnms):  # match all percmap sound name parts
+                    ps = [
+                        (nm, mnum) for nm, mnum in ps if _f(ip, nm.split("-"), pnm)
+                    ]  # filter instruments
+                    if len(ps) <= 1:
+                        break  # no match or one instrument left
+                if len(ps) == 0:
+                    info("drum sound: %s not found" % sndnm)
+                    return "38"
+                return ps[0][1]  # midi number of (first) instrument found
+
+            def midiVal(acc, step, oct):  # abc note -> midi note number
+                oct = (4 if step.upper() == step else 5) + int(oct)
+                return (
+                    oct * 12
+                    + [0, 2, 4, 5, 7, 9, 11]["CDEFGAB".index(step.upper())]
+                    + {"^": 1, "_": -1, "=": 0}.get(acc, 0)
+                    + 12
+                )
+
+            p0, p1, p2, p3, p4 = abc_percmap.parseString(
+                x
+            ).asList()  # percmap, abc-note, display-step, midi, note-head
+            acc, astep, aoct = p1
+            nstep, noct = (astep, aoct) if p2 == "*" else p2
+            if p3 == "*":
+                midi = str(midiVal(acc, astep, aoct))
+            elif isinstance(p3, list_type):
+                midi = str(midiVal(p3[0], p3[1], p3[2]))
+            elif isinstance(p3, int_type):
+                midi = str(p3)
+            else:
+                midi = getMidNum(p3.lower())
+            head = re.sub(
+                r"(.)-([^x])", r"\1 \2", p4
+            )  # convert abc note head names to xml
+            s.percMap[(s.pid, acc + astep, aoct)] = (nstep, noct, midi, head)
+
+        if x.startswith("score") or x.startswith("staves"):
+            s.staveDefs += [x]  # collect all voice mappings
+        elif x.startswith("staffwidth"):
+            info("skipped I-field: %s" % x)
+        elif x.startswith("staff"):  # set new staff number of the current voice
+            r1 = re.search(r"staff *([+-]?)(\d)", x)
+            if r1:
+                sign = r1.group(1)
+                num = int(r1.group(2))
+                gstaff = s.gStaffNums.get(s.vid, 0)  # staff number of the current voice
+                if sign:  # relative staff number
+                    num = (sign == "-") and gstaff - num or gstaff + num
+                else:  # absolute abc staff number
+                    try:
+                        vabc = s.staves[num - 1][
+                            0
+                        ]  # vid of (first voice of) abc-staff num
+                    except Exception:
+                        vabc = 0
+                        info("abc staff %s does not exist" % num)
+                    num = s.gStaffNumsOrg.get(
+                        vabc, 0
+                    )  # xml staff number of abc-staff num
+                if gstaff and num > 0 and num <= s.gNstaves[s.vid]:
+                    s.gStaffNums[s.vid] = num
+                else:
+                    info("could not relocate to staff: %s" % r1.group())
+            else:
+                info("not a valid staff redirection: %s" % x)
+        elif x.startswith("scale"):
+            readPfmt(x, 0)
+        elif x.startswith("pageheight"):
+            readPfmt(x, 1)
+        elif x.startswith("pagewidth"):
+            readPfmt(x, 2)
+        elif x.startswith("leftmargin"):
+            readPfmt(x, 3)
+        elif x.startswith("rightmargin"):
+            readPfmt(x, 4)
+        elif x.startswith("topmargin"):
+            readPfmt(x, 5)
+        elif x.startswith("botmargin"):
+            readPfmt(x, 6)
+        elif x.startswith("MIDI") or x.startswith("midi"):
+            r1 = re.search(r"program *(\d*) +(\d+)", x)
+            r2 = re.search(r"channel *(\d+)", x)
+            r3 = re.search(r"drummap\s+([_=^]*)([A-Ga-g])([,']*)\s+(\d+)", x)
+            r4 = re.search(r"control *(\d+) +(\d+)", x)
+            ch_nw, prg_nw, vol_nw, pan_nw = "", "", "", ""
+            if r1:
+                ch_nw, prg_nw = r1.groups()  # channel nr or '', program nr
+            if r2:
+                ch_nw = r2.group(1)  # channel nr only
+            if r4:
+                cnum, cval = r4.groups()  # controller number, controller value
+                if cnum == "7":
+                    vol_nw = cval
+                if cnum == "10":
+                    pan_nw = cval
+            if r1 or r2 or r4:
+                ch = ch_nw or s.midprg[0]
+                prg = prg_nw or s.midprg[1]
+                vol = vol_nw or s.midprg[2]
+                pan = pan_nw or s.midprg[3]
+                instId = "I%s-%s" % (s.pid, "")  # only look for real instruments, no percussion
+                if instId in s.midiInst:
+                    instChange(ch, prg)  # instChance -> doFields
+                s.midprg = [ch, prg, vol, pan]  # mknote: new instrument -> s.midiInst
+            if r3:  # translate drummap to percmap
+                acc, step, oct, midi = r3.groups()
+                oct = -len(oct) if "," in x else len(oct)
+                notehead = "x" if acc == "^" else "circle-x" if acc == "_" else "normal"
+                s.percMap[(s.pid, acc + step, oct)] = (step, oct, midi, notehead)
+            r = re.search(r"transpose[^-\d]*(-?\d+)", x)
+            if r:
+                addTrans(r.group(1))  # addTrans -> doFields
+        elif x.startswith("percmap"):
+            readPercMap(x)
+            s.pMapFound = 1
+        else:
+            info("skipped I-field: %s" % x)
+
+    def parseStaveDef(s, vdefs):
+        for vid in vdefs:
+            s.vcepid[vid] = vid  # default: each voice becomes an xml part
+        if not s.staveDefs:
+            return vdefs
+        for x in s.staveDefs[1:]:
+            info("%%%%%s dropped, multiple stave mappings not supported" % x)
+        x = s.staveDefs[0]  # only the first %%score is honoured
+        score = abc_scoredef.parseString(x)[0]
+
+        def f(x):
+            return [x] if isinstance(x, uni_type) else x
+        s.staves = lmap(f, mkStaves(score, vdefs))  # [[vid] for each staff]
+        s.grands = lmap(f, mkGrand(score, vdefs))  # [staff-id], staff-id == [vid][0]
+        s.groups = mkGroups(score)
+        vce_groups = [vids for vids in s.staves if len(vids) > 1]  # all voice groups
+        d = {}  # for each voice group: map first voice id -> all merged voice ids
+        for vgr in vce_groups:
+            d[vgr[0]] = vgr
+        for gstaff in s.grands:  # for all grand staves
+            if len(gstaff) == 1:
+                continue  # skip single parts
+            for v, stf_num in zip(gstaff, range(1, len(gstaff) + 1)):
+                for vx in d.get(v, [v]):  # allocate staff numbers
+                    s.gStaffNums[vx] = stf_num  # to all constituant voices
+                    s.gNstaves[vx] = len(gstaff)  # also remember total number of staves
+        s.gStaffNumsOrg = (
+            s.gStaffNums.copy()
+        )  # keep original allocation for abc -> xml staff map
+        for xmlpart in s.grands:
+            pid = xmlpart[0]  # part id == first staff id == first voice id
+            vces = [v for stf in xmlpart for v in d.get(stf, [stf])]
+            for v in vces:
+                s.vcepid[v] = pid
+        return vdefs
+
+    def voiceNamesAndMaps(s, ps):  # get voice names and mappings
+        vdefs = {}
+        for vid, vcedef, vce in ps:  # vcedef == emtpy or first pObj == voice definition
+            pname, psubnm = "", ""  # part name and abbreviation
+            if not vcedef:  # simple abc without voice definitions
+                vdefs[vid] = pname, psubnm, ""
+            else:  # abc with voice definitions
+                if vid != vcedef.t[1]:
+                    info(
+                        "voice ids unequal: %s (reg-ex) != %s (grammar)"
+                        % (vid, vcedef.t[1])
+                    )
+                rn = re.search(r'(?:name|nm)="([^"]*)"', vcedef.t[2])
+                if rn:
+                    pname = rn.group(1)
+                rn = re.search(r'(?:subname|snm|sname)="([^"]*)"', vcedef.t[2])
+                if rn:
+                    psubnm = rn.group(1)
+                vcedef.t[2] = (
+                    vcedef.t[2]
+                    .replace('"%s"' % pname, '""')
+                    .replace('"%s"' % psubnm, '""')
+                )  # clear voice name to avoid false clef matches later on
+                vdefs[vid] = pname, psubnm, vcedef.t[2]
+            xs = [
+                pObj.t[1] for maat in vce for pObj in maat if pObj.name == "inline"
+            ]  # all inline statements in vce
+            s.staveDefs += [
+                x.replace("%5d", "]")
+                for x in xs
+                if x.startswith("score") or x.startswith("staves")
+            ]  # filter %%score and %%staves
+        return vdefs
+
+    def doHeaderField(s, fld, attrmap):
+        type, value = fld.t[0], fld.t[1].replace(
+            "%5d", "]"
+        )  # restore closing brackets (see splitHeaderVoices)
+        if not value:  # skip empty field
+            return
+        if type == "M":
+            attrmap[type] = value
+        elif type == "L":
+            try:
+                s.unitL = lmap(int, fld.t[1].split("/"))
+            except Exception:
+                info("illegal unit length:%s, 1/8 assumed" % fld.t[1])
+                s.unitL = 1, 8
+            if len(s.unitL) == 1 or s.unitL[1] not in s.typeMap:
+                info("L:%s is not allowed, 1/8 assumed" % fld.t[1])
+                s.unitL = 1, 8
+        elif type == "K":
+            attrmap[type] = value
+        elif type == "T":
+            s.title = s.title + "\n" + value if s.title else value
+        elif type == "U":
+            sym = fld.t[2].strip("!+")
+            s.usrSyms[value] = sym
+        elif type == "I":
+            s.doField_I(type, value, lambda x, y, z: 0, lambda x: 0)
+        elif type == "Q":
+            attrmap[type] = value
+        elif type in "CRZNOAGHBDFSPW":  # part maps are treated as meta data
+            type = s.metaMap.get(
+                type, type
+            )  # respect the (user defined --meta) mapping of various ABC fields to XML meta data types
+            c = s.metadata.get(type, "")
+            s.metadata[type] = (
+                c + "\n" + value if c else value
+            )  # concatenate multiple info fields with new line as separator
+        else:
+            info("skipped header: %s" % fld)
+
+    def mkIdentification(s, score, lev):
+        if s.title:
+            xs = s.title.split("\n")  # the first T: line goes to work-title
+            ys = "\n".join(xs[1:])  # place subsequent T: lines into work-number
+            w = E.Element("work")
+            addElem(score, w, lev + 1)
+            if ys:
+                addElemT(w, "work-number", ys, lev + 2)
+            addElemT(w, "work-title", xs[0], lev + 2)
+        ident = E.Element("identification")
+        addElem(score, ident, lev + 1)
+        for mtype, mval in s.metadata.items():
+            if (
+                mtype in s.metaTypes and mtype != "rights"
+            ):  # all metaTypes are MusicXML creator types
+                c = E.Element("creator", type=mtype)
+                c.text = mval
+                addElem(ident, c, lev + 2)
+        if "rights" in s.metadata:
+            c = addElemT(ident, "rights", s.metadata["rights"], lev + 2)
+        encoding = E.Element("encoding")
+        addElem(ident, encoding, lev + 2)
+        encoder = E.Element("encoder")
+        encoder.text = "abc2xml version %d" % VERSION
+        addElem(encoding, encoder, lev + 3)
+        if (
+            s.supports_tag
+        ):  # avoids interference of auto-flowing and explicit linebreaks
+            suports = E.Element(
+                "supports",
+                attribute="new-system",
+                element="print",
+                type="yes",
+                value="yes",
+            )
+            addElem(encoding, suports, lev + 3)
+        encodingDate = E.Element("encoding-date")
+        encodingDate.text = str(datetime.date.today())
+        addElem(encoding, encodingDate, lev + 3)
+        s.addMeta(ident, lev + 2)
+
+    def mkDefaults(s, score, lev):
+        if s.pageFmtCmd:
+            s.pageFmtAbc = s.pageFmtCmd
+        if not s.pageFmtAbc:
+            return  # do not output the defaults if none is desired
+        abcScale, h, w, l, r, t, b = s.pageFmtAbc
+        space = (
+            abcScale * 2.117
+        )  # 2.117 = 6pt = space between staff lines for scale = 1.0 in abcm2ps
+        mils = 4 * space  # staff height in millimeters
+        scale = 40.0 / mils  # tenth's per millimeter
+        dflts = E.Element("defaults")
+        addElem(score, dflts, lev)
+        scaling = E.Element("scaling")
+        addElem(dflts, scaling, lev + 1)
+        addElemT(scaling, "millimeters", "%g" % mils, lev + 2)
+        addElemT(scaling, "tenths", "40", lev + 2)
+        layout = E.Element("page-layout")
+        addElem(dflts, layout, lev + 1)
+        addElemT(layout, "page-height", "%g" % (h * scale), lev + 2)
+        addElemT(layout, "page-width", "%g" % (w * scale), lev + 2)
+        margins = E.Element("page-margins", type="both")
+        addElem(layout, margins, lev + 2)
+        addElemT(margins, "left-margin", "%g" % (l * scale), lev + 3)
+        addElemT(margins, "right-margin", "%g" % (r * scale), lev + 3)
+        addElemT(margins, "top-margin", "%g" % (t * scale), lev + 3)
+        addElemT(margins, "bottom-margin", "%g" % (b * scale), lev + 3)
+
+    def addMeta(s, parent, lev):
+        misc = E.Element("miscellaneous")
+        mf = 0
+        for mtype, mval in sorted(s.metadata.items()):
+            if mtype == "S":
+                addElemT(parent, "source", mval, lev)
+            elif mtype in s.metaTypes:
+                continue  # mapped meta data has already been output (in creator elements)
+            else:
+                mf = E.Element("miscellaneous-field", name=s.metaTab[mtype])
+                mf.text = mval
+                addElem(misc, mf, lev + 1)
+        if mf != 0:
+            addElem(parent, misc, lev)
+
+    def parse(s, abc_string, rOpt=False, bOpt=False, fOpt=False):
+        abctext = abc_string.replace("[I:staff ", "[I:staff")  # avoid false beam breaks
+        s.reset(fOpt)
+        header, voices = splitHeaderVoices(abctext)
         ps = []
         try:
-            lbrk_insert = 0 if re.search (r'I:linebreak\s*([!$]|none)|I:continueall\s*(1|true)', header) else bOpt
-            hs = abc_header.parseString (header) if header else ''
+            lbrk_insert = (
+                0
+                if re.search(
+                    r"I:linebreak\s*([!$]|none)|I:continueall\s*(1|true)", header
+                )
+                else bOpt
+            )
+            hs = abc_header.parseString(header) if header else ""
             for id, voice in voices:
-                if lbrk_insert:                                 # insert linebreak at EOL
-                    r1 = re.compile (r'\[[wA-Z]:[^]]*\]')       # inline field
-                    has_abc = lambda x: r1.sub ('', x).strip () # empty if line only contains inline fields
-                    voice = '\n'.join ([balk.rstrip ('$!') + '$' if has_abc (balk) else balk for balk in voice.splitlines ()])
-                prevLeftBar = None      # previous voice ended with a left-bar symbol (double repeat)
-                s.orderChords = s.fOpt and ('tab' in voice [:200] or [x for x in hs if x.t[0] == 'K' and 'tab' in x.t[1]])
-                vce = abc_voice.parseString (voice).asList ()
-                lyr_notes = []          # remember notes between lyric blocks
-                for m in vce:           # all measures
-                    for e in m:         # all abc-elements
-                        if e.name == 'lyr_blk':         # -> e.objs is list of lyric lines
-                            lyr = [line.objs for line in e.objs]    # line.objs is listof syllables
-                            alignLyr (lyr_notes, lyr)   # put all syllables into corresponding notes
+                if lbrk_insert:  # insert linebreak at EOL
+                    r1 = re.compile(r"\[[wA-Z]:[^]]*\]")  # inline field
+                    
+                    def has_abc(x):
+                        return r1.sub("", x).strip()  # empty if line only contains inline fields
+                    voice = "\n".join(
+                        [
+                            balk.rstrip("$!") + "$" if has_abc(balk) else balk
+                            for balk in voice.splitlines()
+                        ]
+                    )
+                prevLeftBar = (
+                    None  # previous voice ended with a left-bar symbol (double repeat)
+                )
+                s.orderChords = s.fOpt and (
+                    "tab" in voice[:200]
+                    or [x for x in hs if x.t[0] == "K" and "tab" in x.t[1]]
+                )
+                vce = abc_voice.parseString(voice).asList()
+                lyr_notes = []  # remember notes between lyric blocks
+                for m in vce:  # all measures
+                    for e in m:  # all abc-elements
+                        if e.name == "lyr_blk":  # -> e.objs is list of lyric lines
+                            lyr = [
+                                line.objs for line in e.objs
+                            ]  # line.objs is listof syllables
+                            alignLyr(
+                                lyr_notes, lyr
+                            )  # put all syllables into corresponding notes
                             lyr_notes = []
                         else:
-                            lyr_notes.append (e)
-                if not vce:             # empty voice, insert an inline field that will be rejected
-                    vce = [[pObj ('inline', ['I', 'empty voice'])]]
+                            lyr_notes.append(e)
+                if not vce:  # empty voice, insert an inline field that will be rejected
+                    vce = [[pObj("inline", ["I", "empty voice"])]]
                 if prevLeftBar:
-                    vce[0].insert (0, prevLeftBar)  # insert at begin of first measure
+                    vce[0].insert(0, prevLeftBar)  # insert at begin of first measure
                     prevLeftBar = None
-                if vce[-1] and vce[-1][-1].name == 'lbar':  # last measure ends with an lbar
+                if (
+                    vce[-1] and vce[-1][-1].name == "lbar"
+                ):  # last measure ends with an lbar
                     prevLeftBar = vce[-1][-1]
-                    if len (vce) > 1:   # vce should not become empty (-> exception when taking vcelyr [0][0])
-                        del vce[-1]     # lbar was the only element in measure vce[-1]
+                    if (
+                        len(vce) > 1
+                    ):  # vce should not become empty (-> exception when taking vcelyr [0][0])
+                        del vce[-1]  # lbar was the only element in measure vce[-1]
                 vcelyr = vce
-                elem1 = vcelyr [0][0]   # the first element of the first measure
-                if  elem1.name == 'inline'and elem1.t[0] == 'V':    # is a voice definition
-                    voicedef = elem1 
-                    del vcelyr [0][0]   # do not read voicedef twice
+                elem1 = vcelyr[0][0]  # the first element of the first measure
+                if (
+                    elem1.name == "inline" and elem1.t[0] == "V"
+                ):  # is a voice definition
+                    voicedef = elem1
+                    del vcelyr[0][0]  # do not read voicedef twice
                 else:
-                    voicedef = ''
-                ps.append ((id, voicedef, vcelyr))
+                    voicedef = ""
+                ps.append((id, voicedef, vcelyr))
         except ParseException as err:
-            if err.loc > 40:    # limit length of error message, compatible with markInputline
-                err.pstr = err.pstr [err.loc - 40: err.loc + 40]
+            if (
+                err.loc > 40
+            ):  # limit length of error message, compatible with markInputline
+                err.pstr = err.pstr[err.loc - 40 : err.loc + 40]
                 err.loc = 40
-            xs = err.line[err.col-1:]
-            info (err.line, warn=0)
-            info ((err.col-1) * '-' + '^', warn=0)
-            if   re.search (r'\[U:', xs):
-                info ('Error: illegal user defined symbol: %s' % xs[1:], warn=0)
-            elif re.search (r'\[[OAPZNGHRBDFSXTCIU]:', xs):
-                info ('Error: header-only field %s appears after K:' % xs[1:], warn=0)
+            xs = err.line[err.col - 1 :]
+            info(err.line, warn=0)
+            info((err.col - 1) * "-" + "^", warn=0)
+            if re.search(r"\[U:", xs):
+                info("Error: illegal user defined symbol: %s" % xs[1:], warn=0)
+            elif re.search(r"\[[OAPZNGHRBDFSXTCIU]:", xs):
+                info("Error: header-only field %s appears after K:" % xs[1:], warn=0)
             else:
-                info ('Syntax error at column %d' % err.col, warn=0)
+                info("Syntax error at column %d" % err.col, warn=0)
             raise
 
-        score = E.Element ('score-partwise')
-        attrmap = {'Div': str (s.divisions), 'K':'C treble', 'M':'4/4'}
+        score = E.Element("score-partwise")
+        attrmap = {"Div": str(s.divisions), "K": "C treble", "M": "4/4"}
         for res in hs:
-            if res.name == 'field':
-                s.doHeaderField (res, attrmap)
+            if res.name == "field":
+                s.doHeaderField(res, attrmap)
             else:
-                info ('unexpected header item: %s' % res)
+                info("unexpected header item: %s" % res)
 
-        vdefs = s.voiceNamesAndMaps (ps)
-        vdefs = s.parseStaveDef (vdefs)
+        vdefs = s.voiceNamesAndMaps(ps)
+        vdefs = s.parseStaveDef(vdefs)
 
         lev = 0
         vids, parts, partAttr = [], [], {}
-        s.strAlloc = stringAlloc ()
-        for vid, _, vce in ps:          # voice id, voice parse tree
-            pname, psubnm, voicedef = vdefs [vid]   # part name
-            attrmap ['V'] = voicedef    # abc text of first voice definition (after V:vid) or empty
-            pid = 'P%s' % vid           # let part id start with an alpha
-            s.vid = vid                 # avoid parameter passing, needed in mkNote for instrument id
-            s.pid = s.vcepid [s.vid]    # xml part-id for the current voice
-            s.gTime = (0, 0)            # reset time
-            s.strAlloc.beginZoek ()     # reset search index
-            part = s.mkPart (vce, pid, lev + 1, attrmap, s.gNstaves.get (vid, 0), rOpt)
-            if 'Q' in attrmap: del attrmap ['Q']    # header tempo only in first part
-            parts.append (part)
-            vids.append (vid)
-            partAttr [vid] = (pname, psubnm, s.midprg)
-            if s.midprg != ['', '', '', ''] and not s.percVoice:    # when a part has only rests
-                instId = 'I%s-%s' % (s.pid, s.vid)
-                if instId not in s.midiInst: s.midiInst [instId] = (s.pid, s.vid, s.midprg [0], s.midprg [1], s.midprg [2], s.midprg [3])
-        parts, vidsnew = mergeParts (parts, vids, s.staves, rOpt) # merge parts into staves as indicated by %%score
-        parts, vidsnew = mergeParts (parts, vidsnew, s.grands, rOpt, 1) # merge grand staves
-        reduceMids (parts, vidsnew, s.midiInst)
+        s.strAlloc = stringAlloc()
+        for vid, _, vce in ps:  # voice id, voice parse tree
+            pname, psubnm, voicedef = vdefs[vid]  # part name
+            attrmap["V"] = (
+                voicedef  # abc text of first voice definition (after V:vid) or empty
+            )
+            pid = "P%s" % vid  # let part id start with an alpha
+            s.vid = vid  # avoid parameter passing, needed in mkNote for instrument id
+            s.pid = s.vcepid[s.vid]  # xml part-id for the current voice
+            s.gTime = (0, 0)  # reset time
+            s.strAlloc.beginZoek()  # reset search index
+            part = s.mkPart(vce, pid, lev + 1, attrmap, s.gNstaves.get(vid, 0), rOpt)
+            if "Q" in attrmap:
+                del attrmap["Q"]  # header tempo only in first part
+            parts.append(part)
+            vids.append(vid)
+            partAttr[vid] = (pname, psubnm, s.midprg)
+            if (
+                s.midprg != ["", "", "", ""] and not s.percVoice
+            ):  # when a part has only rests
+                instId = "I%s-%s" % (s.pid, s.vid)
+                if instId not in s.midiInst:
+                    s.midiInst[instId] = (
+                        s.pid,
+                        s.vid,
+                        s.midprg[0],
+                        s.midprg[1],
+                        s.midprg[2],
+                        s.midprg[3],
+                    )
+        parts, vidsnew = mergeParts(
+            parts, vids, s.staves, rOpt
+        )  # merge parts into staves as indicated by %%score
+        parts, vidsnew = mergeParts(
+            parts, vidsnew, s.grands, rOpt, 1
+        )  # merge grand staves
+        reduceMids(parts, vidsnew, s.midiInst)
 
-        s.mkIdentification (score, lev)
-        s.mkDefaults (score, lev + 1)
+        s.mkIdentification(score, lev)
+        s.mkDefaults(score, lev + 1)
 
-        partlist = s.mkPartlist (vids, partAttr, lev + 1)
-        addElem (score, partlist, lev + 1)
-        for ip, part in enumerate (parts): addElem (score, part, lev + 1)
+        partlist = s.mkPartlist(vids, partAttr, lev + 1)
+        addElem(score, partlist, lev + 1)
+        for ip, part in enumerate(parts):
+            addElem(score, part, lev + 1)
 
         return score
 
 
-def decodeInput (data_string):
-    try:        enc = 'utf-8';   unicode_string = data_string.decode (enc)
-    except:
-        try:    enc = 'latin-1'; unicode_string = data_string.decode (enc)
-        except: raise ValueError ('data not encoded in utf-8 nor in latin-1')
-    info ('decoded from %s' % enc)
+def decodeInput(data_string):
+    try:
+        enc = "utf-8"
+        unicode_string = data_string.decode(enc)
+    except Exception:
+        try:
+            enc = "latin-1"
+            unicode_string = data_string.decode(enc)
+        except Exception:
+            raise ValueError("data not encoded in utf-8 nor in latin-1")
+    info("decoded from %s" % enc)
     return unicode_string
 
-def ggd (a, b): # greatest common divisor
-    return a if b == 0 else ggd (b, a % b)
 
-xmlVersion = "<?xml version='1.0' encoding='utf-8'?>"    
-def fixDoctype (elem):
-    if python3: xs = E.tostring (elem, encoding='unicode')  # writing to file will auto-encode to utf-8
-    else:       xs = E.tostring (elem, encoding='utf-8')    # keep the string utf-8 encoded for writing to file
-    ys = xs.split ('\n')
-    ys.insert (0, xmlVersion)  # crooked logic of ElementTree lib
-    ys.insert (1, '<!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 3.0 Partwise//EN" "http://www.musicxml.org/dtds/partwise.dtd">')
-    return '\n'.join (ys)
+def ggd(a, b):  # greatest common divisor
+    return a if b == 0 else ggd(b, a % b)
 
-def xml2mxl (pad, fnm, data):   # write xml data to compressed .mxl file
+
+xmlVersion = "<?xml version='1.0' encoding='utf-8'?>"
+
+
+def fixDoctype(elem):
+    if python3:
+        xs = E.tostring(
+            elem, encoding="unicode"
+        )  # writing to file will auto-encode to utf-8
+    else:
+        xs = E.tostring(
+            elem, encoding="utf-8"
+        )  # keep the string utf-8 encoded for writing to file
+    ys = xs.split("\n")
+    ys.insert(0, xmlVersion)  # crooked logic of ElementTree lib
+    ys.insert(
+        1,
+        '<!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 3.0 Partwise//EN" "http://www.musicxml.org/dtds/partwise.dtd">',
+    )
+    return "\n".join(ys)
+
+
+def xml2mxl(pad, fnm, data):  # write xml data to compressed .mxl file
     from zipfile import ZipFile, ZIP_DEFLATED
-    fnmext = fnm + '.xml'       # file name with extension, relative to the root within the archive
-    outfile = os.path.join (pad, fnm + '.mxl')
-    meta  = '%s\n<container><rootfiles>\n' % xmlVersion
-    meta += '<rootfile full-path="%s" media-type="application/vnd.recordare.musicxml+xml"/>\n' % fnmext
-    meta += '</rootfiles></container>'
-    f = ZipFile (outfile, 'w', ZIP_DEFLATED)
-    f.writestr ('META-INF/container.xml', meta)
-    f.writestr (fnmext, data)
-    f.close ()
-    info ('%s written' % outfile, warn=0)
 
-def convert (pad, fnm, abc_string, mxl, rOpt=False, tOpt=False, bOpt=False, fOpt=False):  # not used, backwards compatibility
-    score = mxm.parse (abc_string, rOpt, bOpt, fOpt)
-    writefile (pad, fnm, '', score, mxl, tOpt)
+    fnmext = (
+        fnm + ".xml"
+    )  # file name with extension, relative to the root within the archive
+    outfile = os.path.join(pad, fnm + ".mxl")
+    meta = "%s\n<container><rootfiles>\n" % xmlVersion
+    meta += (
+        '<rootfile full-path="%s" media-type="application/vnd.recordare.musicxml+xml"/>\n'
+        % fnmext
+    )
+    meta += "</rootfiles></container>"
+    f = ZipFile(outfile, "w", ZIP_DEFLATED)
+    f.writestr("META-INF/container.xml", meta)
+    f.writestr(fnmext, data)
+    f.close()
+    info("%s written" % outfile, warn=0)
 
-def writefile (pad, fnm, fnmNum, xmldoc, mxlOpt, tOpt=False):
-    ipad, ifnm = os.path.split (fnm)                    # base name of input path is
+
+def convert(
+    pad, fnm, abc_string, mxl, rOpt=False, tOpt=False, bOpt=False, fOpt=False
+):  # not used, backwards compatibility
+    score = mxm.parse(abc_string, rOpt, bOpt, fOpt)
+    writefile(pad, fnm, "", score, mxl, tOpt)
+
+
+def writefile(pad, fnm, fnmNum, xmldoc, mxlOpt, tOpt=False):
+    ipad, ifnm = os.path.split(fnm)  # base name of input path is
     if tOpt:
-        x = xmldoc.findtext ('work/work-title', 'no_title')
-        ifnm = x.replace (',','_').replace ("'",'_').replace ('?','_')
+        x = xmldoc.findtext("work/work-title", "no_title")
+        ifnm = x.replace(",", "_").replace("'", "_").replace("?", "_")
     else:
         ifnm += fnmNum
-    xmlstr = fixDoctype (xmldoc)
+    xmlstr = fixDoctype(xmldoc)
     if pad:
-        if not mxlOpt or mxlOpt in ['a', 'add']:
-            outfnm = os.path.join (pad, ifnm + '.xml')  # joined with path from -o option
-            outfile = open (outfnm, 'w')
-            outfile.write (xmlstr)
-            outfile.close ()
-            info ('%s written' % outfnm, warn=0)
-        if mxlOpt: xml2mxl (pad, ifnm, xmlstr)          # also write a compressed version
+        if not mxlOpt or mxlOpt in ["a", "add"]:
+            outfnm = os.path.join(pad, ifnm + ".xml")  # joined with path from -o option
+            outfile = open(outfnm, "w")
+            outfile.write(xmlstr)
+            outfile.close()
+            info("%s written" % outfnm, warn=0)
+        if mxlOpt:
+            xml2mxl(pad, ifnm, xmlstr)  # also write a compressed version
     else:
         outfile = sys.stdout
-        outfile.write (xmlstr)
-        outfile.write ('\n')
+        outfile.write(xmlstr)
+        outfile.write("\n")
 
-def readfile (fnmext, errmsg='read error: '):
+
+def readfile(fnmext, errmsg="read error: "):
     try:
-        if fnmext == '-.abc': fobj = stdin  # see python2/3 differences
-        else: fobj = open (fnmext, 'rb')
-        encoded_data = fobj.read ()
-        fobj.close ()
-        return encoded_data if type (encoded_data) == uni_type else decodeInput (encoded_data)
+        if fnmext == "-.abc":
+            fobj = stdin  # see python2/3 differences
+        else:
+            fobj = open(fnmext, "rb")
+        encoded_data = fobj.read()
+        fobj.close()
+        return (
+            encoded_data
+            if isinstance(encoded_data, uni_type)
+            else decodeInput(encoded_data)
+        )
     except Exception as e:
-        info (errmsg + repr (e) + ' ' + fnmext)
+        info(errmsg + repr(e) + " " + fnmext)
         return None
 
-def expand_abc_include (abctxt):
+
+def expand_abc_include(abctxt):
     ys = []
-    for x in abctxt.splitlines ():
-        if x.startswith ('%%abc-include') or x.startswith ('I:abc-include'):
-            x = readfile (x[13:].strip (), 'include error: ')
-        if x != None: ys.append (x)
-    return '\n'.join (ys)
+    for x in abctxt.splitlines():
+        if x.startswith("%%abc-include") or x.startswith("I:abc-include"):
+            x = readfile(x[13:].strip(), "include error: ")
+        if x is not None:
+            ys.append(x)
+    return "\n".join(ys)
 
-abc_header, abc_voice, abc_scoredef, abc_percmap = abc_grammar () # compute grammars only once
-mxm = MusicXml ()               # same for instance of MusicXml
 
-def getXmlScores (abc_string, skip=0, num=1, rOpt=False, bOpt=False, fOpt=False): # not used, backwards compatibility
-    return [fixDoctype (xml_doc) for xml_doc in
-        getXmlDocs (abc_string, skip=0, num=1, rOpt=False, bOpt=False, fOpt=False)]
+abc_header, abc_voice, abc_scoredef, abc_percmap = (
+    abc_grammar()
+)  # compute grammars only once
+mxm = MusicXml()  # same for instance of MusicXml
 
-def getXmlDocs (abc_string, skip=0, num=1, rOpt=False, bOpt=False, fOpt=False): # added by David Randolph
+
+def getXmlScores(
+    abc_string, skip=0, num=1, rOpt=False, bOpt=False, fOpt=False
+):  # not used, backwards compatibility
+    return [
+        fixDoctype(xml_doc)
+        for xml_doc in getXmlDocs(
+            abc_string, skip=0, num=1, rOpt=False, bOpt=False, fOpt=False
+        )
+    ]
+
+
+def getXmlDocs(
+    abc_string, skip=0, num=1, rOpt=False, bOpt=False, fOpt=False
+):  # added by David Randolph
     xml_docs = []
-    abctext = expand_abc_include (abc_string)
-    fragments = re.split (r'^\s*X:', abctext, flags=re.M)
-    preamble = fragments [0]    # tunes can be preceeded by formatting instructions
+    abctext = expand_abc_include(abc_string)
+    fragments = re.split(r"^\s*X:", abctext, flags=re.M)
+    preamble = fragments[0]  # tunes can be preceeded by formatting instructions
     tunes = fragments[1:]
-    if not tunes and preamble: tunes, preamble = ['1\n' + preamble], ''  # tune without X:
-    for itune, tune in enumerate (tunes):
-        if itune < skip: continue           # skip tunes, then read at most num tunes
-        if itune >= skip + num: break
-        tune = preamble + 'X:' + tune       # restore preamble before each tune
-        try:                                # convert string abctext -> file pad/fnmNum.xml
-            score = mxm.parse (tune, rOpt, bOpt, fOpt)
-            ds = list (score.iter ('duration')) # need to iterate twice
-            ss = [int (d.text) for d in ds]
-            deler = reduce (ggd, ss + [21]) # greatest common divisor of all durations
-            for i, d in enumerate (ds): d.text = str (ss [i] // deler)
-            for d in score.iter ('divisions'): d.text = str (int (d.text) // deler)
-            xml_docs.append (score)
+    if not tunes and preamble:
+        tunes, preamble = ["1\n" + preamble], ""  # tune without X:
+    for itune, tune in enumerate(tunes):
+        if itune < skip:
+            continue  # skip tunes, then read at most num tunes
+        if itune >= skip + num:
+            break
+        tune = preamble + "X:" + tune  # restore preamble before each tune
+        try:  # convert string abctext -> file pad/fnmNum.xml
+            score = mxm.parse(tune, rOpt, bOpt, fOpt)
+            ds = list(score.iter("duration"))  # need to iterate twice
+            ss = [int(d.text) for d in ds]
+            deler = reduce(ggd, ss + [21])  # greatest common divisor of all durations
+            for i, d in enumerate(ds):
+                d.text = str(ss[i] // deler)
+            for d in score.iter("divisions"):
+                d.text = str(int(d.text) // deler)
+            xml_docs.append(score)
         except ParseException:
-            pass         # output already printed
+            pass  # output already printed
         except Exception as err:
-            info ('an exception occurred.\n%s' % err)
+            info("an exception occurred.\n%s" % err)
     return xml_docs
 
-#----------------
+
+# ----------------
 # Main Program
-#----------------
-if __name__ == '__main__':
+# ----------------
+if __name__ == "__main__":
     from optparse import OptionParser
     from glob import glob
     import time
 
-    parser = OptionParser (usage='%prog [-h] [-r] [-t] [-b] [-m SKIP NUM] [-o DIR] [-p PFMT] [-z MODE] [--meta MAP] <file1> [<file2> ...]', version='version %d' % VERSION)
-    parser.add_option ("-o", action="store", help="store xml files in DIR", default='', metavar='DIR')
-    parser.add_option ("-m", action="store", help="skip SKIP (0) tunes, then read at most NUM (1) tunes", nargs=2, type='int', default=(0,1), metavar='SKIP NUM')
-    parser.add_option ("-p", action="store", help="pageformat PFMT (mm) = scale (0.75), pageheight (297), pagewidth (210), leftmargin (18), rightmargin (18), topmargin (10), botmargin (10)", default='', metavar='PFMT')
-    parser.add_option ("-z", "--mxl", dest="mxl", help="store as compressed mxl, MODE = a(dd) or r(eplace)", default='', metavar='MODE')
-    parser.add_option ("-r", action="store_true", help="show whole measure rests in merged staffs", default=False)
-    parser.add_option ("-t", action="store_true", help="use tune title as file name", default=False)
-    parser.add_option ("-b", action="store_true", help="line break at EOL", default=False)
-    parser.add_option ("--meta", action="store", help="map infofields to XML metadata, MAP = R:poet,Z:lyricist,N:...", default='', metavar='MAP')
-    parser.add_option ("-f", action="store_true", help="force string/fret allocations for tab staves", default=False)
-    options, args = parser.parse_args ()
-    if len (args) == 0: parser.error ('no input file given')
+    parser = OptionParser(
+        usage="%prog [-h] [-r] [-t] [-b] [-m SKIP NUM] [-o DIR] [-p PFMT] [-z MODE] [--meta MAP] <file1> [<file2> ...]",
+        version="version %d" % VERSION,
+    )
+    parser.add_option(
+        "-o", action="store", help="store xml files in DIR", default="", metavar="DIR"
+    )
+    parser.add_option(
+        "-m",
+        action="store",
+        help="skip SKIP (0) tunes, then read at most NUM (1) tunes",
+        nargs=2,
+        type="int",
+        default=(0, 1),
+        metavar="SKIP NUM",
+    )
+    parser.add_option(
+        "-p",
+        action="store",
+        help="pageformat PFMT (mm) = scale (0.75), pageheight (297), pagewidth (210), leftmargin (18), rightmargin (18), topmargin (10), botmargin (10)",
+        default="",
+        metavar="PFMT",
+    )
+    parser.add_option(
+        "-z",
+        "--mxl",
+        dest="mxl",
+        help="store as compressed mxl, MODE = a(dd) or r(eplace)",
+        default="",
+        metavar="MODE",
+    )
+    parser.add_option(
+        "-r",
+        action="store_true",
+        help="show whole measure rests in merged staffs",
+        default=False,
+    )
+    parser.add_option(
+        "-t", action="store_true", help="use tune title as file name", default=False
+    )
+    parser.add_option(
+        "-b", action="store_true", help="line break at EOL", default=False
+    )
+    parser.add_option(
+        "--meta",
+        action="store",
+        help="map infofields to XML metadata, MAP = R:poet,Z:lyricist,N:...",
+        default="",
+        metavar="MAP",
+    )
+    parser.add_option(
+        "-f",
+        action="store_true",
+        help="force string/fret allocations for tab staves",
+        default=False,
+    )
+    options, args = parser.parse_args()
+    if len(args) == 0:
+        parser.error("no input file given")
     pad = options.o
-    if options.mxl and options.mxl not in ['a','add', 'r', 'replace']:
-        parser.error ('MODE should be a(dd) or r(eplace), not: %s' % options.mxl)
+    if options.mxl and options.mxl not in ["a", "add", "r", "replace"]:
+        parser.error("MODE should be a(dd) or r(eplace), not: %s" % options.mxl)
     if pad:
-        if not os.path.exists (pad): os.mkdir (pad)
-        if not os.path.isdir (pad): parser.error ('%s is not a directory' % pad)
-    if options.p:   # set page formatting values
-        try:        # space, page-height, -width, margin-left, -right, -top, -bottom
-            mxm.pageFmtCmd = lmap (float, options.p.split (','))
-            if len (mxm.pageFmtCmd) != 7: raise ValueError ('-p needs 7 values')
-        except Exception as err: parser.error (err)
-    for x in options.meta.split (','):
-        if not x: continue
-        try: field, tag = x.split (':')
-        except: parser.error ('--meta: %s cannot be split on colon' % x)
-        if field not in 'OAZNGHRBDFSPW': parser.error ('--meta: field %s is no valid ABC field' % field)
-        if tag not in mxm.metaTypes: parser.error ('--meta: tag %s is no valid XML creator type' % tag)
-        mxm.metaMap [field] = tag
+        if not os.path.exists(pad):
+            os.mkdir(pad)
+        if not os.path.isdir(pad):
+            parser.error("%s is not a directory" % pad)
+    if options.p:  # set page formatting values
+        try:  # space, page-height, -width, margin-left, -right, -top, -bottom
+            mxm.pageFmtCmd = lmap(float, options.p.split(","))
+            if len(mxm.pageFmtCmd) != 7:
+                raise ValueError("-p needs 7 values")
+        except Exception as err:
+            parser.error(err)
+    for x in options.meta.split(","):
+        if not x:
+            continue
+        try:
+            field, tag = x.split(":")
+        except Exception:
+            parser.error("--meta: %s cannot be split on colon" % x)
+        if field not in "OAZNGHRBDFSPW":
+            parser.error("--meta: field %s is no valid ABC field" % field)
+        if tag not in mxm.metaTypes:
+            parser.error("--meta: tag %s is no valid XML creator type" % tag)
+        mxm.metaMap[field] = tag
     fnmext_list = []
     for i in args:
-        if i == '-': fnmext_list.append ('-.abc')   # represents standard input
-        else:        fnmext_list += glob (i)
-    if not fnmext_list: parser.error ('none of the input files exist')
-    t_start = time.time ()
+        if i == "-":
+            fnmext_list.append("-.abc")  # represents standard input
+        else:
+            fnmext_list += glob(i)
+    if not fnmext_list:
+        parser.error("none of the input files exist")
+    t_start = time.time()
     for fnmext in fnmext_list:
-        fnm, ext = os.path.splitext (fnmext)
-        if ext.lower () not in ('.abc'):
-            info ('skipped input file %s, it should have extension .abc' % fnmext)
+        fnm, ext = os.path.splitext(fnmext)
+        if ext.lower() not in (".abc"):
+            info("skipped input file %s, it should have extension .abc" % fnmext)
             continue
-        if os.path.isdir (fnmext):
-            info ('skipped directory %s. Only files are accepted' % fnmext)
+        if os.path.isdir(fnmext):
+            info("skipped directory %s. Only files are accepted" % fnmext)
             continue
-        abctext = readfile (fnmext)
+        abctext = readfile(fnmext)
         skip, num = options.m
-        xml_docs = getXmlDocs (abctext, skip, num, options.r, options.b, options.f)
-        for itune, xmldoc in enumerate (xml_docs):
-            fnmNum = '%02d' % (itune + 1) if len (xml_docs) > 1 else ''
-            writefile (pad, fnm, fnmNum, xmldoc, options.mxl, options.t)
-    info ('done in %.2f secs' % (time.time () - t_start))
+        xml_docs = getXmlDocs(abctext, skip, num, options.r, options.b, options.f)
+        for itune, xmldoc in enumerate(xml_docs):
+            fnmNum = "%02d" % (itune + 1) if len(xml_docs) > 1 else ""
+            writefile(pad, fnm, fnmNum, xmldoc, options.mxl, options.t)
+    info("done in %.2f secs" % (time.time() - t_start))

--- a/data/xml2abc.py
+++ b/data/xml2abc.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python
 # coding=latin-1
-'''
+"""
 Copyright (C) 2012-2018: W.G. Vree
-Contributions: M. Tarenskeen, N. Liberg, Paul Villiger, Janus Meuris, Larry Myerscough, 
+Contributions: M. Tarenskeen, N. Liberg, Paul Villiger, Janus Meuris, Larry Myerscough,
 Dick Jackson, Jan Wybren de Jong, Mark Zealey.
 
 This program is free software; you can redistribute it and/or modify it under the terms of the
@@ -11,13 +11,19 @@ Lesser GNU General Public License as published by the Free Software Foundation;
 This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
 without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 See the Lesser GNU General Public License for more details. <http://www.gnu.org/licenses/lgpl.html>.
-'''
+"""
 
-'''Small revisions made for NotaGen to improve the succuess rate of conversion.'''
+"""Small revisions made for NotaGen to improve the succuess rate of conversion."""
 
-try:    import xml.etree.cElementTree as E
-except: import xml.etree.ElementTree as E
-import os, sys, types, re, math
+try:
+    import xml.etree.cElementTree as E
+except:
+    import xml.etree.ElementTree as E
+import os
+import sys
+import types
+import re
+import math
 
 VERSION = 143
 
@@ -31,48 +37,48 @@ else:
     listtype = types.ListType
     max_int = sys.maxint
 
-note_ornamentation_map = {        # for notations/, modified from EasyABC
-    'ornaments/trill-mark':       'T',
-    'ornaments/mordent':          'M',
-    'ornaments/inverted-mordent': 'P',
-    'ornaments/turn':             '!turn!',
-    'ornaments/inverted-turn':    '!invertedturn!',
-    'technical/up-bow':           'u',
-    'technical/down-bow':         'v',
-    'technical/harmonic':         '!open!',
-    'technical/open-string':      '!open!',
-    'technical/stopped':          '!plus!',
-    'technical/snap-pizzicato':   '!snap!',
-    'technical/thumb-position':   '!thumb!',
-    'articulations/accent':       '!>!',
-    'articulations/strong-accent':'!^!',
-    'articulations/staccato':     '.',
-    'articulations/staccatissimo':'!wedge!',
-    'articulations/scoop':        '!slide!',
-    'fermata':                    '!fermata!',
-    'arpeggiate':                 '!arpeggio!',
-    'articulations/tenuto':       '!tenuto!',
-    'articulations/staccatissimo':'!wedge!', # not sure whether this is the right translation
-    'articulations/spiccato':     '!wedge!', # not sure whether this is the right translation
-    'articulations/breath-mark':  '!breath!', # this may need to be tested to make sure it appears on the right side of the note
-    'articulations/detached-legato': '!tenuto!.',
+note_ornamentation_map = {  # for notations/, modified from EasyABC
+    "ornaments/trill-mark": "T",
+    "ornaments/mordent": "M",
+    "ornaments/inverted-mordent": "P",
+    "ornaments/turn": "!turn!",
+    "ornaments/inverted-turn": "!invertedturn!",
+    "technical/up-bow": "u",
+    "technical/down-bow": "v",
+    "technical/harmonic": "!open!",
+    "technical/open-string": "!open!",
+    "technical/stopped": "!plus!",
+    "technical/snap-pizzicato": "!snap!",
+    "technical/thumb-position": "!thumb!",
+    "articulations/accent": "!>!",
+    "articulations/strong-accent": "!^!",
+    "articulations/staccato": ".",
+    "articulations/staccatissimo": "!wedge!",
+    "articulations/scoop": "!slide!",
+    "fermata": "!fermata!",
+    "arpeggiate": "!arpeggio!",
+    "articulations/tenuto": "!tenuto!",
+    "articulations/staccatissimo": "!wedge!",  # not sure whether this is the right translation
+    "articulations/spiccato": "!wedge!",  # not sure whether this is the right translation
+    "articulations/breath-mark": "!breath!",  # this may need to be tested to make sure it appears on the right side of the note
+    "articulations/detached-legato": "!tenuto!.",
 }
 
-dynamics_map = {    # for direction/direction-type/dynamics/
-    'p':    '!p!',
-    'pp':   '!pp!',
-    'ppp':  '!ppp!',
-    'pppp': '!pppp!',
-    'f':    '!f!',
-    'ff':   '!ff!',
-    'fff':  '!fff!',
-    'ffff': '!ffff!',
-    'mp':   '!mp!',
-    'mf':   '!mf!',
-    'sfz':  '!sfz!',
+dynamics_map = {  # for direction/direction-type/dynamics/
+    "p": "!p!",
+    "pp": "!pp!",
+    "ppp": "!ppp!",
+    "pppp": "!pppp!",
+    "f": "!f!",
+    "ff": "!ff!",
+    "fff": "!fff!",
+    "ffff": "!ffff!",
+    "mp": "!mp!",
+    "mf": "!mf!",
+    "sfz": "!sfz!",
 }
 
-percSvg = '''%%beginsvg
+percSvg = """%%beginsvg
     <defs>
     <text id="x" x="-3" y="0">&#xe263;</text>
     <text id="x-" x="-3" y="0">&#xe263;</text>
@@ -92,1431 +98,2084 @@ percSvg = '''%%beginsvg
     <path id="diamond-" d="m0 -3l4.2 3.2 -4.2 3.2 -4.2 -3.2z" class="stroke" style="stroke-width:1.4"></path>
     <path id="diamond+" d="m0 -3l4.2 3.2 -4.2 3.2 -4.2 -3.2z" class="stroke" style="fill:#000"></path>
     </defs>
-    %%endsvg'''
+    %%endsvg"""
 
-tabSvg = '''%%beginsvg
+tabSvg = """%%beginsvg
     <style type="text/css">
     .bf {font-family:sans-serif; font-size:7px}
     </style>
     <defs>
     <rect id="clr" x="-3" y="-1" width="6" height="5" fill="white"></rect>
-    <rect id="clr2" x="-3" y="-1" width="11" height="5" fill="white"></rect>'''
+    <rect id="clr2" x="-3" y="-1" width="11" height="5" fill="white"></rect>"""
 
 kopSvg = '<g id="kop%s" class="bf"><use xlink:href="#clr"></use><text x="-2" y="3">%s</text></g>\n'
 kopSvg2 = '<g id="kop%s" class="bf"><use xlink:href="#clr2"></use><text x="-2" y="3">%s</text></g>\n'
 
-def info (s, warn=1): sys.stderr.write ((warn and '-- ' or '') + s + '\n')
 
-#-------------------
+def info(s, warn=1):
+    sys.stderr.write((warn and "-- " or "") + s + "\n")
+
+
+# -------------------
 # data abstractions
-#-------------------
+# -------------------
 class Measure:
-    def __init__ (s, p):
-        s.reset ()
-        s.ixp = p       # part number  
-        s.ixm = 0       # measure number
-        s.mdur = 0      # measure duration (nominal metre value in divisions)
-        s.divs = 0      # number of divisions per 1/4
-        s.mtr = 4,4     # meter
+    def __init__(s, p):
+        s.reset()
+        s.ixp = p  # part number
+        s.ixm = 0  # measure number
+        s.mdur = 0  # measure duration (nominal metre value in divisions)
+        s.divs = 0  # number of divisions per 1/4
+        s.mtr = 4, 4  # meter
 
-    def reset (s):      # reset each measure
-        s.attr = ''     # measure signatures, tempo
-        s.lline = ''    # left barline, but only holds ':' at start of repeat, otherwise empty
-        s.rline = '|'   # right barline
-        s.lnum = ''     # (left) volta number
+    def reset(s):  # reset each measure
+        s.attr = ""  # measure signatures, tempo
+        s.lline = (
+            ""  # left barline, but only holds ':' at start of repeat, otherwise empty
+        )
+        s.rline = "|"  # right barline
+        s.lnum = ""  # (left) volta number
+
 
 class Note:
-    def __init__ (s, dur=0, n=None):
-        s.tijd = 0      # the time in XML division units
-        s.dur = dur     # duration of a note in XML divisions
-        s.fact = None   # time modification for tuplet notes (num, div)
-        s.tup = ['']    # start(s) and/or stop(s) of tuplet
-        s.tupabc = ''   # abc tuplet string to issue before note
-        s.beam = 0      # 1 = beamed
-        s.grace = 0     # 1 = grace note
-        s.before = []   # abc string that goes before the note/chord
-        s.after = ''    # the same after the note/chord
+    def __init__(s, dur=0, n=None):
+        s.tijd = 0  # the time in XML division units
+        s.dur = dur  # duration of a note in XML divisions
+        s.fact = None  # time modification for tuplet notes (num, div)
+        s.tup = [""]  # start(s) and/or stop(s) of tuplet
+        s.tupabc = ""  # abc tuplet string to issue before note
+        s.beam = 0  # 1 = beamed
+        s.grace = 0  # 1 = grace note
+        s.before = []  # abc string that goes before the note/chord
+        s.after = ""  # the same after the note/chord
         s.ns = n and [n] or []  # notes in the chord
-        s.lyrs = {}     # {number -> syllabe}
-        s.tab = None    # (string number, fret number)
-        s.ntdec = ''    # !string!, !courtesy!
+        s.lyrs = {}  # {number -> syllabe}
+        s.tab = None  # (string number, fret number)
+        s.ntdec = ""  # !string!, !courtesy!
+
 
 class Elem:
-    def __init__ (s, string):
-        s.tijd = 0      # the time in XML division units
+    def __init__(s, string):
+        s.tijd = 0  # the time in XML division units
         s.str = string  # any abc string that is not a note
 
+
 class Counter:
-    def inc (s, key, voice): s.counters [key][voice] = s.counters [key].get (voice, 0) + 1
-    def clear (s, vnums):  # reset all counters
-        tups = list( zip (vnums.keys (), len (vnums) * [0]))
-        s.counters = {'note': dict (tups), 'nopr': dict (tups), 'nopt': dict (tups)}
-    def getv (s, key, voice): return s.counters[key][voice]
-    def prcnt (s, ip):  # print summary of all non zero counters
-        for iv in s.counters ['note']:
-            if s.getv ('nopr', iv) != 0:
-                info ( 'part %d, voice %d has %d skipped non printable notes' % (ip, iv, s.getv ('nopr', iv)))
-            if s.getv ('nopt', iv) != 0:
-                info ( 'part %d, voice %d has %d notes without pitch' % (ip, iv, s.getv ('nopt', iv)))
-            if s.getv ('note', iv) == 0: # no real notes counted in this voice
-                info ( 'part %d, skipped empty voice %d' % (ip, iv))
+    def inc(s, key, voice):
+        s.counters[key][voice] = s.counters[key].get(voice, 0) + 1
+
+    def clear(s, vnums):  # reset all counters
+        tups = list(zip(vnums.keys(), len(vnums) * [0]))
+        s.counters = {"note": dict(tups), "nopr": dict(tups), "nopt": dict(tups)}
+
+    def getv(s, key, voice):
+        return s.counters[key][voice]
+
+    def prcnt(s, ip):  # print summary of all non zero counters
+        for iv in s.counters["note"]:
+            if s.getv("nopr", iv) != 0:
+                info(
+                    "part %d, voice %d has %d skipped non printable notes"
+                    % (ip, iv, s.getv("nopr", iv))
+                )
+            if s.getv("nopt", iv) != 0:
+                info(
+                    "part %d, voice %d has %d notes without pitch"
+                    % (ip, iv, s.getv("nopt", iv))
+                )
+            if s.getv("note", iv) == 0:  # no real notes counted in this voice
+                info("part %d, skipped empty voice %d" % (ip, iv))
+
 
 class Music:
     def __init__(s, options):
-        s.tijd = 0              # the current time
-        s.maxtime = 0           # maximum time in a measure
-        s.gMaten = []           # [voices,.. for all measures in a part]
-        s.gLyrics = []          # [{num: (abc_lyric_string, melis)},.. for all measures in a part]
-        s.vnums = {}            # all used voice id's in a part (xml voice id's == numbers)
-        s.cnt = Counter ()      # global counter object
-        s.vceCnt = 1            # the global voice count over all parts
-        s.lastnote = None       # the last real note record inserted in s.voices
-        s.bpl = options.b       # the max number of bars per line when writing abc
-        s.cpl = options.n       # the number of chars per line when writing abc
-        s.repbra = 0            # true if volta is used somewhere
-        s.nvlt = options.v      # no volta on higher voice numbers
-        s.jscript = options.j   # compatibility with javascript version
+        s.tijd = 0  # the current time
+        s.maxtime = 0  # maximum time in a measure
+        s.gMaten = []  # [voices,.. for all measures in a part]
+        s.gLyrics = (
+            []
+        )  # [{num: (abc_lyric_string, melis)},.. for all measures in a part]
+        s.vnums = {}  # all used voice id's in a part (xml voice id's == numbers)
+        s.cnt = Counter()  # global counter object
+        s.vceCnt = 1  # the global voice count over all parts
+        s.lastnote = None  # the last real note record inserted in s.voices
+        s.bpl = options.b  # the max number of bars per line when writing abc
+        s.cpl = options.n  # the number of chars per line when writing abc
+        s.repbra = 0  # true if volta is used somewhere
+        s.nvlt = options.v  # no volta on higher voice numbers
+        s.jscript = options.j  # compatibility with javascript version
 
-    def initVoices (s, newPart=0):
+    def initVoices(s, newPart=0):
         s.vtimes, s.voices, s.lyrics = {}, {}, {}
         for v in s.vnums:
-            s.vtimes [v] = 0    # {voice: the end time of the last item in each voice}
-            s.voices [v] = []   # {voice: [Note|Elem, ..]}
-            s.lyrics [v] = []   # {voice: [{num: syl}, ..]}
-        if newPart: s.cnt.clear (s.vnums)   # clear counters once per part
+            s.vtimes[v] = 0  # {voice: the end time of the last item in each voice}
+            s.voices[v] = []  # {voice: [Note|Elem, ..]}
+            s.lyrics[v] = []  # {voice: [{num: syl}, ..]}
+        if newPart:
+            s.cnt.clear(s.vnums)  # clear counters once per part
 
-    def incTime (s, dt):
+    def incTime(s, dt):
         s.tijd += dt
-        if s.tijd < 0: s.tijd = 0   # erroneous <backup> element
-        if s.tijd > s.maxtime: s.maxtime = s.tijd
+        if s.tijd < 0:
+            s.tijd = 0  # erroneous <backup> element
+        if s.tijd > s.maxtime:
+            s.maxtime = s.tijd
 
-    def appendElemCv (s, voices, elem):
+    def appendElemCv(s, voices, elem):
         for v in voices:
-            s.appendElem (v, elem) # insert element in all voices
+            s.appendElem(v, elem)  # insert element in all voices
 
-    def insertElem (s, v, elem):    # insert at the start of voice v in the current measure
-        obj = Elem (elem)
-        obj.tijd = 0        # because voice is sorted later
-        s.voices [v].insert (0, obj)
+    def insertElem(s, v, elem):  # insert at the start of voice v in the current measure
+        obj = Elem(elem)
+        obj.tijd = 0  # because voice is sorted later
+        s.voices[v].insert(0, obj)
 
-    def appendObj (s, v, obj, dur):
+    def appendObj(s, v, obj, dur):
         obj.tijd = s.tijd
-        s.voices [v].append (obj)
-        s.incTime (dur)
-        if s.tijd > s.vtimes[v]: s.vtimes[v] = s.tijd   # don't update for inserted earlier items
+        s.voices[v].append(obj)
+        s.incTime(dur)
+        if s.tijd > s.vtimes[v]:
+            s.vtimes[v] = s.tijd  # don't update for inserted earlier items
 
-    def appendElem (s, v, elem, tel=0):
-        s.appendObj (v, Elem (elem), 0)
-        if tel: s.cnt.inc ('note', v)   # count number of certain elements in each voice (in addition to notes)
+    def appendElem(s, v, elem, tel=0):
+        s.appendObj(v, Elem(elem), 0)
+        if tel:
+            s.cnt.inc(
+                "note", v
+            )  # count number of certain elements in each voice (in addition to notes)
 
-    def appendElemT (s, v, elem, tijd): # insert element at specified time
-        obj = Elem (elem)
+    def appendElemT(s, v, elem, tijd):  # insert element at specified time
+        obj = Elem(elem)
         obj.tijd = tijd
-        s.voices [v].append (obj)
+        s.voices[v].append(obj)
 
-    def appendNote (s, v, note, noot):
-        note.ns.append (note.ntdec + noot)
-        s.appendObj (v, note, int (note.dur))
-        s.lastnote = note           # remember last note/rest for later modifications (chord, grace)
-        if noot != 'z' and noot != 'x':         # real notes and grace notes
-            s.cnt.inc ('note', v)   # count number of real notes in each voice
-            if not note.grace:                  # for every real note
-                s.lyrics[v].append (note.lyrs)  # even when it has no lyrics
+    def appendNote(s, v, note, noot):
+        note.ns.append(note.ntdec + noot)
+        s.appendObj(v, note, int(note.dur))
+        s.lastnote = (
+            note  # remember last note/rest for later modifications (chord, grace)
+        )
+        if noot != "z" and noot != "x":  # real notes and grace notes
+            s.cnt.inc("note", v)  # count number of real notes in each voice
+            if not note.grace:  # for every real note
+                s.lyrics[v].append(note.lyrs)  # even when it has no lyrics
 
-    def getLastRec (s, voice):
-        if s.gMaten: return s.gMaten[-1][voice][-1] # the last record in the last measure
-        return None                                 # no previous records in the first measure
+    def getLastRec(s, voice):
+        if s.gMaten:
+            return s.gMaten[-1][voice][-1]  # the last record in the last measure
+        return None  # no previous records in the first measure
 
-    def getLastMelis (s, voice, num):   # get melisma of last measure
+    def getLastMelis(s, voice, num):  # get melisma of last measure
         if s.gLyrics:
             lyrdict = s.gLyrics[-1][voice]  # the previous lyrics dict in this voice
-            if num in lyrdict: return lyrdict[num][1]   # lyrdict = num -> (lyric string, melisma)
-        return 0 # no previous lyrics in voice or line number
+            if num in lyrdict:
+                return lyrdict[num][1]  # lyrdict = num -> (lyric string, melisma)
+        return 0  # no previous lyrics in voice or line number
 
-    def addChord (s, note, noot):   # careful: we assume that chord notes follow immediately
-        for d in note.before:       # put all decorations before chord
+    def addChord(
+        s, note, noot
+    ):  # careful: we assume that chord notes follow immediately
+        for d in note.before:  # put all decorations before chord
             if d not in s.lastnote.before:
                 s.lastnote.before += [d]
-        s.lastnote.ns.append (note.ntdec + noot)
+        s.lastnote.ns.append(note.ntdec + noot)
 
-    def addBar (s, lbrk, m): # linebreak, measure data
-        if m.mdur and s.maxtime > m.mdur: info ('measure %d in part %d longer than metre' % (m.ixm+1, m.ixp+1))
-        s.tijd = s.maxtime              # the time of the bar lines inserted here
+    def addBar(s, lbrk, m):  # linebreak, measure data
+        if m.mdur and s.maxtime > m.mdur:
+            info("measure %d in part %d longer than metre" % (m.ixm + 1, m.ixp + 1))
+        s.tijd = s.maxtime  # the time of the bar lines inserted here
         for v in s.vnums:
-            if m.lline or m.lnum:       # if left barline or left volta number
-                p = s.getLastRec (v)    # get the previous barline record
-                if p:                   # in measure 1 no previous measure is available
-                    x = p.str           # p.str is the ABC barline string
-                    if m.lline:         # append begin of repeat, m.lline == ':'
-                        x = (x + m.lline).replace (':|:','::').replace ('||','|')
-                    if s.nvlt == 3:     # add volta number only to lowest voice in part 0 
-                        if m.ixp + v == min (s.vnums): x += m.lnum
-                    elif m.lnum:        # new behaviour with I:repbra 0
-                        x += m.lnum     # add volta number(s) or text to all voices
-                        s.repbra = 1    # signal occurrence of a volta
-                    p.str = x           # modify previous right barline
-                elif m.lline:           # begin of new part and left repeat bar is required
-                    s.insertElem (v, '|:')
+            if m.lline or m.lnum:  # if left barline or left volta number
+                p = s.getLastRec(v)  # get the previous barline record
+                if p:  # in measure 1 no previous measure is available
+                    x = p.str  # p.str is the ABC barline string
+                    if m.lline:  # append begin of repeat, m.lline == ':'
+                        x = (x + m.lline).replace(":|:", "::").replace("||", "|")
+                    if s.nvlt == 3:  # add volta number only to lowest voice in part 0
+                        if m.ixp + v == min(s.vnums):
+                            x += m.lnum
+                    elif m.lnum:  # new behaviour with I:repbra 0
+                        x += m.lnum  # add volta number(s) or text to all voices
+                        s.repbra = 1  # signal occurrence of a volta
+                    p.str = x  # modify previous right barline
+                elif m.lline:  # begin of new part and left repeat bar is required
+                    s.insertElem(v, "|:")
             if lbrk:
-                p = s.getLastRec (v)    # get the previous barline record
-                if p: p.str += lbrk     # insert linebreak char after the barlines+volta
-            if m.attr:                  # insert signatures at front of buffer
-                s.insertElem (v, '%s' % m.attr)
-            s.appendElem (v, ' %s' % m.rline)   # insert current barline record at time maxtime
-            s.voices[v] = sortMeasure (s.voices[v], m)  # make all times consistent
-            lyrs = s.lyrics[v]          # [{number: sylabe}, .. for all notes]
-            lyrdict = {}                # {number: (abc_lyric_string, melis)} for this voice
-            nums = [num for d in lyrs for num in d.keys ()] # the lyrics numbers in this measure
-            maxNums = max (nums + [0])  # the highest lyrics number in this measure
-            for i in range (maxNums, 0, -1):
-                xs = [syldict.get (i, '') for syldict in lyrs]  # collect the syllabi with number i
-                melis = s.getLastMelis (v, i)  # get melisma from last measure
-                lyrdict [i] = abcLyr (xs, melis)
-            s.lyrics[v] = lyrdict       # {number: (abc_lyric_string, melis)} for this measure
-            mkBroken (s.voices[v])
-        s.gMaten.append (s.voices)
-        s.gLyrics.append (s.lyrics)
+                p = s.getLastRec(v)  # get the previous barline record
+                if p:
+                    p.str += lbrk  # insert linebreak char after the barlines+volta
+            if m.attr:  # insert signatures at front of buffer
+                s.insertElem(v, "%s" % m.attr)
+            s.appendElem(
+                v, " %s" % m.rline
+            )  # insert current barline record at time maxtime
+            s.voices[v] = sortMeasure(s.voices[v], m)  # make all times consistent
+            lyrs = s.lyrics[v]  # [{number: sylabe}, .. for all notes]
+            lyrdict = {}  # {number: (abc_lyric_string, melis)} for this voice
+            nums = [
+                num for d in lyrs for num in d.keys()
+            ]  # the lyrics numbers in this measure
+            maxNums = max(nums + [0])  # the highest lyrics number in this measure
+            for i in range(maxNums, 0, -1):
+                xs = [
+                    syldict.get(i, "") for syldict in lyrs
+                ]  # collect the syllabi with number i
+                melis = s.getLastMelis(v, i)  # get melisma from last measure
+                lyrdict[i] = abcLyr(xs, melis)
+            s.lyrics[v] = (
+                lyrdict  # {number: (abc_lyric_string, melis)} for this measure
+            )
+            mkBroken(s.voices[v])
+        s.gMaten.append(s.voices)
+        s.gLyrics.append(s.lyrics)
         s.tijd = s.maxtime = 0
-        s.initVoices ()
+        s.initVoices()
 
-    def outVoices (s, divs, ip, isSib): # output all voices of part ip
-        vvmap = {}                  # xml voice number -> abc voice number (one part)
-        vnum_keys = list (s.vnums.keys ())
-        if s.jscript or isSib: vnum_keys.sort ()
-        lvc = min (vnum_keys or [1])	# lowest xml voice number of this part
+    def outVoices(s, divs, ip, isSib):  # output all voices of part ip
+        vvmap = {}  # xml voice number -> abc voice number (one part)
+        vnum_keys = list(s.vnums.keys())
+        if s.jscript or isSib:
+            vnum_keys.sort()
+        lvc = min(vnum_keys or [1])  # lowest xml voice number of this part
         for iv in vnum_keys:
-            if s.cnt.getv ('note', iv) == 0:    # no real notes counted in this voice
-                continue            # skip empty voices
-            if abcOut.denL: unitL = abcOut.denL # take the unit length from the -d option
-            else:           unitL = compUnitLength (iv, s.gMaten, divs) # compute the best unit length for this voice
-            abcOut.cmpL.append (unitL)  # remember for header output
-            vn, vl = [], {}         # for voice iv: collect all notes to vn and all lyric lines to vl
-            for im in range (len (s.gMaten)):
-                measure = s.gMaten [im][iv]
-                vn.append (outVoice (measure, divs [im], im, ip, unitL))
-                checkMelismas (s.gLyrics, s.gMaten, im, iv)
-                for n, (lyrstr, melis) in s.gLyrics [im][iv].items ():
+            if s.cnt.getv("note", iv) == 0:  # no real notes counted in this voice
+                continue  # skip empty voices
+            if abcOut.denL:
+                unitL = abcOut.denL  # take the unit length from the -d option
+            else:
+                unitL = compUnitLength(
+                    iv, s.gMaten, divs
+                )  # compute the best unit length for this voice
+            abcOut.cmpL.append(unitL)  # remember for header output
+            vn, vl = (
+                [],
+                {},
+            )  # for voice iv: collect all notes to vn and all lyric lines to vl
+            for im in range(len(s.gMaten)):
+                measure = s.gMaten[im][iv]
+                vn.append(outVoice(measure, divs[im], im, ip, unitL))
+                checkMelismas(s.gLyrics, s.gMaten, im, iv)
+                for n, (lyrstr, melis) in s.gLyrics[im][iv].items():
                     if n in vl:
-                        while len (vl[n]) < im: vl[n].append ('') # fill in skipped measures
-                        vl[n].append (lyrstr)
+                        while len(vl[n]) < im:
+                            vl[n].append("")  # fill in skipped measures
+                        vl[n].append(lyrstr)
                     else:
-                        vl[n] = im * [''] + [lyrstr]    # must skip im measures
-            for n, lyrs in vl.items (): # fill up possibly empty lyric measures at the end
-                mis = len (vn) - len (lyrs)
-                lyrs += mis * ['']
-            abcOut.add ('V:%d' % s.vceCnt)
+                        vl[n] = im * [""] + [lyrstr]  # must skip im measures
+            for (
+                n,
+                lyrs,
+            ) in vl.items():  # fill up possibly empty lyric measures at the end
+                mis = len(vn) - len(lyrs)
+                lyrs += mis * [""]
+            abcOut.add("V:%d" % s.vceCnt)
             if s.repbra:
-                if s.nvlt == 1 and s.vceCnt > 1: abcOut.add ('I:repbra 0')  # only volta on first voice
-                if s.nvlt == 2 and iv > lvc:     abcOut.add ('I:repbra 0')  # only volta on first voice of each part
-            if   s.cpl > 0:  s.bpl = 0      # option -n (max chars per line) overrules -b (max bars per line)
-            elif s.bpl == 0: s.cpl = 100    # the default: 100 chars per line
-            bn = 0                  # count bars
-            while vn:               # while still measures available
+                if s.nvlt == 1 and s.vceCnt > 1:
+                    abcOut.add("I:repbra 0")  # only volta on first voice
+                if s.nvlt == 2 and iv > lvc:
+                    abcOut.add("I:repbra 0")  # only volta on first voice of each part
+            if s.cpl > 0:
+                s.bpl = (
+                    0  # option -n (max chars per line) overrules -b (max bars per line)
+                )
+            elif s.bpl == 0:
+                s.cpl = 100  # the default: 100 chars per line
+            bn = 0  # count bars
+            while vn:  # while still measures available
                 ib = 1
-                chunk = vn [0]
-                while ib < len (vn):
-                    if s.cpl > 0 and len (chunk) + len (vn [ib]) >= s.cpl: break    # line full (number of chars)
-                    if s.bpl > 0 and ib >= s.bpl: break                             # line full (number of bars)
-                    chunk += vn [ib]
+                chunk = vn[0]
+                while ib < len(vn):
+                    if s.cpl > 0 and len(chunk) + len(vn[ib]) >= s.cpl:
+                        break  # line full (number of chars)
+                    if s.bpl > 0 and ib >= s.bpl:
+                        break  # line full (number of bars)
+                    chunk += vn[ib]
                     ib += 1
                 bn += ib
-                abcOut.add (chunk + ' %%%d' % bn)   # line with barnumer
-                del vn[:ib]         # chop ib bars
-                lyrlines = sorted (vl.items ())     # order the numbered lyric lines for output
+                abcOut.add(chunk + " %%%d" % bn)  # line with barnumer
+                del vn[:ib]  # chop ib bars
+                lyrlines = sorted(
+                    vl.items()
+                )  # order the numbered lyric lines for output
                 for n, lyrs in lyrlines:
-                    abcOut.add ('w: ' + '|'.join (lyrs[:ib]) + '|')
+                    abcOut.add("w: " + "|".join(lyrs[:ib]) + "|")
                     del lyrs[:ib]
-            vvmap [iv] = s.vceCnt   # xml voice number -> abc voice number
-            s.vceCnt += 1           # count voices over all parts
-        s.gMaten = []               # reset the follwing instance vars for each part
+            vvmap[iv] = s.vceCnt  # xml voice number -> abc voice number
+            s.vceCnt += 1  # count voices over all parts
+        s.gMaten = []  # reset the follwing instance vars for each part
         s.gLyrics = []
-        s.cnt.prcnt (ip+1)          # print summary of skipped items in this part
+        s.cnt.prcnt(ip + 1)  # print summary of skipped items in this part
         return vvmap
 
+
 class ABCoutput:
-    pagekeys = 'scale,pageheight,pagewidth,leftmargin,rightmargin,topmargin,botmargin'.split (',')
-    def __init__ (s, fnmext, pad, X, options):
+    pagekeys = (
+        "scale,pageheight,pagewidth,leftmargin,rightmargin,topmargin,botmargin".split(
+            ","
+        )
+    )
+
+    def __init__(s, fnmext, pad, X, options):
         s.fnmext = fnmext
-        s.outlist = []          # list of ABC strings
-        s.title = 'T:Title'
-        s.key = 'none'
-        s.clefs = {}            # clefs for all abc-voices
-        s.mtr = 'none'
-        s.tempo = 0             # 0 -> no tempo field
-        s.tempo_units = (1,4)	# note type of tempo direction
-        s.pad = pad             # the output path or none
-        s.X = X + 1             # the abc tune number
-        s.denL = options.d      # denominator of the unit length (L:) from -d option
-        s.volpan = int (options.m)  # 0 -> no %%MIDI, 1 -> only program, 2 -> all %%MIDI
-        s.cmpL = []             # computed optimal unit length for all voices
-        s.jscript = options.j   # compatibility with javascript version
-        s.tstep = options.t     # translate percmap to voicemap
-        s.stemless = 0          # use U:s=!stemless!
-        s.shiftStem = options.s # shift note heads 3 units left
+        s.outlist = []  # list of ABC strings
+        s.title = "T:Title"
+        s.key = "none"
+        s.clefs = {}  # clefs for all abc-voices
+        s.mtr = "none"
+        s.tempo = 0  # 0 -> no tempo field
+        s.tempo_units = (1, 4)  # note type of tempo direction
+        s.pad = pad  # the output path or none
+        s.X = X + 1  # the abc tune number
+        s.denL = options.d  # denominator of the unit length (L:) from -d option
+        s.volpan = int(options.m)  # 0 -> no %%MIDI, 1 -> only program, 2 -> all %%MIDI
+        s.cmpL = []  # computed optimal unit length for all voices
+        s.jscript = options.j  # compatibility with javascript version
+        s.tstep = options.t  # translate percmap to voicemap
+        s.stemless = 0  # use U:s=!stemless!
+        s.shiftStem = options.s  # shift note heads 3 units left
         if pad:
-            _, base_name = os.path.split (fnmext)
-            s.outfile = open (os.path.join (pad, base_name), 'w', encoding='utf-8')
-        else:   s.outfile = sys.stdout
-        if s.jscript: s.X = 1   # always X:1 in javascript version
+            _, base_name = os.path.split(fnmext)
+            s.outfile = open(os.path.join(pad, base_name), "w", encoding="utf-8")
+        else:
+            s.outfile = sys.stdout
+        if s.jscript:
+            s.X = 1  # always X:1 in javascript version
         s.pageFmt = {}
-        for k in s.pagekeys: s.pageFmt [k] = None
-        if len (options.p) == 7:
-            for k, v in zip (s.pagekeys, options.p):
-                try: s.pageFmt [k] = float (v)
-                except: info ('illegal float %s for %s', (k, v)); continue
+        for k in s.pagekeys:
+            s.pageFmt[k] = None
+        if len(options.p) == 7:
+            for k, v in zip(s.pagekeys, options.p):
+                try:
+                    s.pageFmt[k] = float(v)
+                except:
+                    info("illegal float %s for %s", (k, v))
+                    continue
 
-    def add (s, str):
-        s.outlist.append (str + '\n')   # collect all ABC output
+    def add(s, str):
+        s.outlist.append(str + "\n")  # collect all ABC output
 
-    def mkHeader (s, stfmap, partlist, midimap, vmpdct, koppen): # stfmap = [parts], part = [staves], stave = [voices]
+    def mkHeader(
+        s, stfmap, partlist, midimap, vmpdct, koppen
+    ):  # stfmap = [parts], part = [staves], stave = [voices]
         accVce, accStf, staffs = [], [], stfmap[:]  # staffs is consumed
-        for x in partlist:              # collect partnames into accVce and staff groups into accStf
-            try: prgroupelem (x, ('', ''), '', stfmap, accVce, accStf)
-            except: info ('lousy musicxml: error in part-list')
-        staves = ' '.join (accStf)
+        for x in partlist:  # collect partnames into accVce and staff groups into accStf
+            try:
+                prgroupelem(x, ("", ""), "", stfmap, accVce, accStf)
+            except:
+                info("lousy musicxml: error in part-list")
+        staves = " ".join(accStf)
         clfnms = {}
-        for part, (partname, partabbrv) in zip (staffs, accVce):
-            if not part: continue       # skip empty part
-            firstVoice = part[0][0]     # the first voice number in this part
-            nm  = partname.replace ('\n','\\n').replace ('.:','.').strip (':')
-            snm = partabbrv.replace ('\n','\\n').replace ('.:','.').strip (':')
-            clfnms [firstVoice] = (nm and 'nm="%s"' % nm or '') + (snm and ' snm="%s"' % snm or '')
-        hd = ['X:%d\n%s\n' % (s.X, s.title)]
-        for i, k in enumerate (s.pagekeys):
-            if s.jscript and k in ['pageheight','topmargin', 'botmargin']: continue
-            if s.pageFmt [k] != None: hd.append ('%%%%%s %.2f%s\n' % (k, s.pageFmt [k], i > 0 and 'cm' or ''))
-        if staves and len (accStf) > 1: hd.append ('%%score ' + staves + '\n')
-        tempo = s.tempo and 'Q:%d/%d=%s\n' % (s.tempo_units [0], s.tempo_units [1], s.tempo) or ''  # default no tempo field
+        for part, (partname, partabbrv) in zip(staffs, accVce):
+            if not part:
+                continue  # skip empty part
+            firstVoice = part[0][0]  # the first voice number in this part
+            nm = partname.replace("\n", "\\n").replace(".:", ".").strip(":")
+            snm = partabbrv.replace("\n", "\\n").replace(".:", ".").strip(":")
+            clfnms[firstVoice] = (nm and 'nm="%s"' % nm or "") + (
+                snm and ' snm="%s"' % snm or ""
+            )
+        hd = ["X:%d\n%s\n" % (s.X, s.title)]
+        for i, k in enumerate(s.pagekeys):
+            if s.jscript and k in ["pageheight", "topmargin", "botmargin"]:
+                continue
+            if s.pageFmt[k] != None:
+                hd.append("%%%%%s %.2f%s\n" % (k, s.pageFmt[k], i > 0 and "cm" or ""))
+        if staves and len(accStf) > 1:
+            hd.append("%%score " + staves + "\n")
+        tempo = (
+            s.tempo
+            and "Q:%d/%d=%s\n" % (s.tempo_units[0], s.tempo_units[1], s.tempo)
+            or ""
+        )  # default no tempo field
         d = {}  # determine the most frequently occurring unit length over all voices
-        for x in s.cmpL: d[x] = d.get (x, 0) + 1
-        if s.jscript:   defLs = sorted (d.items (), key=lambda x: (-x[1], x[0])) # when tie (1) sort on key (0)
-        else:           defLs = sorted (d.items (), key=lambda x: -x[1])
-        defL = s.denL and s.denL or defLs [0][0] # override default unit length with -d option
-        hd.append ('L:1/%d\n%sM:%s\n' % (defL, tempo, s.mtr))
-        hd.append ('K:%s\n' % s.key)
-        if s.stemless: hd.append ('U:s=!stemless!\n')
-        vxs = sorted (vmpdct.keys ())
-        for vx in vxs: hd.extend (vmpdct [vx])
-        s.dojef = 0    # translate percmap to voicemap
-        for vnum, clef in s.clefs.items ():
-            ch, prg, vol, pan = midimap [vnum-1][:4]
-            dmap = midimap [vnum - 1][4:]   # map of abc percussion notes to midi notes
-            if dmap and 'perc' not in clef: clef = (clef + ' map=perc').strip ();
-            hd.append ('V:%d %s %s\n' % (vnum, clef, clfnms.get (vnum, '')))
+        for x in s.cmpL:
+            d[x] = d.get(x, 0) + 1
+        if s.jscript:
+            defLs = sorted(
+                d.items(), key=lambda x: (-x[1], x[0])
+            )  # when tie (1) sort on key (0)
+        else:
+            defLs = sorted(d.items(), key=lambda x: -x[1])
+        defL = (
+            s.denL and s.denL or defLs[0][0]
+        )  # override default unit length with -d option
+        hd.append("L:1/%d\n%sM:%s\n" % (defL, tempo, s.mtr))
+        hd.append("K:%s\n" % s.key)
+        if s.stemless:
+            hd.append("U:s=!stemless!\n")
+        vxs = sorted(vmpdct.keys())
+        for vx in vxs:
+            hd.extend(vmpdct[vx])
+        s.dojef = 0  # translate percmap to voicemap
+        for vnum, clef in s.clefs.items():
+            ch, prg, vol, pan = midimap[vnum - 1][:4]
+            dmap = midimap[vnum - 1][4:]  # map of abc percussion notes to midi notes
+            if dmap and "perc" not in clef:
+                clef = (clef + " map=perc").strip()
+            hd.append("V:%d %s %s\n" % (vnum, clef, clfnms.get(vnum, "")))
             if vnum in vmpdct:
-                hd.append ('%%%%voicemap tab%d\n' % vnum)
-                hd.append ('K:none\nM:none\n%%clef none\n%%staffscale 1.6\n%%flatbeams true\n%%stemdir down\n')
-            if 'perc' in clef: hd.append ('K:none\n');  # no key for a perc voice
-            if s.volpan > 1:    # option -m 2 -> output all recognized midi commands when needed and present in xml
-                if ch > 0 and ch != vnum: hd.append ('%%%%MIDI channel %d\n' % ch)
-                if prg > 0:  hd.append ('%%%%MIDI program %d\n' % (prg - 1))
-                if vol >= 0: hd.append ('%%%%MIDI control 7 %.0f\n' % vol)  # volume == 0 is possible ...
-                if pan >= 0: hd.append ('%%%%MIDI control 10 %.0f\n' % pan)
-            elif s.volpan > 0: # default -> only output midi program command when present in xml
-                if dmap and ch > 0: hd.append ('%%%%MIDI channel %d\n' % ch) # also channel if percussion part
-                if prg > 0:  hd.append ('%%%%MIDI program %d\n' % (prg - 1))
+                hd.append("%%%%voicemap tab%d\n" % vnum)
+                hd.append(
+                    "K:none\nM:none\n%%clef none\n%%staffscale 1.6\n%%flatbeams true\n%%stemdir down\n"
+                )
+            if "perc" in clef:
+                hd.append("K:none\n")  # no key for a perc voice
+            if (
+                s.volpan > 1
+            ):  # option -m 2 -> output all recognized midi commands when needed and present in xml
+                if ch > 0 and ch != vnum:
+                    hd.append("%%%%MIDI channel %d\n" % ch)
+                if prg > 0:
+                    hd.append("%%%%MIDI program %d\n" % (prg - 1))
+                if vol >= 0:
+                    hd.append(
+                        "%%%%MIDI control 7 %.0f\n" % vol
+                    )  # volume == 0 is possible ...
+                if pan >= 0:
+                    hd.append("%%%%MIDI control 10 %.0f\n" % pan)
+            elif (
+                s.volpan > 0
+            ):  # default -> only output midi program command when present in xml
+                if dmap and ch > 0:
+                    hd.append(
+                        "%%%%MIDI channel %d\n" % ch
+                    )  # also channel if percussion part
+                if prg > 0:
+                    hd.append("%%%%MIDI program %d\n" % (prg - 1))
             for abcNote, step, midiNote, notehead in dmap:
-                if not notehead: notehead = 'normal'
-                if abcMid (abcNote) != midiNote or abcNote != step:
-                    if s.volpan > 0: hd.append ('%%%%MIDI drummap %s %s\n' % (abcNote, midiNote))
-                    hd.append ('I:percmap %s %s %s %s\n' % (abcNote, step, midiNote, notehead))
+                if not notehead:
+                    notehead = "normal"
+                if abcMid(abcNote) != midiNote or abcNote != step:
+                    if s.volpan > 0:
+                        hd.append("%%%%MIDI drummap %s %s\n" % (abcNote, midiNote))
+                    hd.append(
+                        "I:percmap %s %s %s %s\n" % (abcNote, step, midiNote, notehead)
+                    )
                     s.dojef = s.tstep
-            if defL != s.cmpL [vnum-1]: # only if computed unit length different from header
-                hd.append ('L:1/%d\n' % s.cmpL [vnum-1])
+            if (
+                defL != s.cmpL[vnum - 1]
+            ):  # only if computed unit length different from header
+                hd.append("L:1/%d\n" % s.cmpL[vnum - 1])
         s.outlist = hd + s.outlist
         if koppen:  # output SVG stuff needed for tablature
-            k1 = kopSvg.replace ('-2','-5') if s.shiftStem else kopSvg  # shift note heads 3 units left
-            k2 = kopSvg2.replace ('-2','-5') if s.shiftStem else kopSvg2
-            tb = tabSvg.replace ('-3','-6') if s.shiftStem else tabSvg
-            ks = sorted (koppen.keys ())                                # javascript compatibility
-            ks = [k2 % (k, k) if len (k) == 2 else k1 % (k, k) for k in ks]
-            tbs = map (lambda x: x.strip () + '\n', tb.splitlines ())   # javascript compatibility
-            s.outlist = tbs + ks + ['</defs>\n%%endsvg\n'] + s.outlist
+            k1 = (
+                kopSvg.replace("-2", "-5") if s.shiftStem else kopSvg
+            )  # shift note heads 3 units left
+            k2 = kopSvg2.replace("-2", "-5") if s.shiftStem else kopSvg2
+            tb = tabSvg.replace("-3", "-6") if s.shiftStem else tabSvg
+            ks = sorted(koppen.keys())  # javascript compatibility
+            ks = [k2 % (k, k) if len(k) == 2 else k1 % (k, k) for k in ks]
+            tbs = map(
+                lambda x: x.strip() + "\n", tb.splitlines()
+            )  # javascript compatibility
+            s.outlist = tbs + ks + ["</defs>\n%%endsvg\n"] + s.outlist
 
-    def writeall (s):  # determine the required encoding of the entire ABC output
-        str = ''.join (s.outlist)
+    def writeall(s):  # determine the required encoding of the entire ABC output
+        str = "".join(s.outlist)
         # print(str)
-        if s.dojef: str = perc2map (str)
-        if python3: s.outfile.write (str)
-        else:       s.outfile.write (str)
-        if s.pad: s.outfile.close ()                # close each file with -o option
-        else: s.outfile.write ('\n')                # add empty line between tunes on stdout
-        info ('%s written with %d voices' % (s.fnmext, len (s.clefs)), warn=0)
+        if s.dojef:
+            str = perc2map(str)
+        if python3:
+            s.outfile.write(str)
+        else:
+            s.outfile.write(str)
+        if s.pad:
+            s.outfile.close()  # close each file with -o option
+        else:
+            s.outfile.write("\n")  # add empty line between tunes on stdout
+        info("%s written with %d voices" % (s.fnmext, len(s.clefs)), warn=0)
 
-#----------------
+
+# ----------------
 # functions
-#----------------
-def abcLyr (xs, melis): # Convert list xs to abc lyrics.
-    if not ''.join (xs): return '', 0  # there is no lyrics in this measure
+# ----------------
+def abcLyr(xs, melis):  # Convert list xs to abc lyrics.
+    if not "".join(xs):
+        return "", 0  # there is no lyrics in this measure
     res = []
-    for x in xs:        # xs has for every note a lyrics syllabe or an empty string
-        if x == '':     # note without lyrics
-            if melis: x = '_'   # set melisma
-            else: x = '*'       # skip note
-        elif x.endswith ('_') and not x.endswith ('\_'): # start of new melisma
-            x = x.replace ('_', '') # remove and set melis boolean
-            melis = 1           # so next skips will become melisma
-        else: melis = 0         # melisma stops on first syllable
-        res.append (x)
-    return (' '.join (res), melis)
+    for x in xs:  # xs has for every note a lyrics syllabe or an empty string
+        if x == "":  # note without lyrics
+            if melis:
+                x = "_"  # set melisma
+            else:
+                x = "*"  # skip note
+        elif x.endswith("_") and not x.endswith("\_"):  # start of new melisma
+            x = x.replace("_", "")  # remove and set melis boolean
+            melis = 1  # so next skips will become melisma
+        else:
+            melis = 0  # melisma stops on first syllable
+        res.append(x)
+    return (" ".join(res), melis)
 
-def simplify (a, b):    # divide a and b by their greatest common divisor
+
+def simplify(a, b):  # divide a and b by their greatest common divisor
     x, y = a, b
-    while b: a, b = b, a % b
+    while b:
+        a, b = b, a % b
     return x // a, y // a
 
-def abcdur (nx, divs, uL):      # convert an musicXML duration d to abc units with L:1/uL
-    if nx.dur == 0: return ''   # when called for elements without duration
-    num, den = simplify (uL * nx.dur, divs * 4) # L=1/8 -> uL = 8 units
-    if nx.fact:                 # apply tuplet time modification
+
+def abcdur(nx, divs, uL):  # convert an musicXML duration d to abc units with L:1/uL
+    if nx.dur == 0:
+        return ""  # when called for elements without duration
+    num, den = simplify(uL * nx.dur, divs * 4)  # L=1/8 -> uL = 8 units
+    if nx.fact:  # apply tuplet time modification
         numfac, denfac = nx.fact
-        num, den = simplify (num * numfac, den * denfac)
-    if den > 64:                # limit the denominator to a maximum of 64
-        x = float (num) / den; n = math.floor (x);  # when just above an integer n
-        if x - n < 0.1 * x: num, den = n, 1;        # round to n
-        num64 = 64. * num / den + 1.0e-15           # to get Python2 behaviour of round
-        num, den = simplify (int (round (num64)), 64)
+        num, den = simplify(num * numfac, den * denfac)
+    if den > 64:  # limit the denominator to a maximum of 64
+        x = float(num) / den
+        n = math.floor(x)  # when just above an integer n
+        if x - n < 0.1 * x:
+            num, den = n, 1  # round to n
+        num64 = 64.0 * num / den + 1.0e-15  # to get Python2 behaviour of round
+        num, den = simplify(int(round(num64)), 64)
     if num == 1:
-        if   den == 1: dabc = ''
-        elif den == 2: dabc = '/'
-        else:          dabc = '/%d' % den
-    elif den == 1:     dabc = '%d' % num
-    else:              dabc = '%d/%d' % (num, den)
+        if den == 1:
+            dabc = ""
+        elif den == 2:
+            dabc = "/"
+        else:
+            dabc = "/%d" % den
+    elif den == 1:
+        dabc = "%d" % num
+    else:
+        dabc = "%d/%d" % (num, den)
     return dabc
 
-def abcMid (note):  # abc note -> midi pitch
-    r = re.search (r"([_^]*)([A-Ga-g])([',]*)", note)
-    if not r: return -1
-    acc, n, oct = r.groups ()
-    nUp = n.upper ()
-    p = 60 + [0,2,4,5,7,9,11]['CDEFGAB'.index (nUp)] + (12 if nUp != n else 0);
-    if acc: p += (1 if acc[0] == '^' else -1) * len (acc)
-    if oct: p += (12 if oct[0] == "'" else -12) * len (oct)
+
+def abcMid(note):  # abc note -> midi pitch
+    r = re.search(r"([_^]*)([A-Ga-g])([',]*)", note)
+    if not r:
+        return -1
+    acc, n, oct = r.groups()
+    nUp = n.upper()
+    p = 60 + [0, 2, 4, 5, 7, 9, 11]["CDEFGAB".index(nUp)] + (12 if nUp != n else 0)
+    if acc:
+        p += (1 if acc[0] == "^" else -1) * len(acc)
+    if oct:
+        p += (12 if oct[0] == "'" else -12) * len(oct)
     return p
 
-def staffStep (ptc, o, clef, tstep):
+
+def staffStep(ptc, o, clef, tstep):
     ndif = 0
-    if 'stafflines=1' in clef: ndif += 4                    # meaning of one line: E (xml) -> B (abc)
-    if not tstep and clef.startswith ('bass'): ndif += 12   # transpose bass -> treble (C3 -> A4)
-    if ndif:    # diatonic transposition == addition modulo 7
-        nm7 = 'C,D,E,F,G,A,B'.split (',')
-        n = nm7.index (ptc) + ndif
-        ptc, o = nm7 [n % 7], o + n // 7
-    if o > 4: ptc = ptc.lower ()
-    if o > 5: ptc = ptc + (o-5) * "'"
-    if o < 4: ptc = ptc + (4-o) * ","
+    if "stafflines=1" in clef:
+        ndif += 4  # meaning of one line: E (xml) -> B (abc)
+    if not tstep and clef.startswith("bass"):
+        ndif += 12  # transpose bass -> treble (C3 -> A4)
+    if ndif:  # diatonic transposition == addition modulo 7
+        nm7 = "C,D,E,F,G,A,B".split(",")
+        n = nm7.index(ptc) + ndif
+        ptc, o = nm7[n % 7], o + n // 7
+    if o > 4:
+        ptc = ptc.lower()
+    if o > 5:
+        ptc = ptc + (o - 5) * "'"
+    if o < 4:
+        ptc = ptc + (4 - o) * ","
     return ptc
 
-def setKey (fifths, mode):
-    sharpness = ['Fb', 'Cb','Gb','Db','Ab','Eb','Bb','F','C','G','D','A', 'E', 'B', 'F#','C#','G#','D#','A#','E#','B#']
-    offTab = {'maj':8, 'ion':8, 'm':11, 'min':11, 'aeo':11, 'mix':9, 'dor':10, 'phr':12, 'lyd':7, 'loc':13, 'non':8}
-    mode = mode.lower ()[:3] # only first three chars, no case
-    key = sharpness [offTab [mode] + fifths] + (mode if offTab [mode] != 8 else '')
-    accs = ['F','C','G','D','A','E','B']
-    if fifths >= 0: msralts = dict (zip (accs[:fifths], fifths * [1]))
-    else:           msralts = dict (zip (accs[fifths:], -fifths * [-1]))
+
+def setKey(fifths, mode):
+    sharpness = [
+        "Fb",
+        "Cb",
+        "Gb",
+        "Db",
+        "Ab",
+        "Eb",
+        "Bb",
+        "F",
+        "C",
+        "G",
+        "D",
+        "A",
+        "E",
+        "B",
+        "F#",
+        "C#",
+        "G#",
+        "D#",
+        "A#",
+        "E#",
+        "B#",
+    ]
+    offTab = {
+        "maj": 8,
+        "ion": 8,
+        "m": 11,
+        "min": 11,
+        "aeo": 11,
+        "mix": 9,
+        "dor": 10,
+        "phr": 12,
+        "lyd": 7,
+        "loc": 13,
+        "non": 8,
+    }
+    mode = mode.lower()[:3]  # only first three chars, no case
+    key = sharpness[offTab[mode] + fifths] + (mode if offTab[mode] != 8 else "")
+    accs = ["F", "C", "G", "D", "A", "E", "B"]
+    if fifths >= 0:
+        msralts = dict(zip(accs[:fifths], fifths * [1]))
+    else:
+        msralts = dict(zip(accs[fifths:], -fifths * [-1]))
     return key, msralts
 
-def insTup (ix, notes, fact):   # read one nested tuplet
+
+def insTup(ix, notes, fact):  # read one nested tuplet
     tupcnt = 0
-    nx = notes [ix]
-    if 'start' in nx.tup:
-        nx.tup.remove ('start') # do recursive calls when starts remain
-    tix = ix                    # index of first tuplet note
-    fn, fd = fact               # xml time-mod of the higher level
-    fnum, fden = nx.fact        # xml time-mod of the current level
-    tupfact = fnum//fn, fden//fd  # abc time mod of this level
-    while ix < len (notes):
-        nx = notes [ix]
-        if isinstance (nx, Elem) or nx.grace:
-            ix += 1             # skip all non tuplet elements
+    nx = notes[ix]
+    if "start" in nx.tup:
+        nx.tup.remove("start")  # do recursive calls when starts remain
+    tix = ix  # index of first tuplet note
+    fn, fd = fact  # xml time-mod of the higher level
+    fnum, fden = nx.fact  # xml time-mod of the current level
+    tupfact = fnum // fn, fden // fd  # abc time mod of this level
+    while ix < len(notes):
+        nx = notes[ix]
+        if isinstance(nx, Elem) or nx.grace:
+            ix += 1  # skip all non tuplet elements
             continue
-        if 'start' in nx.tup:   # more nested tuplets to start
-            ix, tupcntR = insTup (ix, notes, tupfact)   # ix is on the stop note!
+        if "start" in nx.tup:  # more nested tuplets to start
+            ix, tupcntR = insTup(ix, notes, tupfact)  # ix is on the stop note!
             tupcnt += tupcntR
         elif nx.fact:
-            tupcnt += 1         # count tuplet elements
-        if 'stop' in nx.tup:
-            nx.tup.remove ('stop')
+            tupcnt += 1  # count tuplet elements
+        if "stop" in nx.tup:
+            nx.tup.remove("stop")
             break
-        if not nx.fact:         # stop on first non tuplet note
-            ix = lastix         # back to last tuplet note
+        if not nx.fact:  # stop on first non tuplet note
+            ix = lastix  # back to last tuplet note
             break
         lastix = ix
         ix += 1
     # put abc tuplet notation before the recursive ones
     tup = (tupfact[0], tupfact[1], tupcnt)
-    if tup == (3, 2, 3): tupPrefix = '(3'
-    else:                tupPrefix = '(%d:%d:%d' % tup
-    notes [tix].tupabc = tupPrefix + notes [tix].tupabc
-    return ix, tupcnt           # ix is on the last tuplet note
+    if tup == (3, 2, 3):
+        tupPrefix = "(3"
+    else:
+        tupPrefix = "(%d:%d:%d" % tup
+    notes[tix].tupabc = tupPrefix + notes[tix].tupabc
+    return ix, tupcnt  # ix is on the last tuplet note
 
-def mkBroken (vs):      # introduce broken rhythms (vs: one voice, one measure)
-    vs = [n for n in vs if isinstance (n, Note)]
+
+def mkBroken(vs):  # introduce broken rhythms (vs: one voice, one measure)
+    vs = [n for n in vs if isinstance(n, Note)]
     i = 0
-    while i < len (vs) - 1:
-        n1, n2 = vs[i], vs[i+1]     # scan all adjacent pairs
+    while i < len(vs) - 1:
+        n1, n2 = vs[i], vs[i + 1]  # scan all adjacent pairs
         # skip if note in tuplet or has no duration or outside beam
         if not n1.fact and not n2.fact and n1.dur > 0 and n2.beam:
             if n1.dur * 3 == n2.dur:
                 n2.dur = (2 * n2.dur) // 3
                 n1.dur = n1.dur * 2
-                n1.after = '<' + n1.after
-                i += 1              # do not chain broken rhythms
+                n1.after = "<" + n1.after
+                i += 1  # do not chain broken rhythms
             elif n2.dur * 3 == n1.dur:
                 n1.dur = (2 * n1.dur) // 3
                 n2.dur = n2.dur * 2
-                n1.after = '>' + n1.after
-                i += 1              # do not chain broken rhythms
+                n1.after = ">" + n1.after
+                i += 1  # do not chain broken rhythms
         i += 1
 
-def outVoice (measure, divs, im, ip, unitL):    # note/elem objects of one measure in one voice
+
+def outVoice(
+    measure, divs, im, ip, unitL
+):  # note/elem objects of one measure in one voice
     ix = 0
-    while ix < len (measure):   # set all (nested) tuplet annotations
-        nx = measure [ix]
-        if isinstance (nx, Note) and nx.fact and not nx.grace:
-            ix, tupcnt = insTup (ix, measure, (1, 1))   # read one tuplet, insert annotation(s)
-        ix += 1 
+    while ix < len(measure):  # set all (nested) tuplet annotations
+        nx = measure[ix]
+        if isinstance(nx, Note) and nx.fact and not nx.grace:
+            ix, tupcnt = insTup(
+                ix, measure, (1, 1)
+            )  # read one tuplet, insert annotation(s)
+        ix += 1
     vs = []
     for nx in measure:
-        if isinstance (nx, Note):
-            durstr = abcdur (nx, divs, unitL)           # xml -> abc duration string
-            chord = len (nx.ns) > 1
-            cns = [nt[:-1] for nt in nx.ns if nt.endswith ('-')]
-            tie = ''
-            if chord and len (cns) == len (nx.ns):      # all chord notes tied
-                nx.ns = cns     # chord notes without tie
-                tie = '-'       # one tie for whole chord
-            s = nx.tupabc + ''.join (nx.before)
-            if chord: s += '['
-            for nt in nx.ns: s += nt
-            if chord: s += ']' + tie
-            if s.endswith ('-'): s, tie = s[:-1], '-'   # split off tie
-            s += durstr + tie   # and put it back again
+        if isinstance(nx, Note):
+            durstr = abcdur(nx, divs, unitL)  # xml -> abc duration string
+            chord = len(nx.ns) > 1
+            cns = [nt[:-1] for nt in nx.ns if nt.endswith("-")]
+            tie = ""
+            if chord and len(cns) == len(nx.ns):  # all chord notes tied
+                nx.ns = cns  # chord notes without tie
+                tie = "-"  # one tie for whole chord
+            s = nx.tupabc + "".join(nx.before)
+            if chord:
+                s += "["
+            for nt in nx.ns:
+                s += nt
+            if chord:
+                s += "]" + tie
+            if s.endswith("-"):
+                s, tie = s[:-1], "-"  # split off tie
+            s += durstr + tie  # and put it back again
             s += nx.after
             nospace = nx.beam
         else:
-            if isinstance (nx.str, listtype): nx.str = nx.str [0]
+            if isinstance(nx.str, listtype):
+                nx.str = nx.str[0]
             s = nx.str
             nospace = 1
-        if nospace: vs.append (s)
-        else: vs.append (' ' + s)
-    vs = ''.join (vs)   # ad hoc: remove multiple pedal directions
-    while vs.find ('!ped!!ped!') >= 0: vs = vs.replace ('!ped!!ped!','!ped!')
-    while vs.find ('!ped-up!!ped-up!') >= 0: vs = vs.replace ('!ped-up!!ped-up!','!ped-up!')
-    while vs.find ('!8va(!!8va)!') >= 0: vs = vs.replace ('!8va(!!8va)!','')    # remove empty ottava's
+        if nospace:
+            vs.append(s)
+        else:
+            vs.append(" " + s)
+    vs = "".join(vs)  # ad hoc: remove multiple pedal directions
+    while vs.find("!ped!!ped!") >= 0:
+        vs = vs.replace("!ped!!ped!", "!ped!")
+    while vs.find("!ped-up!!ped-up!") >= 0:
+        vs = vs.replace("!ped-up!!ped-up!", "!ped-up!")
+    while vs.find("!8va(!!8va)!") >= 0:
+        vs = vs.replace("!8va(!!8va)!", "")  # remove empty ottava's
     return vs
 
-def sortMeasure (voice, m):
-    voice.sort (key=lambda o: o.tijd)   # sort on time
+
+def sortMeasure(voice, m):
+    voice.sort(key=lambda o: o.tijd)  # sort on time
     time = 0
     v = []
-    rs = []                            # holds rests in between notes
-    for i, nx in enumerate (voice):    # establish sequentiality
-        if nx.tijd > time and chkbug (nx.tijd - time, m):
-            v.append (Note (nx.tijd - time, 'x'))   # fill hole with invisble rest
-            rs.append (len (v) - 1)
-        if isinstance (nx, Elem):
-            if nx.tijd < time: nx.tijd = time # shift elems without duration to where they fit
-            v.append (nx)
+    rs = []  # holds rests in between notes
+    for i, nx in enumerate(voice):  # establish sequentiality
+        if nx.tijd > time and chkbug(nx.tijd - time, m):
+            v.append(Note(nx.tijd - time, "x"))  # fill hole with invisble rest
+            rs.append(len(v) - 1)
+        if isinstance(nx, Elem):
+            if nx.tijd < time:
+                nx.tijd = time  # shift elems without duration to where they fit
+            v.append(nx)
             time = nx.tijd
             continue
-        if nx.tijd < time:                  # overlapping element
-            if nx.ns[0] == 'z': continue    # discard overlapping rest
-            if v[-1].tijd <= nx.tijd:       # we can do something
-                if v[-1].ns[0] == 'z':      # shorten rest
+        if nx.tijd < time:  # overlapping element
+            if nx.ns[0] == "z":
+                continue  # discard overlapping rest
+            if v[-1].tijd <= nx.tijd:  # we can do something
+                if v[-1].ns[0] == "z":  # shorten rest
                     v[-1].dur = nx.tijd - v[-1].tijd
-                    if v[-1].dur == 0: del v[-1]        # nothing left
-                    info ('overlap in part %d, measure %d: rest shortened' % (m.ixp+1, m.ixm+1))
-                else:                       # make a chord of overlap
+                    if v[-1].dur == 0:
+                        del v[-1]  # nothing left
+                    info(
+                        "overlap in part %d, measure %d: rest shortened"
+                        % (m.ixp + 1, m.ixm + 1)
+                    )
+                else:  # make a chord of overlap
                     v[-1].ns += nx.ns
-                    info ('overlap in part %d, measure %d: added chord' % (m.ixp+1, m.ixm+1))
+                    info(
+                        "overlap in part %d, measure %d: added chord"
+                        % (m.ixp + 1, m.ixm + 1)
+                    )
                     nx.dur = (nx.tijd + nx.dur) - time  # the remains
-                    if nx.dur <= 0: continue            # nothing left
-                    nx.tijd = time          # append remains
-            else:                           # give up
-                info ('overlapping notes in one voice! part %d, measure %d, note %s discarded' % (m.ixp+1, m.ixm+1, isinstance (nx, Note) and nx.ns or nx.str))
+                    if nx.dur <= 0:
+                        continue  # nothing left
+                    nx.tijd = time  # append remains
+            else:  # give up
+                info(
+                    "overlapping notes in one voice! part %d, measure %d, note %s discarded"
+                    % (m.ixp + 1, m.ixm + 1, isinstance(nx, Note) and nx.ns or nx.str)
+                )
                 continue
-        v.append (nx)
-        if isinstance (nx, Note):
-            if nx.ns [0] in 'zx':
-                rs.append (len (v) - 1)     # remember rests between notes
-            elif len (rs):
-                if nx.beam and not nx.grace:    # copy beam into rests
-                    for j in rs: v[j].beam = nx.beam
-                rs = []                     # clear rests on each note
+        v.append(nx)
+        if isinstance(nx, Note):
+            if nx.ns[0] in "zx":
+                rs.append(len(v) - 1)  # remember rests between notes
+            elif len(rs):
+                if nx.beam and not nx.grace:  # copy beam into rests
+                    for j in rs:
+                        v[j].beam = nx.beam
+                rs = []  # clear rests on each note
         time = nx.tijd + nx.dur
     #   when a measure contains no elements and no forwards -> no incTime -> s.maxtime = 0 -> right barline
     #   is inserted at time == 0 (in addbar) and is only element in the voice when sortMeasure is called
-    if time == 0: info ('empty measure in part %d, measure %d, it should contain at least a rest to advance the time!' % (m.ixp+1, m.ixm+1))
+    if time == 0:
+        info(
+            "empty measure in part %d, measure %d, it should contain at least a rest to advance the time!"
+            % (m.ixp + 1, m.ixm + 1)
+        )
     return v
 
-def getPartlist (ps):   # correct part-list (from buggy xml-software)
-    xs = [] # the corrected part-list
+
+def getPartlist(ps):  # correct part-list (from buggy xml-software)
+    xs = []  # the corrected part-list
     e = []  # stack of opened part-groups
-    for x in list (ps): # insert missing stops, delete double starts
-        if x.tag ==  'part-group':
-            num, type = x.get ('number'), x.get ('type')
-            if type == 'start':
-                if num in e:    # missing stop: insert one
-                    xs.append (E.Element ('part-group', number = num, type = 'stop'))
-                    xs.append (x)
-                else:           # normal start
-                    xs.append (x)
-                    e.append (num)
+    for x in list(ps):  # insert missing stops, delete double starts
+        if x.tag == "part-group":
+            num, type = x.get("number"), x.get("type")
+            if type == "start":
+                if num in e:  # missing stop: insert one
+                    xs.append(E.Element("part-group", number=num, type="stop"))
+                    xs.append(x)
+                else:  # normal start
+                    xs.append(x)
+                    e.append(num)
             else:
-                if num in e:    # normal stop
-                    e.remove (num)
-                    xs.append (x)
-                else: pass      # double stop: skip it
-        else: xs.append (x)
-    for num in reversed (e):    # fill missing stops at the end
-        xs.append (E.Element ('part-group', number = num, type = 'stop'))
+                if num in e:  # normal stop
+                    e.remove(num)
+                    xs.append(x)
+                else:
+                    pass  # double stop: skip it
+        else:
+            xs.append(x)
+    for num in reversed(e):  # fill missing stops at the end
+        xs.append(E.Element("part-group", number=num, type="stop"))
     return xs
 
-def parseParts (xs, d, e):  # -> [elems on current level], rest of xs
-    if not xs: return [],[]
-    x = xs.pop (0)
-    if x.tag == 'part-group':
-        num, type = x.get ('number'), x.get ('type')
-        if type == 'start': # go one level deeper
-            s = [x.findtext (n, '') for n in ['group-symbol','group-barline','group-name','group-abbreviation']]
-            d [num] = s     # remember groupdata by group number
-            e.append (num)  # make stack of open group numbers
-            elemsnext, rest1 = parseParts (xs, d, e) # parse one level deeper to next stop
-            elems, rest2 = parseParts (rest1, d, e)  # parse the rest on this level
+
+def parseParts(xs, d, e):  # -> [elems on current level], rest of xs
+    if not xs:
+        return [], []
+    x = xs.pop(0)
+    if x.tag == "part-group":
+        num, type = x.get("number"), x.get("type")
+        if type == "start":  # go one level deeper
+            s = [
+                x.findtext(n, "")
+                for n in [
+                    "group-symbol",
+                    "group-barline",
+                    "group-name",
+                    "group-abbreviation",
+                ]
+            ]
+            d[num] = s  # remember groupdata by group number
+            e.append(num)  # make stack of open group numbers
+            elemsnext, rest1 = parseParts(
+                xs, d, e
+            )  # parse one level deeper to next stop
+            elems, rest2 = parseParts(rest1, d, e)  # parse the rest on this level
             return [elemsnext] + elems, rest2
-        else:               # stop: close level and return group-data
-            nums = e.pop () # last open group number in stack order
-            if xs and xs[0].get ('type') == 'stop':     # two consequetive stops
-                if num != nums:                         # in the wrong order (tempory solution)
-                    d[nums], d[num] = d[num], d[nums]   # exchange values    (only works for two stops!!!)
-            sym = d[num]    # retrieve an return groupdata as last element of the group
+        else:  # stop: close level and return group-data
+            nums = e.pop()  # last open group number in stack order
+            if xs and xs[0].get("type") == "stop":  # two consequetive stops
+                if num != nums:  # in the wrong order (tempory solution)
+                    d[nums], d[num] = (
+                        d[num],
+                        d[nums],
+                    )  # exchange values    (only works for two stops!!!)
+            sym = d[num]  # retrieve an return groupdata as last element of the group
             return [sym], xs
     else:
-        elems, rest = parseParts (xs, d, e) # parse remaining elements on current level
-        name = x.findtext ('part-name',''), x.findtext ('part-abbreviation','')
+        elems, rest = parseParts(xs, d, e)  # parse remaining elements on current level
+        name = x.findtext("part-name", ""), x.findtext("part-abbreviation", "")
         return [name] + elems, rest
 
-def bracePart (part):       # put a brace on multistaff part and group voices
-    if not part: return []  # empty part in the score
+
+def bracePart(part):  # put a brace on multistaff part and group voices
+    if not part:
+        return []  # empty part in the score
     brace = []
     for ivs in part:
-        if len (ivs) == 1:  # stave with one voice
-            brace.append ('%s' % ivs[0])
-        else:               # stave with multiple voices
-            brace += ['('] + ['%s' % iv for iv in ivs] + [')']
-        brace.append ('|')
-    del brace[-1]           # no barline at the end
-    if len (part) > 1:
-        brace = ['{'] + brace + ['}']
+        if len(ivs) == 1:  # stave with one voice
+            brace.append("%s" % ivs[0])
+        else:  # stave with multiple voices
+            brace += ["("] + ["%s" % iv for iv in ivs] + [")"]
+        brace.append("|")
+    del brace[-1]  # no barline at the end
+    if len(part) > 1:
+        brace = ["{"] + brace + ["}"]
     return brace
 
-def prgroupelem (x, gnm, bar, pmap, accVce, accStf):    # collect partnames (accVce) and %%score map (accStf)
-    if type (x) == tupletype:   # partname-tuple = (part-name, part-abbrev)
-        y = pmap.pop (0)
-        if gnm[0]: x = [n1 + ':' + n2 for n1, n2 in zip (gnm, x)]   # put group-name before part-name
-        accVce.append (x)
-        accStf.extend (bracePart (y))
-    elif len (x) == 2 and type (x[0]) == tupletype: # misuse of group just to add extra name to stave
-        y = pmap.pop (0)
-        nms = [n1 + ':' + n2 for n1, n2 in zip (x[0], x[1][2:])]    # x[0] = partname-tuple, x[1][2:] = groupname-tuple
-        accVce.append (nms)
-        accStf.extend (bracePart (y))
+
+def prgroupelem(
+    x, gnm, bar, pmap, accVce, accStf
+):  # collect partnames (accVce) and %%score map (accStf)
+    if type(x) == tupletype:  # partname-tuple = (part-name, part-abbrev)
+        y = pmap.pop(0)
+        if gnm[0]:
+            x = [
+                n1 + ":" + n2 for n1, n2 in zip(gnm, x)
+            ]  # put group-name before part-name
+        accVce.append(x)
+        accStf.extend(bracePart(y))
+    elif (
+        len(x) == 2 and type(x[0]) == tupletype
+    ):  # misuse of group just to add extra name to stave
+        y = pmap.pop(0)
+        nms = [
+            n1 + ":" + n2 for n1, n2 in zip(x[0], x[1][2:])
+        ]  # x[0] = partname-tuple, x[1][2:] = groupname-tuple
+        accVce.append(nms)
+        accStf.extend(bracePart(y))
     else:
-        prgrouplist (x, bar, pmap, accVce, accStf)
+        prgrouplist(x, bar, pmap, accVce, accStf)
 
-def prgrouplist (x, pbar, pmap, accVce, accStf):    # collect partnames, scoremap for a part-group
-    sym, bar, gnm, gabbr = x[-1]    # bracket symbol, continue barline, group-name-tuple
-    bar = bar == 'yes' or pbar      # pbar -> the parent has bar
-    accStf.append (sym == 'brace' and '{' or '[')
+
+def prgrouplist(
+    x, pbar, pmap, accVce, accStf
+):  # collect partnames, scoremap for a part-group
+    sym, bar, gnm, gabbr = x[-1]  # bracket symbol, continue barline, group-name-tuple
+    bar = bar == "yes" or pbar  # pbar -> the parent has bar
+    accStf.append(sym == "brace" and "{" or "[")
     for z in x[:-1]:
-        prgroupelem (z, (gnm, gabbr), bar, pmap, accVce, accStf)
-        if bar: accStf.append ('|')
-    if bar: del accStf [-1]         # remove last one before close
-    accStf.append (sym == 'brace' and '}' or ']')
+        prgroupelem(z, (gnm, gabbr), bar, pmap, accVce, accStf)
+        if bar:
+            accStf.append("|")
+    if bar:
+        del accStf[-1]  # remove last one before close
+    accStf.append(sym == "brace" and "}" or "]")
 
-def compUnitLength (iv, maten, divs):   # compute optimal unit length
+
+def compUnitLength(iv, maten, divs):  # compute optimal unit length
     uLmin, minLen = 0, max_int
-    for uL in [4,8,16]:     # try 1/4, 1/8 and 1/16
-        vLen = 0            # total length of abc duration strings in this voice
-        for im, m in enumerate (maten): # all measures
-            for e in m[iv]: # all notes in voice iv
-                if isinstance (e, Elem) or e.dur == 0: continue # no real durations
-                vLen += len (abcdur (e, divs [im], uL))  # add len of duration string
-        if vLen < minLen: uLmin, minLen = uL, vLen  # remember the smallest
+    for uL in [4, 8, 16]:  # try 1/4, 1/8 and 1/16
+        vLen = 0  # total length of abc duration strings in this voice
+        for im, m in enumerate(maten):  # all measures
+            for e in m[iv]:  # all notes in voice iv
+                if isinstance(e, Elem) or e.dur == 0:
+                    continue  # no real durations
+                vLen += len(abcdur(e, divs[im], uL))  # add len of duration string
+        if vLen < minLen:
+            uLmin, minLen = uL, vLen  # remember the smallest
     return uLmin
 
-def doSyllable (syl):
-    txt = ''
+
+def doSyllable(syl):
+    txt = ""
     for e in syl:
-        if   e.tag == 'elision': txt += '~'
-        elif e.tag == 'text':   # escape - and space characters
-            txt += (e.text or '').replace ('_','\_').replace('-', r'\-').replace(' ', '~')
-    if not txt: return txt
-    if syl.findtext('syllabic') in ['begin', 'middle']: txt += '-'
-    if syl.find('extend') is not None:                  txt += '_'
+        if e.tag == "elision":
+            txt += "~"
+        elif e.tag == "text":  # escape - and space characters
+            txt += (
+                (e.text or "").replace("_", "\_").replace("-", r"\-").replace(" ", "~")
+            )
+    if not txt:
+        return txt
+    if syl.findtext("syllabic") in ["begin", "middle"]:
+        txt += "-"
+    if syl.find("extend") is not None:
+        txt += "_"
     return txt
 
-def checkMelismas (lyrics, maten, im, iv):
-    if im == 0: return
-    maat = maten [im][iv]               # notes of the current measure
-    curlyr = lyrics [im][iv]            # lyrics dict of current measure
-    prvlyr = lyrics [im-1][iv]          # lyrics dict of previous measure
-    for n, (lyrstr, melis) in prvlyr.items ():  # all lyric numbers in the previous measure
-        if n not in curlyr and melis:   # melisma required, but no lyrics present -> make one!
-            ms = getMelisma (maat)      # get a melisma for the current measure
-            if ms: curlyr [n] = (ms, 0) # set melisma as the n-th lyrics of the current measure
 
-def getMelisma (maat):                  # get melisma from notes in maat
+def checkMelismas(lyrics, maten, im, iv):
+    if im == 0:
+        return
+    maat = maten[im][iv]  # notes of the current measure
+    curlyr = lyrics[im][iv]  # lyrics dict of current measure
+    prvlyr = lyrics[im - 1][iv]  # lyrics dict of previous measure
+    for n, (
+        lyrstr,
+        melis,
+    ) in prvlyr.items():  # all lyric numbers in the previous measure
+        if (
+            n not in curlyr and melis
+        ):  # melisma required, but no lyrics present -> make one!
+            ms = getMelisma(maat)  # get a melisma for the current measure
+            if ms:
+                curlyr[n] = (
+                    ms,
+                    0,
+                )  # set melisma as the n-th lyrics of the current measure
+
+
+def getMelisma(maat):  # get melisma from notes in maat
     ms = []
-    for note in maat:                   # every note should get an underscore
-        if not isinstance (note, Note): continue    # skip Elem's
-        if note.grace: continue         # skip grace notes
-        if note.ns [0] in 'zx': break   # stop on first rest
-        ms.append ('_')
-    return ' '.join (ms)
+    for note in maat:  # every note should get an underscore
+        if not isinstance(note, Note):
+            continue  # skip Elem's
+        if note.grace:
+            continue  # skip grace notes
+        if note.ns[0] in "zx":
+            break  # stop on first rest
+        ms.append("_")
+    return " ".join(ms)
 
-def perc2map (abcIn):
-    fillmap = {'diamond':1, 'triangle':1, 'square':1, 'normal':1};
-    abc = map (lambda x: x.strip (), percSvg.splitlines ())
-    id='default'
-    maps = {'default': []};
-    dmaps = {'default': []}
-    r1 = re.compile (r'V:\s*(\S+)')
-    ls = abcIn.splitlines ()
+
+def perc2map(abcIn):
+    fillmap = {"diamond": 1, "triangle": 1, "square": 1, "normal": 1}
+    abc = map(lambda x: x.strip(), percSvg.splitlines())
+    id = "default"
+    maps = {"default": []}
+    dmaps = {"default": []}
+    r1 = re.compile(r"V:\s*(\S+)")
+    ls = abcIn.splitlines()
     for x in ls:
-        if 'I:percmap' in x:
-            noot, step, midi, kop = map (lambda x: x.strip (), x.split ()[1:])
-            if kop in fillmap: kop = kop + '+' + ',' + kop
-            x = '%%%%map perc%s %s print=%s midi=%s heads=%s' % (id, noot, step, midi, kop)
-            maps [id].append (x)
-        if '%%MIDI' in x: dmaps [id].append (x)
-        if 'V:' in x:
-            r = r1.match (x)
+        if "I:percmap" in x:
+            noot, step, midi, kop = map(lambda x: x.strip(), x.split()[1:])
+            if kop in fillmap:
+                kop = kop + "+" + "," + kop
+            x = "%%%%map perc%s %s print=%s midi=%s heads=%s" % (
+                id,
+                noot,
+                step,
+                midi,
+                kop,
+            )
+            maps[id].append(x)
+        if "%%MIDI" in x:
+            dmaps[id].append(x)
+        if "V:" in x:
+            r = r1.match(x)
             if r:
-                id = r.group (1);
-                if id not in maps: maps [id] = []; dmaps [id] = []
-    ids = sorted (maps.keys ())
-    for id in ids: abc += maps [id]
-    id='default'
+                id = r.group(1)
+                if id not in maps:
+                    maps[id] = []
+                    dmaps[id] = []
+    ids = sorted(maps.keys())
+    for id in ids:
+        abc += maps[id]
+    id = "default"
     for x in ls:
-        if 'I:percmap' in x: continue
-        if '%%MIDI' in x: continue
-        if 'V:' in x or 'K:' in x:
-            r = r1.match (x)
-            if r: id = r.group (1)
-            abc.append (x)
-            if id in dmaps and len (dmaps [id]) > 0: abc.extend (dmaps [id]); del dmaps [id]
-            if 'perc' in x and 'map=' not in x: x += ' map=perc';
-            if 'map=perc' in x and len (maps [id]) > 0: abc.append ('%%voicemap perc' + id);
-            if 'map=off' in x: abc.append ('%%voicemap');            
+        if "I:percmap" in x:
+            continue
+        if "%%MIDI" in x:
+            continue
+        if "V:" in x or "K:" in x:
+            r = r1.match(x)
+            if r:
+                id = r.group(1)
+            abc.append(x)
+            if id in dmaps and len(dmaps[id]) > 0:
+                abc.extend(dmaps[id])
+                del dmaps[id]
+            if "perc" in x and "map=" not in x:
+                x += " map=perc"
+            if "map=perc" in x and len(maps[id]) > 0:
+                abc.append("%%voicemap perc" + id)
+            if "map=off" in x:
+                abc.append("%%voicemap")
         else:
-            abc.append (x)
-    return '\n'.join (abc) + '\n'
+            abc.append(x)
+    return "\n".join(abc) + "\n"
 
-def addoct (ptc, o):    # xml staff step, xml octave number
+
+def addoct(ptc, o):  # xml staff step, xml octave number
     p = ptc
-    if o > 4: p = ptc.lower ()
-    if o > 5: p = p + (o-5) * "'"
-    if o < 4: p = p + (4-o) * ","
-    return p            # abc pitch == abc note without accidental
+    if o > 4:
+        p = ptc.lower()
+    if o > 5:
+        p = p + (o - 5) * "'"
+    if o < 4:
+        p = p + (4 - o) * ","
+    return p  # abc pitch == abc note without accidental
 
-def chkbug (dt, m):
-    if dt > m.divs / 16: return 1   # duration should be > 1/64 note
-    info ('MuseScore bug: incorrect duration, smaller then 1/64! in measure %d, part %d' % (m.ixm, m.ixp))
+
+def chkbug(dt, m):
+    if dt > m.divs / 16:
+        return 1  # duration should be > 1/64 note
+    info(
+        "MuseScore bug: incorrect duration, smaller then 1/64! in measure %d, part %d"
+        % (m.ixm, m.ixp)
+    )
     return 0
 
-#----------------
-# parser
-#----------------
-class Parser:
-    note_alts = [   # 3 alternative notations of the same note for tablature mapping
-        [x.strip () for x in '=C,  ^C, =D, ^D, =E, =F, ^F, =G, ^G, =A, ^A, =B'.split (',')],
-        [x.strip () for x in '^B,  _D,^^C, _E, _F, ^E, _G,^^F, _A,^^G, _B, _C'.split (',')],
-        [x.strip () for x in '__D,^^B,__E,__F,^^D,__G,^^E,__A,_/A,__B,__C,^^A'.split (',')] ]
-    step_map = {'C':0,'D':2,'E':4,'F':5,'G':7,'A':9,'B':11}
-    def __init__ (s, options):
-        # unfold repeats, number of chars per line, credit filter level, volta option
-        s.slurBuf = {}    # dict of open slurs keyed by slur number
-        s.dirStk = {}     # {direction-type + number -> (type, voice | time)} dict for proper closing
-        s.ingrace = 0     # marks a sequence of grace notes
-        s.msc = Music (options)  # global music data abstraction
-        s.unfold = options.u    # turn unfolding repeats on
-        s.ctf = options.c       # credit text filter level
-        s.gStfMap = []    # [[abc voice numbers] for all parts]
-        s.midiMap = []    # midi-settings for each abc voice, in order
-        s.drumInst = {}   # inst_id -> midi pitch for channel 10 notes
-        s.drumNotes = {}  # (xml voice, abc note) -> (midi note, note head)
-        s.instMid = []    # [{inst id -> midi-settings} for all parts]
-        s.midDflt = [-1,-1,-1,-91] # default midi settings for channel, program, volume, panning
-        s.msralts = {}    # xml-notenames (without octave) with accidentals from the key
-        s.curalts = {}    # abc-notenames (with voice number) with passing accidentals
-        s.stfMap = {}     # xml staff number -> [xml voice number]
-        s.vce2stf = {}    # xml voice number -> allocated staff number
-        s.clefMap = {}    # xml staff number -> abc clef (for header only)
-        s.curClef = {}    # xml staff number -> current abc clef
-        s.stemDir = {}    # xml voice number -> current stem direction
-        s.clefOct = {}    # xml staff number -> current clef-octave-change
-        s.curStf = {}     # xml voice number -> current xml staff number
-        s.nolbrk = options.x;   # generate no linebreaks ($)
-        s.jscript = options.j   # compatibility with javascript version
-        s.ornaments = sorted (note_ornamentation_map.items ())
-        s.doPageFmt = len (options.p) == 1 # translate xml page format
-        s.tstep = options.t     # clef determines step on staff (percussion)
-        s.dirtov1 = options.v1  # all directions to first voice of staff
-        s.ped = options.ped     # render pedal directions
-        s.wstems = options.stm  # translate stem elements
-        s.pedVce = None   # voice for pedal directions
-        s.repeat_str = {} # staff number -> [measure number, repeat-text]
-        s.tabVceMap = {}  # abc voice num -> [%%map ...] for tab voices
-        s.koppen = {}     # noteheads needed for %%map
 
-    def matchSlur (s, type2, n, v2, note2, grace, stopgrace): # match slur number n in voice v2, add abc code to before/after
-        if type2 not in ['start', 'stop']: return   # slur type continue has no abc equivalent
-        if n == None: n = '1'
+# ----------------
+# parser
+# ----------------
+class Parser:
+    note_alts = [  # 3 alternative notations of the same note for tablature mapping
+        [
+            x.strip()
+            for x in "=C,  ^C, =D, ^D, =E, =F, ^F, =G, ^G, =A, ^A, =B".split(",")
+        ],
+        [
+            x.strip()
+            for x in "^B,  _D,^^C, _E, _F, ^E, _G,^^F, _A,^^G, _B, _C".split(",")
+        ],
+        [
+            x.strip()
+            for x in "__D,^^B,__E,__F,^^D,__G,^^E,__A,_/A,__B,__C,^^A".split(",")
+        ],
+    ]
+    step_map = {"C": 0, "D": 2, "E": 4, "F": 5, "G": 7, "A": 9, "B": 11}
+
+    def __init__(s, options):
+        # unfold repeats, number of chars per line, credit filter level, volta option
+        s.slurBuf = {}  # dict of open slurs keyed by slur number
+        s.dirStk = (
+            {}
+        )  # {direction-type + number -> (type, voice | time)} dict for proper closing
+        s.ingrace = 0  # marks a sequence of grace notes
+        s.msc = Music(options)  # global music data abstraction
+        s.unfold = options.u  # turn unfolding repeats on
+        s.ctf = options.c  # credit text filter level
+        s.gStfMap = []  # [[abc voice numbers] for all parts]
+        s.midiMap = []  # midi-settings for each abc voice, in order
+        s.drumInst = {}  # inst_id -> midi pitch for channel 10 notes
+        s.drumNotes = {}  # (xml voice, abc note) -> (midi note, note head)
+        s.instMid = []  # [{inst id -> midi-settings} for all parts]
+        s.midDflt = [
+            -1,
+            -1,
+            -1,
+            -91,
+        ]  # default midi settings for channel, program, volume, panning
+        s.msralts = {}  # xml-notenames (without octave) with accidentals from the key
+        s.curalts = {}  # abc-notenames (with voice number) with passing accidentals
+        s.stfMap = {}  # xml staff number -> [xml voice number]
+        s.vce2stf = {}  # xml voice number -> allocated staff number
+        s.clefMap = {}  # xml staff number -> abc clef (for header only)
+        s.curClef = {}  # xml staff number -> current abc clef
+        s.stemDir = {}  # xml voice number -> current stem direction
+        s.clefOct = {}  # xml staff number -> current clef-octave-change
+        s.curStf = {}  # xml voice number -> current xml staff number
+        s.nolbrk = options.x  # generate no linebreaks ($)
+        s.jscript = options.j  # compatibility with javascript version
+        s.ornaments = sorted(note_ornamentation_map.items())
+        s.doPageFmt = len(options.p) == 1  # translate xml page format
+        s.tstep = options.t  # clef determines step on staff (percussion)
+        s.dirtov1 = options.v1  # all directions to first voice of staff
+        s.ped = options.ped  # render pedal directions
+        s.wstems = options.stm  # translate stem elements
+        s.pedVce = None  # voice for pedal directions
+        s.repeat_str = {}  # staff number -> [measure number, repeat-text]
+        s.tabVceMap = {}  # abc voice num -> [%%map ...] for tab voices
+        s.koppen = {}  # noteheads needed for %%map
+
+    def matchSlur(
+        s, type2, n, v2, note2, grace, stopgrace
+    ):  # match slur number n in voice v2, add abc code to before/after
+        if type2 not in ["start", "stop"]:
+            return  # slur type continue has no abc equivalent
+        if n == None:
+            n = "1"
         if n in s.slurBuf:
-            type1, v1, note1, grace1 = s.slurBuf [n]
-            if type2 != type1:              # slur complete, now check the voice
-                if v2 == v1:                # begins and ends in the same voice: keep it
-                    if type1 == 'start' and (not grace1 or not stopgrace):  # normal slur: start before stop and no grace slur
-                        note1.before = ['('] + note1.before # keep left-right order!
-                        note2.after += ')'
+            type1, v1, note1, grace1 = s.slurBuf[n]
+            if type2 != type1:  # slur complete, now check the voice
+                if v2 == v1:  # begins and ends in the same voice: keep it
+                    if type1 == "start" and (
+                        not grace1 or not stopgrace
+                    ):  # normal slur: start before stop and no grace slur
+                        note1.before = ["("] + note1.before  # keep left-right order!
+                        note2.after += ")"
                     # no else: don't bother with reversed stave spanning slurs
-                del s.slurBuf [n]           # slur finished, remove from stack
-            else:                           # double definition, keep the last
-                info ('double slur numbers %s-%s in part %d, measure %d, voice %d note %s, first discarded' % (type2, n, s.msr.ixp+1, s.msr.ixm+1, v2, note2.ns))
-                s.slurBuf [n] = (type2, v2, note2, grace)
-        else:                               # unmatched slur, put in dict
-            s.slurBuf [n] = (type2, v2, note2, grace)
-    
-    def doNotations (s, note, nttn, isTab):
+                del s.slurBuf[n]  # slur finished, remove from stack
+            else:  # double definition, keep the last
+                info(
+                    "double slur numbers %s-%s in part %d, measure %d, voice %d note %s, first discarded"
+                    % (type2, n, s.msr.ixp + 1, s.msr.ixm + 1, v2, note2.ns)
+                )
+                s.slurBuf[n] = (type2, v2, note2, grace)
+        else:  # unmatched slur, put in dict
+            s.slurBuf[n] = (type2, v2, note2, grace)
+
+    def doNotations(s, note, nttn, isTab):
         for key, val in s.ornaments:
-            if nttn.find (key) != None: note.before += [val]  # just concat all ornaments
-        trem = nttn.find ('ornaments/tremolo')
+            if nttn.find(key) != None:
+                note.before += [val]  # just concat all ornaments
+        trem = nttn.find("ornaments/tremolo")
         if trem != None:
-            type = trem.get ('type')
-            if type == 'single':
-                note.before.insert (0, '!%s!' % (int (trem.text) * '/'))
+            type = trem.get("type")
+            if type == "single":
+                note.before.insert(0, "!%s!" % (int(trem.text) * "/"))
             else:
-                note.fact = None    # no time modification in ABC
-                if s.tstep:         # abc2svg version
-                    if type == 'stop': note.before.insert (0, '!trem%s!' % trem.text);
-                else:               # abc2xml version
-                    if type == 'start': note.before.insert (0, '!%s-!' % (int (trem.text) * '/'));
-        fingering = nttn.findall ('technical/fingering')
-        for finger in fingering:    # handle multiple finger annotations
-            if not isTab: note.before += ['!%s!' % finger.text] # fingering goes before chord (addChord)
-        snaar = nttn.find ('technical/string')
+                note.fact = None  # no time modification in ABC
+                if s.tstep:  # abc2svg version
+                    if type == "stop":
+                        note.before.insert(0, "!trem%s!" % trem.text)
+                else:  # abc2xml version
+                    if type == "start":
+                        note.before.insert(0, "!%s-!" % (int(trem.text) * "/"))
+        fingering = nttn.findall("technical/fingering")
+        for finger in fingering:  # handle multiple finger annotations
+            if not isTab:
+                note.before += [
+                    "!%s!" % finger.text
+                ]  # fingering goes before chord (addChord)
+        snaar = nttn.find("technical/string")
         if snaar != None and isTab:
             if s.tstep:
-                fret = nttn.find ('technical/fret')
-                if fret != None: note.tab = (snaar.text, fret.text)
+                fret = nttn.find("technical/fret")
+                if fret != None:
+                    note.tab = (snaar.text, fret.text)
             else:
-                deco = '!%s!' % snaar.text  # no double string decos (bug in musescore)
-                if deco not in note.ntdec: note.ntdec += deco
-        wvln = nttn.find ('ornaments/wavy-line')
+                deco = "!%s!" % snaar.text  # no double string decos (bug in musescore)
+                if deco not in note.ntdec:
+                    note.ntdec += deco
+        wvln = nttn.find("ornaments/wavy-line")
         if wvln != None:
-            if   wvln.get ('type') == 'start': note.before = ['!trill(!'] + note.before # keep left-right order!
-            elif wvln.get ('type') == 'stop': note.before = ['!trill)!'] + note.before
-        glis = nttn.find ('glissando')
-        if glis == None: glis = nttn.find ('slide') # treat slide as glissando
+            if wvln.get("type") == "start":
+                note.before = ["!trill(!"] + note.before  # keep left-right order!
+            elif wvln.get("type") == "stop":
+                note.before = ["!trill)!"] + note.before
+        glis = nttn.find("glissando")
+        if glis == None:
+            glis = nttn.find("slide")  # treat slide as glissando
         if glis != None:
-            lt = '~' if glis.get ('line-type') =='wavy' else '-'
-            if   glis.get ('type') == 'start': note.before = ['!%s(!' % lt] + note.before # keep left-right order!
-            elif glis.get ('type') == 'stop': note.before = ['!%s)!' % lt] + note.before
+            lt = "~" if glis.get("line-type") == "wavy" else "-"
+            if glis.get("type") == "start":
+                note.before = ["!%s(!" % lt] + note.before  # keep left-right order!
+            elif glis.get("type") == "stop":
+                note.before = ["!%s)!" % lt] + note.before
 
-    def tabnote (s, alt, ptc, oct, v, ntrec):
-        p = s.step_map [ptc] + int (alt or '0') # p in -2 .. 13
-        if p > 11: oct += 1             # octave correction
-        if p < 0: oct -= 1
-        p = p % 12                      # remap p into 0..11
-        snaar_nw, fret_nw = ntrec.tab   # the computed/annotated allocation of nt
-        for i in range (4):             # support same note on 4 strings
-            na = s.note_alts [i % 3] [p]    # get alternative representation of same note
+    def tabnote(s, alt, ptc, oct, v, ntrec):
+        p = s.step_map[ptc] + int(alt or "0")  # p in -2 .. 13
+        if p > 11:
+            oct += 1  # octave correction
+        if p < 0:
+            oct -= 1
+        p = p % 12  # remap p into 0..11
+        snaar_nw, fret_nw = ntrec.tab  # the computed/annotated allocation of nt
+        for i in range(4):  # support same note on 4 strings
+            na = s.note_alts[i % 3][p]  # get alternative representation of same note
             o = oct
-            if na in ['^B', '^^B']: o -= 1  # because in adjacent octave
-            if na in ['_C', '__C']: o += 1
-            if '/' in na or i == 3: o = 9   # emergency notation for 4th string case
-            nt = addoct (na, o)
-            snaar, fret = s.tabmap.get ((v, nt), ('', ''))  # the current allocation of nt
-            if not snaar: break             # note not yet allocated
-            if snaar_nw == snaar: return nt # use present allocation
-            if i == 3:                  # new allocaion needed but none is free
-                fmt = 'rejected: voice %d note %3s string %s fret %2s remains: string %s fret %s'
-                info (fmt % (v, nt, snaar_nw, fret_nw, snaar, fret), 1)
+            if na in ["^B", "^^B"]:
+                o -= 1  # because in adjacent octave
+            if na in ["_C", "__C"]:
+                o += 1
+            if "/" in na or i == 3:
+                o = 9  # emergency notation for 4th string case
+            nt = addoct(na, o)
+            snaar, fret = s.tabmap.get(
+                (v, nt), ("", "")
+            )  # the current allocation of nt
+            if not snaar:
+                break  # note not yet allocated
+            if snaar_nw == snaar:
+                return nt  # use present allocation
+            if i == 3:  # new allocaion needed but none is free
+                fmt = "rejected: voice %d note %3s string %s fret %2s remains: string %s fret %s"
+                info(fmt % (v, nt, snaar_nw, fret_nw, snaar, fret), 1)
                 ntrec.tab = (snaar, fret)
-        s.tabmap [v, nt] = ntrec.tab    # for tablature map (voice, note) -> (string, fret)
-        return nt                       # ABC code always in key C (with midi pitch alterations)
+        s.tabmap[v, nt] = ntrec.tab  # for tablature map (voice, note) -> (string, fret)
+        return nt  # ABC code always in key C (with midi pitch alterations)
 
-    def ntAbc (s, ptc, oct, note, v, ntrec, isTab): # pitch, octave -> abc notation
+    def ntAbc(s, ptc, oct, note, v, ntrec, isTab):  # pitch, octave -> abc notation
         acc2alt = {
-            'double-flat': -2,
-            'flat-flat': -2,
-            'flat': -1,
-            'natural-flat': -1,
-            'natural': 0,
-            'sharp': 1,
-            'natural-sharp': 1,
-            'sharp-sharp': 2,
-            'double-sharp': 2
+            "double-flat": -2,
+            "flat-flat": -2,
+            "flat": -1,
+            "natural-flat": -1,
+            "natural": 0,
+            "sharp": 1,
+            "natural-sharp": 1,
+            "sharp-sharp": 2,
+            "double-sharp": 2,
         }
-        oct += s.clefOct.get (s.curStf [v], 0)  # minus clef-octave-change value
-        acc = note.findtext ('accidental')  # should be the notated accidental
-        alt = note.findtext ('pitch/alter') # pitch alteration (midi)
-        if ntrec.tab: return s.tabnote (alt, ptc, oct, v, ntrec)    # implies s.tstep is true (options.t was given)
+        oct += s.clefOct.get(s.curStf[v], 0)  # minus clef-octave-change value
+        acc = note.findtext("accidental")  # should be the notated accidental
+        alt = note.findtext("pitch/alter")  # pitch alteration (midi)
+        if ntrec.tab:
+            return s.tabnote(
+                alt, ptc, oct, v, ntrec
+            )  # implies s.tstep is true (options.t was given)
         elif isTab and s.tstep:
-            nt = ['__','_','','^','^^'][int (alt or '0') + 2] + addoct (ptc, oct)
-            info ('no string notation found for note %s in voice %d' % (nt, v), 1)
-        p = addoct (ptc, oct)
-        if alt == None and s.msralts.get (ptc, 0): alt = 0  # no alt but key implies alt -> natural!!
-        if alt == None and (p, v) in s.curalts: alt = 0     # no alt but previous note had one -> natural!!
-        if acc == None and alt == None: return p    # no acc, no alt
+            nt = ["__", "_", "", "^", "^^"][int(alt or "0") + 2] + addoct(ptc, oct)
+            info("no string notation found for note %s in voice %d" % (nt, v), 1)
+        p = addoct(ptc, oct)
+        if alt == None and s.msralts.get(ptc, 0):
+            alt = 0  # no alt but key implies alt -> natural!!
+        if alt == None and (p, v) in s.curalts:
+            alt = 0  # no alt but previous note had one -> natural!!
+        if acc == None and alt == None:
+            return p  # no acc, no alt
         elif acc != None:
-            alt = acc2alt [acc]      # acc takes precedence over the pitch here!
-        else:   # now see if we really must add an accidental
-            alt = int (float (alt))
+            alt = acc2alt[acc]  # acc takes precedence over the pitch here!
+        else:  # now see if we really must add an accidental
+            alt = int(float(alt))
             if (p, v) in s.curalts:  # the note in this voice has been altered before
-                if alt == s.curalts [(p, v)]: return p      # alteration still the same
-            elif alt == s.msralts.get (ptc, 0): return p    # alteration implied by the key
-            tieElms = note.findall ('tie') + note.findall ('notations/tied')    # in xml we have separate notated ties and playback ties
-            if 'stop' in [e.get ('type') for e in tieElms]: return p    # don't alter tied notes
-            info ('accidental %d added in part %d, measure %d, voice %d note %s' % (alt, s.msr.ixp+1, s.msr.ixm+1, v+1, p))
-        s.curalts [(p, v)] = alt
-        p = ['__','_','=','^','^^'][alt+2] + p # and finally ... prepend the accidental
+                if alt == s.curalts[(p, v)]:
+                    return p  # alteration still the same
+            elif alt == s.msralts.get(ptc, 0):
+                return p  # alteration implied by the key
+            tieElms = note.findall("tie") + note.findall(
+                "notations/tied"
+            )  # in xml we have separate notated ties and playback ties
+            if "stop" in [e.get("type") for e in tieElms]:
+                return p  # don't alter tied notes
+            info(
+                "accidental %d added in part %d, measure %d, voice %d note %s"
+                % (alt, s.msr.ixp + 1, s.msr.ixm + 1, v + 1, p)
+            )
+        s.curalts[(p, v)] = alt
+        p = ["__", "_", "=", "^", "^^"][
+            alt + 2
+        ] + p  # and finally ... prepend the accidental
         return p
 
-    def doNote (s, n):    # parse a musicXML note tag
-        note = Note ()
-        v = int (n.findtext ('voice', '1'))
-        if s.isSib: v += 100 * int (n.findtext ('staff', '1'))  # repair bug in Sibelius
-        chord = n.find ('chord') != None
-        p = n.findtext ('pitch/step') or n.findtext ('unpitched/display-step')
-        o = n.findtext ('pitch/octave') or n.findtext ('unpitched/display-octave')
-        r = n.find ('rest')
-        numer = n.findtext ('time-modification/actual-notes')
+    def doNote(s, n):  # parse a musicXML note tag
+        note = Note()
+        v = int(n.findtext("voice", "1"))
+        if s.isSib:
+            v += 100 * int(n.findtext("staff", "1"))  # repair bug in Sibelius
+        chord = n.find("chord") != None
+        p = n.findtext("pitch/step") or n.findtext("unpitched/display-step")
+        o = n.findtext("pitch/octave") or n.findtext("unpitched/display-octave")
+        r = n.find("rest")
+        numer = n.findtext("time-modification/actual-notes")
         if numer:
-            denom = n.findtext ('time-modification/normal-notes')
-            note.fact = (int (numer), int (denom))
-        note.tup = [x.get ('type') for x in n.findall ('notations/tuplet')]
-        dur = n.findtext ('duration')
-        grc = n.find ('grace')
+            denom = n.findtext("time-modification/normal-notes")
+            note.fact = (int(numer), int(denom))
+        note.tup = [x.get("type") for x in n.findall("notations/tuplet")]
+        dur = n.findtext("duration")
+        grc = n.find("grace")
         note.grace = grc != None
-        note.before, note.after = [], '' # strings with ABC stuff that goes before or after a note/chord
-        if note.grace and not s.ingrace: # open a grace sequence
+        note.before, note.after = (
+            [],
+            "",
+        )  # strings with ABC stuff that goes before or after a note/chord
+        if note.grace and not s.ingrace:  # open a grace sequence
             s.ingrace = 1
-            note.before = ['{']
-            if grc.get ('slash') == 'yes': note.before += ['/'] # acciaccatura
+            note.before = ["{"]
+            if grc.get("slash") == "yes":
+                note.before += ["/"]  # acciaccatura
         stopgrace = not note.grace and s.ingrace
-        if stopgrace:                   # close the grace sequence
+        if stopgrace:  # close the grace sequence
             s.ingrace = 0
-            s.msc.lastnote.after += '}' # close grace on lastenote.after
-        if dur == None or note.grace: dur = 0
-        if r == None and n.get ('print-object') == 'no':
-            if chord: return
+            s.msc.lastnote.after += "}"  # close grace on lastenote.after
+        if dur == None or note.grace:
+            dur = 0
+        if r == None and n.get("print-object") == "no":
+            if chord:
+                return
             r = 1  # turn invisible notes (that advance the time) into invisible rests
-        note.dur = int (dur)
+        note.dur = int(dur)
         if r == None and (not p or not o):  # not a rest and no pitch
-            s.msc.cnt.inc ('nopt', v)       # count unpitched notes
-            o, p = 5,'E'                    # make it an E5 ??
-        isTab = s.curClef and s.curClef.get (s.curStf [v], '').startswith ('tab')
-        nttn = n.find ('notations')     # add ornaments
-        if nttn != None: s.doNotations (note, nttn, isTab)
-        e = n.find ('stem') if r == None else None  # no !stemless! before rest
-        if e != None and e.text == 'none' and (not isTab or v in s.hasStems or s.tstep):
-            note.before += ['!stemless!']; abcOut.stemless = 0; # ???????????U???????????!stemless!
+            s.msc.cnt.inc("nopt", v)  # count unpitched notes
+            o, p = 5, "E"  # make it an E5 ??
+        isTab = s.curClef and s.curClef.get(s.curStf[v], "").startswith("tab")
+        nttn = n.find("notations")  # add ornaments
+        if nttn != None:
+            s.doNotations(note, nttn, isTab)
+        e = n.find("stem") if r == None else None  # no !stemless! before rest
+        if e != None and e.text == "none" and (not isTab or v in s.hasStems or s.tstep):
+            note.before += ["!stemless!"]
+            abcOut.stemless = 0  # ???????????U???????????!stemless!
             # note.before += ['s']; abcOut.stemless = 1;
-        e = n.find ('accidental')
-        if e != None and e.get ('parentheses') == 'yes': note.ntdec += '!courtesy!'
-        if r != None: noot = 'x' if n.get ('print-object') == 'no' or isTab else 'z'
-        else: noot = s.ntAbc (p, int (o), n, v, note, isTab)
-        if n.find ('unpitched') != None:
-            clef = s.curClef [s.curStf [v]]     # the current clef for this voice
-            step = staffStep (p, int (o), clef, s.tstep)        # (clef independent) step value of note on the staff
-            instr = n.find ('instrument')
-            instId = instr.get ('id') if instr != None else 'dummyId'
-            midi = s.drumInst.get (instId, abcMid (noot))
-            nh =  n.findtext ('notehead', '').replace (' ','-') # replace spaces in xml notehead names for percmap
-            if nh == 'x': noot = '^' + noot.replace ('^','').replace ('_','')
-            if nh in ['circle-x','diamond','triangle']: noot = '_' + noot.replace ('^','').replace ('_','')
-            if nh and n.find ('notehead').get ('filled','') == 'yes': nh += '+'
-            if nh and n.find ('notehead').get ('filled','') == 'no': nh += '-'
-            s.drumNotes [(v, noot)] = (step, midi, nh) # keep data for percussion map
-        tieElms = n.findall ('tie') + n.findall ('notations/tied')  # in xml we have separate notated ties and playback ties
-        if 'start' in [e.get ('type') for e in tieElms]:            # n can have stop and start tie
-            noot = noot + '-'
-        note.beam = sum ([1 for b in n.findall('beam') if b.text in ['continue', 'end']]) + int (note.grace)
-        lyrlast = 0; rsib = re.compile (r'^.*verse')
-        for e in n.findall ('lyric'):
-            lyrnum = int (rsib.sub ('', e.get ('number', '1'))) # also do Sibelius numbers
-            if lyrnum == 0: lyrnum = lyrlast + 1                # and correct Sibelius bugs
-            else: lyrlast = lyrnum
-            note.lyrs [lyrnum] = doSyllable (e)
-        stemdir = n.findtext ('stem')
-        if s.wstems and (stemdir == 'up' or stemdir == 'down'):
-            if stemdir != s.stemDir.get (v, ''):
-                s.stemDir [v] = stemdir
-                s.msc.appendElem (v, '[I:stemdir %s]' % stemdir)
-        if chord: s.msc.addChord (note, noot)
+        e = n.find("accidental")
+        if e != None and e.get("parentheses") == "yes":
+            note.ntdec += "!courtesy!"
+        if r != None:
+            noot = "x" if n.get("print-object") == "no" or isTab else "z"
         else:
-            xmlstaff = int (n.findtext ('staff', '1'))
-            if s.curStf [v] != xmlstaff:    # the note should go to another staff
-                dstaff = xmlstaff - s.curStf [v]    # relative new staff number
-                s.curStf [v] = xmlstaff     # remember the new staff for this voice
-                s.msc.appendElem (v, '[I:staff %+d]' % dstaff)  # insert a move before the note
-            s.msc.appendNote (v, note, noot)
-        for slur in n.findall ('notations/slur'):   # s.msc.lastnote points to the last real note/chord inserted above
-            s.matchSlur (slur.get ('type'), slur.get ('number'), v, s.msc.lastnote, note.grace, stopgrace) # match slur definitions
+            noot = s.ntAbc(p, int(o), n, v, note, isTab)
+        if n.find("unpitched") != None:
+            clef = s.curClef[s.curStf[v]]  # the current clef for this voice
+            step = staffStep(
+                p, int(o), clef, s.tstep
+            )  # (clef independent) step value of note on the staff
+            instr = n.find("instrument")
+            instId = instr.get("id") if instr != None else "dummyId"
+            midi = s.drumInst.get(instId, abcMid(noot))
+            nh = n.findtext("notehead", "").replace(
+                " ", "-"
+            )  # replace spaces in xml notehead names for percmap
+            if nh == "x":
+                noot = "^" + noot.replace("^", "").replace("_", "")
+            if nh in ["circle-x", "diamond", "triangle"]:
+                noot = "_" + noot.replace("^", "").replace("_", "")
+            if nh and n.find("notehead").get("filled", "") == "yes":
+                nh += "+"
+            if nh and n.find("notehead").get("filled", "") == "no":
+                nh += "-"
+            s.drumNotes[(v, noot)] = (step, midi, nh)  # keep data for percussion map
+        tieElms = n.findall("tie") + n.findall(
+            "notations/tied"
+        )  # in xml we have separate notated ties and playback ties
+        if "start" in [e.get("type") for e in tieElms]:  # n can have stop and start tie
+            noot = noot + "-"
+        note.beam = sum(
+            [1 for b in n.findall("beam") if b.text in ["continue", "end"]]
+        ) + int(note.grace)
+        lyrlast = 0
+        rsib = re.compile(r"^.*verse")
+        for e in n.findall("lyric"):
+            lyrnum = int(rsib.sub("", e.get("number", "1")))  # also do Sibelius numbers
+            if lyrnum == 0:
+                lyrnum = lyrlast + 1  # and correct Sibelius bugs
+            else:
+                lyrlast = lyrnum
+            note.lyrs[lyrnum] = doSyllable(e)
+        stemdir = n.findtext("stem")
+        if s.wstems and (stemdir == "up" or stemdir == "down"):
+            if stemdir != s.stemDir.get(v, ""):
+                s.stemDir[v] = stemdir
+                s.msc.appendElem(v, "[I:stemdir %s]" % stemdir)
+        if chord:
+            s.msc.addChord(note, noot)
+        else:
+            xmlstaff = int(n.findtext("staff", "1"))
+            if s.curStf[v] != xmlstaff:  # the note should go to another staff
+                dstaff = xmlstaff - s.curStf[v]  # relative new staff number
+                s.curStf[v] = xmlstaff  # remember the new staff for this voice
+                s.msc.appendElem(
+                    v, "[I:staff %+d]" % dstaff
+                )  # insert a move before the note
+            s.msc.appendNote(v, note, noot)
+        for slur in n.findall(
+            "notations/slur"
+        ):  # s.msc.lastnote points to the last real note/chord inserted above
+            s.matchSlur(
+                slur.get("type"),
+                slur.get("number"),
+                v,
+                s.msc.lastnote,
+                note.grace,
+                stopgrace,
+            )  # match slur definitions
 
-    def doAttr (s, e):    # parse a musicXML attribute tag
-        teken = {'C1':'alto1','C2':'alto2','C3':'alto','C4':'tenor','F4':'bass','F3':'bass3','G2':'treble','TAB':'tab','percussion':'perc'}
-        dvstxt = e.findtext ('divisions')
-        if dvstxt: s.msr.divs = int (dvstxt)
-        steps = int (e.findtext ('transpose/chromatic', '0'))   # for transposing instrument
-        fifths = e.findtext ('key/fifths')
+    def doAttr(s, e):  # parse a musicXML attribute tag
+        teken = {
+            "C1": "alto1",
+            "C2": "alto2",
+            "C3": "alto",
+            "C4": "tenor",
+            "F4": "bass",
+            "F3": "bass3",
+            "G2": "treble",
+            "TAB": "tab",
+            "percussion": "perc",
+        }
+        dvstxt = e.findtext("divisions")
+        if dvstxt:
+            s.msr.divs = int(dvstxt)
+        steps = int(
+            e.findtext("transpose/chromatic", "0")
+        )  # for transposing instrument
+        fifths = e.findtext("key/fifths")
         first = s.msc.tijd == 0 and s.msr.ixm == 0  # first attributes in first measure
         if fifths:
-            key, s.msralts = setKey (int (fifths), e.findtext ('key/mode','major'))
-            if first and not steps and abcOut.key == 'none':
-                abcOut.key = key                # first measure -> header, if not transposing instrument or percussion part!
+            key, s.msralts = setKey(int(fifths), e.findtext("key/mode", "major"))
+            if first and not steps and abcOut.key == "none":
+                abcOut.key = key  # first measure -> header, if not transposing instrument or percussion part!
             elif key != abcOut.key or not first:
-                s.msr.attr += '[K:%s]' % key    # otherwise -> voice
-        beats = e.findtext ('time/beats')
+                s.msr.attr += "[K:%s]" % key  # otherwise -> voice
+        beats = e.findtext("time/beats")
         if beats:
-            unit = e.findtext ('time/beat-type')
-            mtr = beats + '/' + unit
-            if first: abcOut.mtr = mtr          # first measure -> header
-            else: s.msr.attr += '[M:%s]' % mtr  # otherwise -> voice
-            s.msr.mtr = int (beats), int (unit)
-        s.msr.mdur = (s.msr.divs * s.msr.mtr[0] * 4) // s.msr.mtr[1]   # duration of measure in xml-divisions
-        for ms in e.findall('measure-style'):
-            n = int (ms.get ('number', '1'))    # staff number
-            voices = s.stfMap [n]               # all voices of staff n
-            for mr in ms.findall('measure-repeat'):
-                ty = mr.get('type')
-                if ty == 'start':               # remember start measure number and text voor each staff
-                    s.repeat_str [n] = [s.msr.ixm, mr.text]
-                    for v in voices:            # insert repeat into all voices, value will be overwritten at stop
-                        s.msc.insertElem (v, s.repeat_str [n])
-                elif ty == 'stop':              # calculate repeat measure count for this staff n
-                    start_ix, text_ = s.repeat_str [n]
+            unit = e.findtext("time/beat-type")
+            mtr = beats + "/" + unit
+            if first:
+                abcOut.mtr = mtr  # first measure -> header
+            else:
+                s.msr.attr += "[M:%s]" % mtr  # otherwise -> voice
+            s.msr.mtr = int(beats), int(unit)
+        s.msr.mdur = (s.msr.divs * s.msr.mtr[0] * 4) // s.msr.mtr[
+            1
+        ]  # duration of measure in xml-divisions
+        for ms in e.findall("measure-style"):
+            n = int(ms.get("number", "1"))  # staff number
+            voices = s.stfMap[n]  # all voices of staff n
+            for mr in ms.findall("measure-repeat"):
+                ty = mr.get("type")
+                if (
+                    ty == "start"
+                ):  # remember start measure number and text voor each staff
+                    s.repeat_str[n] = [s.msr.ixm, mr.text]
+                    for (
+                        v
+                    ) in (
+                        voices
+                    ):  # insert repeat into all voices, value will be overwritten at stop
+                        s.msc.insertElem(v, s.repeat_str[n])
+                elif ty == "stop":  # calculate repeat measure count for this staff n
+                    start_ix, text_ = s.repeat_str[n]
                     repeat_count = s.msr.ixm - start_ix
                     if text_:
-                        mid_str =  "%s " % text_
-                        repeat_count /= int (text_)
+                        mid_str = "%s " % text_
+                        repeat_count /= int(text_)
                     else:
-                        mid_str = ""            # overwrite repeat with final string
-                    s.repeat_str [n][0] = '[I:repeat %s%d]' % (mid_str, repeat_count)
-                    del s.repeat_str [n]        # remove closed repeats
-        toct = e.findtext ('transpose/octave-change', '')
-        if toct: steps += 12 * int (toct)       # extra transposition of toct octaves
-        for clef in e.findall ('clef'):         # a part can have multiple staves
-            n = int (clef.get ('number', '1'))  # local staff number for this clef
-            sgn = clef.findtext ('sign')
-            line = clef.findtext ('line', '') if sgn not in ['percussion','TAB'] else ''
-            cs = teken.get (sgn + line, '')
-            oct = clef.findtext ('clef-octave-change', '') or '0'
-            if oct: cs += {-2:'-15', -1:'-8', 1:'+8', 2:'+15'}.get (int (oct), '')
-            s.clefOct [n] = -int (oct);         # xml playback pitch -> abc notation pitch
-            if steps: cs += ' transpose=' + str (steps)
-            stfdtl = e.find ('staff-details')
-            if stfdtl and int (stfdtl.get ('number', '1')) == n:
-                lines = stfdtl.findtext ('staff-lines')
+                        mid_str = ""  # overwrite repeat with final string
+                    s.repeat_str[n][0] = "[I:repeat %s%d]" % (mid_str, repeat_count)
+                    del s.repeat_str[n]  # remove closed repeats
+        toct = e.findtext("transpose/octave-change", "")
+        if toct:
+            steps += 12 * int(toct)  # extra transposition of toct octaves
+        for clef in e.findall("clef"):  # a part can have multiple staves
+            n = int(clef.get("number", "1"))  # local staff number for this clef
+            sgn = clef.findtext("sign")
+            line = clef.findtext("line", "") if sgn not in ["percussion", "TAB"] else ""
+            cs = teken.get(sgn + line, "")
+            oct = clef.findtext("clef-octave-change", "") or "0"
+            if oct:
+                cs += {-2: "-15", -1: "-8", 1: "+8", 2: "+15"}.get(int(oct), "")
+            s.clefOct[n] = -int(oct)  # xml playback pitch -> abc notation pitch
+            if steps:
+                cs += " transpose=" + str(steps)
+            stfdtl = e.find("staff-details")
+            if stfdtl and int(stfdtl.get("number", "1")) == n:
+                lines = stfdtl.findtext("staff-lines")
                 if lines:
-                    lns= '|||' if lines == '3' and sgn == 'TAB' else lines
-                    cs += ' stafflines=%s' % lns
-                    s.stafflines = int (lines)  # remember for tab staves
-                strings = stfdtl.findall ('staff-tuning')
+                    lns = "|||" if lines == "3" and sgn == "TAB" else lines
+                    cs += " stafflines=%s" % lns
+                    s.stafflines = int(lines)  # remember for tab staves
+                strings = stfdtl.findall("staff-tuning")
                 if strings:
-                    tuning = [st.findtext ('tuning-step') + st.findtext ('tuning-octave') for st in strings]
-                    cs += ' strings=%s' % ','.join (tuning) 
-                capo = stfdtl.findtext ('capo')
-                if capo: cs += ' capo=%s' % capo
-            s.curClef [n] = cs                  # keep track of current clef (for percmap)
-            if first: s.clefMap [n] = cs        # clef goes to header (where it is mapped to voices)
+                    tuning = [
+                        st.findtext("tuning-step") + st.findtext("tuning-octave")
+                        for st in strings
+                    ]
+                    cs += " strings=%s" % ",".join(tuning)
+                capo = stfdtl.findtext("capo")
+                if capo:
+                    cs += " capo=%s" % capo
+            s.curClef[n] = cs  # keep track of current clef (for percmap)
+            if first:
+                s.clefMap[n] = cs  # clef goes to header (where it is mapped to voices)
             else:
-                voices = s.stfMap[n]            # clef change to all voices of staff n
+                voices = s.stfMap[n]  # clef change to all voices of staff n
                 for v in voices:
-                    if n != s.curStf [v]:       # voice is not at its home staff n
-                        dstaff = n - s.curStf [v]
-                        s.curStf [v] = n        # reset current staff at start of measure to home position
-                        s.msc.appendElem (v, '[I:staff %+d]' % dstaff)
-                    s.msc.appendElem (v, '[K:%s]' % cs)
+                    if n != s.curStf[v]:  # voice is not at its home staff n
+                        dstaff = n - s.curStf[v]
+                        s.curStf[v] = (
+                            n  # reset current staff at start of measure to home position
+                        )
+                        s.msc.appendElem(v, "[I:staff %+d]" % dstaff)
+                    s.msc.appendElem(v, "[K:%s]" % cs)
 
-    def findVoice (s, i, es):
-        stfnum = int (es[i].findtext ('staff',1))   # directions belong to a staff
-        vs = s.stfMap [stfnum]                      # voices in this staff
-        v1 = vs [0] if vs else 1                    # directions to first voice of staff
-        if s.dirtov1: return stfnum, v1, v1         # option --v1
-        for e in es [i+1:]:                         # or to the voice of the next note
-            if e.tag == 'note':
-                v = int (e.findtext ('voice', '1'))
-                if s.isSib: v += 100 * int (e.findtext ('staff', '1'))  # repair bug in Sibelius
-                stf = s.vce2stf [v]                 # use our own staff allocation
-                return stf, v, v1                   # voice of next note, first voice of staff
-            if e.tag == 'backup': break
-        return stfnum, v1, v1                       # no note found, fall back to v1
+    def findVoice(s, i, es):
+        stfnum = int(es[i].findtext("staff", 1))  # directions belong to a staff
+        vs = s.stfMap[stfnum]  # voices in this staff
+        v1 = vs[0] if vs else 1  # directions to first voice of staff
+        if s.dirtov1:
+            return stfnum, v1, v1  # option --v1
+        for e in es[i + 1 :]:  # or to the voice of the next note
+            if e.tag == "note":
+                v = int(e.findtext("voice", "1"))
+                if s.isSib:
+                    v += 100 * int(e.findtext("staff", "1"))  # repair bug in Sibelius
+                stf = s.vce2stf[v]  # use our own staff allocation
+                return stf, v, v1  # voice of next note, first voice of staff
+            if e.tag == "backup":
+                break
+        return stfnum, v1, v1  # no note found, fall back to v1
 
-    def doDirection (s, e, i, es): # parse a musicXML direction tag
-        def addDirection (x, vs, tijd, stfnum):
-            if not x: return
-            vs = s.stfMap [stfnum] if '!8v' in x else [vs]  # ottava's go to all voices of staff
+    def doDirection(s, e, i, es):  # parse a musicXML direction tag
+        def addDirection(x, vs, tijd, stfnum):
+            if not x:
+                return
+            vs = (
+                s.stfMap[stfnum] if "!8v" in x else [vs]
+            )  # ottava's go to all voices of staff
             for v in vs:
-                if tijd != None:   # insert at time of encounter
-                    s.msc.appendElemT (v, x.replace ('(',')').replace ('ped','ped-up'), tijd)
+                if tijd != None:  # insert at time of encounter
+                    s.msc.appendElemT(
+                        v, x.replace("(", ")").replace("ped", "ped-up"), tijd
+                    )
                 else:
-                    s.msc.appendElem (v, x)
-        def startStop (dtype, vs, stfnum=1):
-            typmap = {'down':'!8va(!', 'up':'!8vb(!', 'crescendo':'!<(!', 'diminuendo':'!>(!', 'start':'!ped!'}
-            type = t.get ('type', '')
-            k = dtype + t.get ('number', '1')       # key to match the closing direction
-            if type in typmap:                      # opening the direction
-                x = typmap [type]
-                if k in s.dirStk:                   # closing direction already encountered
-                    stype, tijd = s.dirStk [k]; del s.dirStk [k]
-                    if stype == 'stop':
-                        addDirection (x, vs, tijd, stfnum)
+                    s.msc.appendElem(v, x)
+
+        def startStop(dtype, vs, stfnum=1):
+            typmap = {
+                "down": "!8va(!",
+                "up": "!8vb(!",
+                "crescendo": "!<(!",
+                "diminuendo": "!>(!",
+                "start": "!ped!",
+            }
+            type = t.get("type", "")
+            k = dtype + t.get("number", "1")  # key to match the closing direction
+            if type in typmap:  # opening the direction
+                x = typmap[type]
+                if k in s.dirStk:  # closing direction already encountered
+                    stype, tijd = s.dirStk[k]
+                    del s.dirStk[k]
+                    if stype == "stop":
+                        addDirection(x, vs, tijd, stfnum)
                     else:
-                        info ('%s direction %s has no stop in part %d, measure %d, voice %d' % (dtype, stype, s.msr.ixp+1, s.msr.ixm+1, vs+1))
-                        s.dirStk [k] = ((type , vs))    # remember voice and type for closing
+                        info(
+                            "%s direction %s has no stop in part %d, measure %d, voice %d"
+                            % (dtype, stype, s.msr.ixp + 1, s.msr.ixm + 1, vs + 1)
+                        )
+                        s.dirStk[k] = (type, vs)  # remember voice and type for closing
                 else:
-                    s.dirStk [k] = ((type , vs))    # remember voice and type for closing
-            elif type == 'stop':
-                if k in s.dirStk:                   # matching open direction found
-                    type, vs = s.dirStk [k]; del s.dirStk [k]   # into the same voice
-                    if type == 'stop':
-                        info ('%s direction %s has double stop in part %d, measure %d, voice %d' % (dtype, type, s.msr.ixp+1, s.msr.ixm+1, vs+1))
-                        x = ''
+                    s.dirStk[k] = (type, vs)  # remember voice and type for closing
+            elif type == "stop":
+                if k in s.dirStk:  # matching open direction found
+                    type, vs = s.dirStk[k]
+                    del s.dirStk[k]  # into the same voice
+                    if type == "stop":
+                        info(
+                            "%s direction %s has double stop in part %d, measure %d, voice %d"
+                            % (dtype, type, s.msr.ixp + 1, s.msr.ixm + 1, vs + 1)
+                        )
+                        x = ""
                     else:
-                        x = typmap [type].replace ('(',')').replace ('ped','ped-up')
-                else:                               # closing direction found before opening
-                    s.dirStk [k] = ('stop', s.msc.tijd)
-                    x = ''                          # delay code generation until opening found
-            elif type in ['continue', 'resume', 'discontinue', 'change']:
+                        x = typmap[type].replace("(", ")").replace("ped", "ped-up")
+                else:  # closing direction found before opening
+                    s.dirStk[k] = ("stop", s.msc.tijd)
+                    x = ""  # delay code generation until opening found
+            elif type in ["continue", "resume", "discontinue", "change"]:
                 # ?? 'continue' ? 'resume'????????????????
                 # ??????????????
                 # info('Ignoring unsupported direction type: %s' % type)
-                x = ''
-            else: raise ValueError ('wrong direction type')
-            addDirection (x, vs, None, stfnum)
-        tempo, wrdstxt = None, ''
-        plcmnt = e.get ('placement')
-        stf, vs, v1 = s.findVoice (i, es)
-        jmp = ''    # for jump sound elements: dacapo, dalsegno and family
-        jmps = [('dacapo','D.C.'),('dalsegno','D.S.'),('tocoda','dacoda'),('fine','fine'),('coda','O'),('segno','S')]
-        t = e.find ('sound')        # there are many possible attributes for sound
-        if t != None:
-            minst = t.find ('midi-instrument')
-            if minst:
-                prg = t.findtext ('midi-instrument/midi-program')
-                chn = t.findtext ('midi-instrument/midi-channel')
-                vids = [v for v, id in s.vceInst.items () if id == minst.get ('id')]
-                if vids: vs = vids [0]          # direction for the indentified voice, not the staff
-                parm, inst = ('program', str (int (prg) - 1)) if prg else ('channel', chn)
-                if inst and abcOut.volpan > 0: s.msc.appendElem (vs, '[I:MIDI= %s %s]' % (parm, inst))
-            tempo = t.get ('tempo') # look for tempo attribute
-            if tempo:
-                tempo = '%.0f' % float (tempo) # hope it is a number and insert in voice 1
-                tempo_units = (1,4) # always 1/4 for sound elements!
-            for r, v in jmps:
-                if t.get (r, ''): jmp = v; break
-        dirtypes = e.findall ('direction-type')
-        for dirtyp in dirtypes:
-            units = { 'whole': (1,1), 'half': (1,2), 'quarter': (1,4), 'eighth': (1,8) }
-            metr = dirtyp.find ('metronome')
-            if metr != None:
-                t = metr.findtext ('beat-unit', '')
-                if t in units:  tempo_units = units [t]
-                else:           tempo_units = units ['quarter']
-                if metr.find ('beat-unit-dot') != None:
-                    tempo_units = simplify (tempo_units [0] * 3, tempo_units [1] * 2)
+                x = ""
+            else:
+                raise ValueError("wrong direction type")
+            addDirection(x, vs, None, stfnum)
 
-                debugtext = metr.findtext ('per-minute')
-                tmpro = None
-                if metr.findtext ('per-minute'):
-                    tmpro = re.search ('[.\d]+', metr.findtext ('per-minute'))  # look for a number #####
-                if tmpro: tempo = tmpro.group () # overwrites the value set by the sound element of this direction
-            t = dirtyp.find ('wedge')
-            if t != None: startStop ('wedge', vs)
-            allwrds = dirtyp.findall ('words')        # insert text annotations
-            if not allwrds: allwrds = dirtyp.findall ('rehearsal')   # treat rehearsal mark as text annotation
-            for wrds in allwrds:
-                if jmp: # ignore the words when a jump sound element is present in this direction
-                    s.msc.appendElem (vs, '!%s!' % jmp , 1) # to voice
+        tempo, wrdstxt = None, ""
+        plcmnt = e.get("placement")
+        stf, vs, v1 = s.findVoice(i, es)
+        jmp = ""  # for jump sound elements: dacapo, dalsegno and family
+        jmps = [
+            ("dacapo", "D.C."),
+            ("dalsegno", "D.S."),
+            ("tocoda", "dacoda"),
+            ("fine", "fine"),
+            ("coda", "O"),
+            ("segno", "S"),
+        ]
+        t = e.find("sound")  # there are many possible attributes for sound
+        if t != None:
+            minst = t.find("midi-instrument")
+            if minst:
+                prg = t.findtext("midi-instrument/midi-program")
+                chn = t.findtext("midi-instrument/midi-channel")
+                vids = [v for v, id in s.vceInst.items() if id == minst.get("id")]
+                if vids:
+                    vs = vids[0]  # direction for the indentified voice, not the staff
+                parm, inst = ("program", str(int(prg) - 1)) if prg else ("channel", chn)
+                if inst and abcOut.volpan > 0:
+                    s.msc.appendElem(vs, "[I:MIDI= %s %s]" % (parm, inst))
+            tempo = t.get("tempo")  # look for tempo attribute
+            if tempo:
+                tempo = "%.0f" % float(
+                    tempo
+                )  # hope it is a number and insert in voice 1
+                tempo_units = (1, 4)  # always 1/4 for sound elements!
+            for r, v in jmps:
+                if t.get(r, ""):
+                    jmp = v
                     break
-                plc = plcmnt == 'below' and '_' or '^'
-                if float (wrds.get ('default-y', '0')) < 0: plc = '_'
-                wrdstxt += (wrds.text or '').replace ('"','\\"').replace ('\n', '\\n')
-            wrdstxt = wrdstxt.strip ()
-            for key, val in dynamics_map.items ():
-                if dirtyp.find ('dynamics/' + key) != None:
-                    s.msc.appendElem (vs, val, 1)   # to voice
-            if dirtyp.find ('coda') != None: s.msc.appendElem (vs, 'O', 1)
-            if dirtyp.find ('segno') != None: s.msc.appendElem (vs, 'S', 1)
-            t = dirtyp.find ('octave-shift')
-            if t != None: startStop ('octave-shift', vs, stf)   # assume size == 8 for the time being
-            t = dirtyp.find ('pedal')
+        dirtypes = e.findall("direction-type")
+        for dirtyp in dirtypes:
+            units = {
+                "whole": (1, 1),
+                "half": (1, 2),
+                "quarter": (1, 4),
+                "eighth": (1, 8),
+            }
+            metr = dirtyp.find("metronome")
+            if metr != None:
+                t = metr.findtext("beat-unit", "")
+                if t in units:
+                    tempo_units = units[t]
+                else:
+                    tempo_units = units["quarter"]
+                if metr.find("beat-unit-dot") != None:
+                    tempo_units = simplify(tempo_units[0] * 3, tempo_units[1] * 2)
+
+                debugtext = metr.findtext("per-minute")
+                tmpro = None
+                if metr.findtext("per-minute"):
+                    tmpro = re.search(
+                        "[.\d]+", metr.findtext("per-minute")
+                    )  # look for a number #####
+                if tmpro:
+                    tempo = (
+                        tmpro.group()
+                    )  # overwrites the value set by the sound element of this direction
+            t = dirtyp.find("wedge")
+            if t != None:
+                startStop("wedge", vs)
+            allwrds = dirtyp.findall("words")  # insert text annotations
+            if not allwrds:
+                allwrds = dirtyp.findall(
+                    "rehearsal"
+                )  # treat rehearsal mark as text annotation
+            for wrds in allwrds:
+                if (
+                    jmp
+                ):  # ignore the words when a jump sound element is present in this direction
+                    s.msc.appendElem(vs, "!%s!" % jmp, 1)  # to voice
+                    break
+                plc = plcmnt == "below" and "_" or "^"
+                if float(wrds.get("default-y", "0")) < 0:
+                    plc = "_"
+                wrdstxt += (wrds.text or "").replace('"', '\\"').replace("\n", "\\n")
+            wrdstxt = wrdstxt.strip()
+            for key, val in dynamics_map.items():
+                if dirtyp.find("dynamics/" + key) != None:
+                    s.msc.appendElem(vs, val, 1)  # to voice
+            if dirtyp.find("coda") != None:
+                s.msc.appendElem(vs, "O", 1)
+            if dirtyp.find("segno") != None:
+                s.msc.appendElem(vs, "S", 1)
+            t = dirtyp.find("octave-shift")
+            if t != None:
+                startStop(
+                    "octave-shift", vs, stf
+                )  # assume size == 8 for the time being
+            t = dirtyp.find("pedal")
             if t != None and s.ped:
-                if not s.pedVce: s.pedVce = vs
-                startStop ('pedal', s.pedVce)
-            if dirtyp.findtext ('other-direction') == 'diatonic fretting': s.diafret = 1;
+                if not s.pedVce:
+                    s.pedVce = vs
+                startStop("pedal", s.pedVce)
+            if dirtyp.findtext("other-direction") == "diatonic fretting":
+                s.diafret = 1
         if tempo:
-            tempo = '%.0f' % float (tempo) # hope it is a number and insert in voice 1
-            if s.msc.tijd == 0 and s.msr.ixm == 0:      # first measure -> header
+            tempo = "%.0f" % float(tempo)  # hope it is a number and insert in voice 1
+            if s.msc.tijd == 0 and s.msr.ixm == 0:  # first measure -> header
                 abcOut.tempo = tempo
                 abcOut.tempo_units = tempo_units
             else:
-                s.msc.appendElem (v1, '[Q:%d/%d=%s]' % (tempo_units [0], tempo_units [1], tempo))   # otherwise -> 1st voice
-        if wrdstxt: s.msc.appendElem (vs, '"%s%s"' % (plc, wrdstxt), 1) # to voice, but after tempo
+                s.msc.appendElem(
+                    v1, "[Q:%d/%d=%s]" % (tempo_units[0], tempo_units[1], tempo)
+                )  # otherwise -> 1st voice
+        if wrdstxt:
+            s.msc.appendElem(
+                vs, '"%s%s"' % (plc, wrdstxt), 1
+            )  # to voice, but after tempo
 
-    def doHarmony (s, e, i, es):    # parse a musicXMl harmony tag
-        _, vt, _ = s.findVoice (i, es)
-        short = {'major':'', 'minor':'m', 'augmented':'+', 'diminished':'dim', 'dominant':'7', 'half-diminished':'m7b5'}
-        accmap = {'major':'maj', 'dominant':'', 'minor':'m', 'diminished':'dim', 'augmented':'+', 'suspended':'sus'}
-        modmap = {'second':'2', 'fourth':'4', 'seventh':'7', 'sixth':'6', 'ninth':'9', '11th':'11', '13th':'13'}
-        altmap = {'1':'#', '0':'', '-1':'b'}
-        root = e.findtext ('root/root-step','')
-        alt = altmap.get (e.findtext ('root/root-alter'), '')
-        sus = ''
-        kind = e.findtext ('kind', '')
-        if kind in short: kind = short [kind]
-        elif '-' in kind:   # xml chord names: <triad name>-<modification>
-            triad, mod = kind.split ('-')
-            kind = accmap.get (triad, '') + modmap.get (mod, '')
-            if kind.startswith ('sus'): kind, sus = '', kind    # sus-suffix goes to the end
-        elif kind == 'none': kind = e.find ('kind').get ('text','')
-        degrees = e.findall ('degree')
-        for d in degrees:   # chord alterations
-            kind += altmap.get (d.findtext ('degree-alter'),'') + d.findtext ('degree-value','')
-        kind = kind.replace ('79','9').replace ('713','13').replace ('maj6','6')
-        bass = e.findtext ('bass/bass-step','') + altmap.get (e.findtext ('bass/bass-alter'),'') 
-        s.msc.appendElem (vt, '"%s%s%s%s%s"' % (root, alt, kind, sus, bass and '/' + bass), 1)
+    def doHarmony(s, e, i, es):  # parse a musicXMl harmony tag
+        _, vt, _ = s.findVoice(i, es)
+        short = {
+            "major": "",
+            "minor": "m",
+            "augmented": "+",
+            "diminished": "dim",
+            "dominant": "7",
+            "half-diminished": "m7b5",
+        }
+        accmap = {
+            "major": "maj",
+            "dominant": "",
+            "minor": "m",
+            "diminished": "dim",
+            "augmented": "+",
+            "suspended": "sus",
+        }
+        modmap = {
+            "second": "2",
+            "fourth": "4",
+            "seventh": "7",
+            "sixth": "6",
+            "ninth": "9",
+            "11th": "11",
+            "13th": "13",
+        }
+        altmap = {"1": "#", "0": "", "-1": "b"}
+        root = e.findtext("root/root-step", "")
+        alt = altmap.get(e.findtext("root/root-alter"), "")
+        sus = ""
+        kind = e.findtext("kind", "")
+        if kind in short:
+            kind = short[kind]
+        elif "-" in kind:  # xml chord names: <triad name>-<modification>
+            triad, mod = kind.split("-")
+            kind = accmap.get(triad, "") + modmap.get(mod, "")
+            if kind.startswith("sus"):
+                kind, sus = "", kind  # sus-suffix goes to the end
+        elif kind == "none":
+            kind = e.find("kind").get("text", "")
+        degrees = e.findall("degree")
+        for d in degrees:  # chord alterations
+            kind += altmap.get(d.findtext("degree-alter"), "") + d.findtext(
+                "degree-value", ""
+            )
+        kind = kind.replace("79", "9").replace("713", "13").replace("maj6", "6")
+        bass = e.findtext("bass/bass-step", "") + altmap.get(
+            e.findtext("bass/bass-alter"), ""
+        )
+        s.msc.appendElem(
+            vt, '"%s%s%s%s%s"' % (root, alt, kind, sus, bass and "/" + bass), 1
+        )
 
-    def doBarline (s, e):       # 0 = no repeat, 1 = begin repeat, 2 = end repeat
-        rep = e.find ('repeat')
-        if rep != None: rep = rep.get ('direction')
-        if s.unfold:            # unfold repeat, don't translate barlines
-            return rep and (rep == 'forward' and 1 or 2) or 0
-        loc = e.get ('location', 'right')   # right is the default
-        if loc == 'right':      # only change style for the right side
-            style = e.findtext ('bar-style')
-            if   style == 'light-light': s.msr.rline = '||'
-            elif style == 'light-heavy': s.msr.rline = '|]'
-        if rep != None:         # repeat found
-            if rep == 'forward': s.msr.lline = ':'
-            else:                s.msr.rline = ':|' # override barline style
-        end = e.find ('ending')
+    def doBarline(s, e):  # 0 = no repeat, 1 = begin repeat, 2 = end repeat
+        rep = e.find("repeat")
+        if rep != None:
+            rep = rep.get("direction")
+        if s.unfold:  # unfold repeat, don't translate barlines
+            return rep and (rep == "forward" and 1 or 2) or 0
+        loc = e.get("location", "right")  # right is the default
+        if loc == "right":  # only change style for the right side
+            style = e.findtext("bar-style")
+            if style == "light-light":
+                s.msr.rline = "||"
+            elif style == "light-heavy":
+                s.msr.rline = "|]"
+        if rep != None:  # repeat found
+            if rep == "forward":
+                s.msr.lline = ":"
+            else:
+                s.msr.rline = ":|"  # override barline style
+        end = e.find("ending")
         if end != None:
-            if end.get ('type') == 'start':
-                n = end.get ('number', '1').replace ('.','').replace (' ','')
-                try: list (map (int, n.split (',')))    # should be a list of integers
-                except: n = '"%s"' % n.strip ()         # illegal musicXML
-                s.msr.lnum = n          # assume a start is always at the beginning of a measure
-            elif s.msr.rline == '|':    # stop and discontinue the same  in ABC ?
-                s.msr.rline = '||'      # to stop on a normal barline use || in ABC ?
+            if end.get("type") == "start":
+                n = end.get("number", "1").replace(".", "").replace(" ", "")
+                try:
+                    list(map(int, n.split(",")))  # should be a list of integers
+                except:
+                    n = '"%s"' % n.strip()  # illegal musicXML
+                s.msr.lnum = n  # assume a start is always at the beginning of a measure
+            elif s.msr.rline == "|":  # stop and discontinue the same  in ABC ?
+                s.msr.rline = "||"  # to stop on a normal barline use || in ABC ?
         return 0
 
-    def doPrint (s, e):     # print element, measure number -> insert a line break
-        if e.get ('new-system') == 'yes' or e.get ('new-page') == 'yes':
-            if not s.nolbrk: return '$'  # a line break
+    def doPrint(s, e):  # print element, measure number -> insert a line break
+        if e.get("new-system") == "yes" or e.get("new-page") == "yes":
+            if not s.nolbrk:
+                return "$"  # a line break
 
-    def doPartList (s, e):  # translate the start/stop-event-based xml-partlist into proper tree
-        for sp in e.findall ('part-list/score-part'):
+    def doPartList(
+        s, e
+    ):  # translate the start/stop-event-based xml-partlist into proper tree
+        for sp in e.findall("part-list/score-part"):
             midi = {}
-            for m in sp.findall ('midi-instrument'):
-                x = [m.findtext (p, s.midDflt [i]) for i,p in enumerate (['midi-channel','midi-program','volume','pan'])]
-                pan = float (x[3])
-                if pan >= -90 and pan <= 90:    # would be better to map behind-pannings
-                    pan = (float (x[3]) + 90) / 180 * 127   # xml between -90 and +90
-                midi [m.get ('id')] = [int (x[0]), int (x[1]), float (x[2]) * 1.27, pan]    # volume 100 -> midi 127
-                up = m.findtext ('midi-unpitched')
-                if up: s.drumInst [m.get ('id')] = int (up) - 1 # store midi-pitch for channel 10 notes
-            s.instMid.append (midi)
-        ps = e.find ('part-list')               # partlist  = [groupelem]
-        xs = getPartlist (ps)                   # groupelem = partname | grouplist
-        partlist, _ = parseParts (xs, {}, [])   # grouplist = [groupelem, ..., groupdata]
-        return partlist                         # groupdata = [group-symbol, group-barline, group-name, group-abbrev]
+            for m in sp.findall("midi-instrument"):
+                x = [
+                    m.findtext(p, s.midDflt[i])
+                    for i, p in enumerate(
+                        ["midi-channel", "midi-program", "volume", "pan"]
+                    )
+                ]
+                pan = float(x[3])
+                if pan >= -90 and pan <= 90:  # would be better to map behind-pannings
+                    pan = (float(x[3]) + 90) / 180 * 127  # xml between -90 and +90
+                midi[m.get("id")] = [
+                    int(x[0]),
+                    int(x[1]),
+                    float(x[2]) * 1.27,
+                    pan,
+                ]  # volume 100 -> midi 127
+                up = m.findtext("midi-unpitched")
+                if up:
+                    s.drumInst[m.get("id")] = (
+                        int(up) - 1
+                    )  # store midi-pitch for channel 10 notes
+            s.instMid.append(midi)
+        ps = e.find("part-list")  # partlist  = [groupelem]
+        xs = getPartlist(ps)  # groupelem = partname | grouplist
+        partlist, _ = parseParts(xs, {}, [])  # grouplist = [groupelem, ..., groupdata]
+        return partlist  # groupdata = [group-symbol, group-barline, group-name, group-abbrev]
 
-    def mkTitle (s, e):
-        def filterCredits (y):  # y == filter level, higher filters less
+    def mkTitle(s, e):
+        def filterCredits(y):  # y == filter level, higher filters less
             cs = []
-            for x in credits:   # skip redundant credit lines
-                if y < 6 and (x in title or x in mvttl): continue         # sure skip
-                if y < 5 and (x in composer or x in lyricist): continue   # almost sure skip
-                if y < 4 and ((title and title in x) or (mvttl and mvttl in x)): continue   # may skip too much
-                if y < 3 and ([1 for c in composer if c in x] or [1 for c in lyricist if c in x]): continue # skips too much
-                if y < 2 and re.match (r'^[\d\W]*$', x): continue       # line only contains numbers and punctuation
-                cs.append (x)
-            if y == 0 and (title + mvttl): cs = ''  # default: only credit when no title set
+            for x in credits:  # skip redundant credit lines
+                if y < 6 and (x in title or x in mvttl):
+                    continue  # sure skip
+                if y < 5 and (x in composer or x in lyricist):
+                    continue  # almost sure skip
+                if y < 4 and ((title and title in x) or (mvttl and mvttl in x)):
+                    continue  # may skip too much
+                if y < 3 and (
+                    [1 for c in composer if c in x] or [1 for c in lyricist if c in x]
+                ):
+                    continue  # skips too much
+                if y < 2 and re.match(r"^[\d\W]*$", x):
+                    continue  # line only contains numbers and punctuation
+                cs.append(x)
+            if y == 0 and (title + mvttl):
+                cs = ""  # default: only credit when no title set
             return cs
-        title = e.findtext ('work/work-title', '').strip ()
-        mvttl = e.findtext ('movement-title', '').strip ()
+
+        title = e.findtext("work/work-title", "").strip()
+        mvttl = e.findtext("movement-title", "").strip()
         composer, lyricist, credits = [], [], []
-        for creator in e.findall ('identification/creator'):
+        for creator in e.findall("identification/creator"):
             if creator.text:
-                if creator.get ('type') == 'composer':
-                    composer += [line.strip () for line in creator.text.split ('\n')]
-                elif creator.get ('type') in ('lyricist', 'transcriber'):
-                    lyricist += [line.strip () for line in creator.text.split ('\n')]
-        for rights in e.findall ('identification/rights'):
+                if creator.get("type") == "composer":
+                    composer += [line.strip() for line in creator.text.split("\n")]
+                elif creator.get("type") in ("lyricist", "transcriber"):
+                    lyricist += [line.strip() for line in creator.text.split("\n")]
+        for rights in e.findall("identification/rights"):
             if rights.text:
-                lyricist += [line.strip () for line in rights.text.split ('\n')]
-        for credit in e.findall('credit'):
-            cs = ''.join (e.text or '' for e in credit.findall('credit-words'))
-            credits += [re.sub (r'\s*[\r\n]\s*', ' ', cs)]
-        credits = filterCredits (s.ctf)
-        if title: title = 'T:%s\n' % title.replace ('\n', '\nT:')
-        if mvttl: title += 'T:%s\n' % mvttl.replace ('\n', '\nT:')
-        if credits: title += '\n'.join (['T:%s' % c for c in credits]) + '\n'
-        if composer: title += '\n'.join (['C:%s' % c for c in composer]) + '\n'
-        if lyricist: title += '\n'.join (['Z:%s' % c for c in lyricist]) + '\n'
-        if title: abcOut.title = title[:-1]
-        s.isSib = 'Sibelius' in (e.findtext ('identification/encoding/software') or '')
-        if s.isSib: info ('Sibelius MusicXMl is unreliable')
+                lyricist += [line.strip() for line in rights.text.split("\n")]
+        for credit in e.findall("credit"):
+            cs = "".join(e.text or "" for e in credit.findall("credit-words"))
+            credits += [re.sub(r"\s*[\r\n]\s*", " ", cs)]
+        credits = filterCredits(s.ctf)
+        if title:
+            title = "T:%s\n" % title.replace("\n", "\nT:")
+        if mvttl:
+            title += "T:%s\n" % mvttl.replace("\n", "\nT:")
+        if credits:
+            title += "\n".join(["T:%s" % c for c in credits]) + "\n"
+        if composer:
+            title += "\n".join(["C:%s" % c for c in composer]) + "\n"
+        if lyricist:
+            title += "\n".join(["Z:%s" % c for c in lyricist]) + "\n"
+        if title:
+            abcOut.title = title[:-1]
+        s.isSib = "Sibelius" in (e.findtext("identification/encoding/software") or "")
+        if s.isSib:
+            info("Sibelius MusicXMl is unreliable")
 
-    def doDefaults (s, e):
-        if not s.doPageFmt: return  # return if -pf option absent
-        d = e.find ('defaults');
-        if d == None: return;
-        mils = d.findtext ('scaling/millimeters')   # mills == staff height (mm)
-        tenths = d.findtext ('scaling/tenths')      # staff height in tenths
-        if not mils or not tenths: return
-        xmlScale = float (mils) / float (tenths) / 10   # tenths -> mm
-        space = 10 * xmlScale       # space between staff lines == 10 tenths
-        abcScale = space / 0.2117   # 0.2117 cm = 6pt = space between staff lines for scale = 1.0 in abcm2ps
-        abcOut.pageFmt ['scale'] = abcScale
-        eks = 2 * ['page-layout/'] + 4 * ['page-layout/page-margins/']
-        eks = [a+b for a,b in zip (eks, 'page-height,page-width,left-margin,right-margin,top-margin,bottom-margin'.split (','))]
-        for i in range (6):
-            v = d.findtext (eks [i])
-            k = abcOut.pagekeys [i+1]   # pagekeys [0] == scale already done, skip it
-            if not abcOut.pageFmt [k] and v:
-                try: abcOut.pageFmt [k] = float (v) * xmlScale  # -> cm
-                except: info ('illegal value %s for xml element %s', (v, eks [i])); continue    # just skip illegal values
+    def doDefaults(s, e):
+        if not s.doPageFmt:
+            return  # return if -pf option absent
+        d = e.find("defaults")
+        if d == None:
+            return
+        mils = d.findtext("scaling/millimeters")  # mills == staff height (mm)
+        tenths = d.findtext("scaling/tenths")  # staff height in tenths
+        if not mils or not tenths:
+            return
+        xmlScale = float(mils) / float(tenths) / 10  # tenths -> mm
+        space = 10 * xmlScale  # space between staff lines == 10 tenths
+        abcScale = (
+            space / 0.2117
+        )  # 0.2117 cm = 6pt = space between staff lines for scale = 1.0 in abcm2ps
+        abcOut.pageFmt["scale"] = abcScale
+        eks = 2 * ["page-layout/"] + 4 * ["page-layout/page-margins/"]
+        eks = [
+            a + b
+            for a, b in zip(
+                eks,
+                "page-height,page-width,left-margin,right-margin,top-margin,bottom-margin".split(
+                    ","
+                ),
+            )
+        ]
+        for i in range(6):
+            v = d.findtext(eks[i])
+            k = abcOut.pagekeys[i + 1]  # pagekeys [0] == scale already done, skip it
+            if not abcOut.pageFmt[k] and v:
+                try:
+                    abcOut.pageFmt[k] = float(v) * xmlScale  # -> cm
+                except:
+                    info("illegal value %s for xml element %s", (v, eks[i]))
+                    continue  # just skip illegal values
 
-    def locStaffMap (s, part, maten):   # map voice to staff with majority voting
-        vmap = {}   # {voice -> {staff -> n}} count occurrences of voice in staff
-        s.vceInst = {}          # {voice -> instrument id} for this part
-        s.msc.vnums = {}        # voice id's
-        s.hasStems = {}         # XML voice nums with at least one note with a stem (for tab key)
-        s.stfMap, s.clefMap = {}, {}    # staff -> [voices], staff -> clef
-        ns = part.findall ('measure/note')
-        for n in ns:            # count staff allocations for all notes
-            v = int (n.findtext ('voice', '1'))
-            if s.isSib: v += 100 * int (n.findtext ('staff', '1'))  # repair bug in Sibelius
-            s.msc.vnums [v] = 1 # collect all used voice id's in this part
-            sn = int (n.findtext ('staff', '1'))
-            s.stfMap [sn] = []
+    def locStaffMap(s, part, maten):  # map voice to staff with majority voting
+        vmap = {}  # {voice -> {staff -> n}} count occurrences of voice in staff
+        s.vceInst = {}  # {voice -> instrument id} for this part
+        s.msc.vnums = {}  # voice id's
+        s.hasStems = (
+            {}
+        )  # XML voice nums with at least one note with a stem (for tab key)
+        s.stfMap, s.clefMap = {}, {}  # staff -> [voices], staff -> clef
+        ns = part.findall("measure/note")
+        for n in ns:  # count staff allocations for all notes
+            v = int(n.findtext("voice", "1"))
+            if s.isSib:
+                v += 100 * int(n.findtext("staff", "1"))  # repair bug in Sibelius
+            s.msc.vnums[v] = 1  # collect all used voice id's in this part
+            sn = int(n.findtext("staff", "1"))
+            s.stfMap[sn] = []
             if v not in vmap:
-                vmap [v] = {sn:1}
+                vmap[v] = {sn: 1}
             else:
-                d = vmap[v]     # counter for voice v
-                d[sn] = d.get (sn, 0) + 1   # ++ number of allocations for staff sn
-            x = n.find ('instrument')
-            if x != None: s.vceInst [v] = x.get ('id')
-            x, noRest = n.findtext ('stem'), n.find ('rest') == None
-            if noRest and (not x or x != 'none'): s.hasStems [v] = 1    # XML voice v has at least one stem
-        vks = list (vmap.keys ())
-        if s.jscript or s.isSib: vks.sort ()
-        for v in vks:           # choose staff with most allocations for each voice
-            xs = [(n, sn) for sn, n in vmap[v].items ()]
-            xs.sort ()
-            stf = xs[-1][1]     # the winner: staff with most notes of voice v
-            s.stfMap [stf].append (v)
-            s.vce2stf [v] = stf # reverse map
-            s.curStf [v] = stf  # current staff of XML voice v
+                d = vmap[v]  # counter for voice v
+                d[sn] = d.get(sn, 0) + 1  # ++ number of allocations for staff sn
+            x = n.find("instrument")
+            if x != None:
+                s.vceInst[v] = x.get("id")
+            x, noRest = n.findtext("stem"), n.find("rest") == None
+            if noRest and (not x or x != "none"):
+                s.hasStems[v] = 1  # XML voice v has at least one stem
+        vks = list(vmap.keys())
+        if s.jscript or s.isSib:
+            vks.sort()
+        for v in vks:  # choose staff with most allocations for each voice
+            xs = [(n, sn) for sn, n in vmap[v].items()]
+            xs.sort()
+            stf = xs[-1][1]  # the winner: staff with most notes of voice v
+            s.stfMap[stf].append(v)
+            s.vce2stf[v] = stf  # reverse map
+            s.curStf[v] = stf  # current staff of XML voice v
 
-    def addStaffMap (s, vvmap): # vvmap: xml voice number -> global abc voice number
-        part = [] # default: brace on staffs of one part
-        for stf, voices in sorted (s.stfMap.items ()):  # s.stfMap has xml staff and voice numbers
-            locmap = [vvmap [iv] for iv in voices if iv in vvmap]
-            nostem = [(iv not in s.hasStems) for iv in voices if iv in vvmap]   # same order as locmap
-            if locmap:          # abc voice number of staff stf
-                part.append (locmap)
-                clef = s.clefMap.get (stf, 'treble')    # {xml staff number -> clef}
-                for i, iv in enumerate (locmap):
-                    clef_attr = ''
-                    if clef.startswith ('tab'):
-                        if nostem [i] and 'nostems' not in clef: clef_attr = ' nostems'
-                        if s.diafret and 'diafret' not in clef: clef_attr += ' diafret' # for all voices in the part
-                    abcOut.clefs [iv] = clef + clef_attr # add nostems when all notes of voice had no stem
-        s.gStfMap.append (part)
+    def addStaffMap(s, vvmap):  # vvmap: xml voice number -> global abc voice number
+        part = []  # default: brace on staffs of one part
+        for stf, voices in sorted(
+            s.stfMap.items()
+        ):  # s.stfMap has xml staff and voice numbers
+            locmap = [vvmap[iv] for iv in voices if iv in vvmap]
+            nostem = [
+                (iv not in s.hasStems) for iv in voices if iv in vvmap
+            ]  # same order as locmap
+            if locmap:  # abc voice number of staff stf
+                part.append(locmap)
+                clef = s.clefMap.get(stf, "treble")  # {xml staff number -> clef}
+                for i, iv in enumerate(locmap):
+                    clef_attr = ""
+                    if clef.startswith("tab"):
+                        if nostem[i] and "nostems" not in clef:
+                            clef_attr = " nostems"
+                        if s.diafret and "diafret" not in clef:
+                            clef_attr += " diafret"  # for all voices in the part
+                    abcOut.clefs[iv] = (
+                        clef + clef_attr
+                    )  # add nostems when all notes of voice had no stem
+        s.gStfMap.append(part)
 
-    def addMidiMap (s, ip, vvmap):      # map abc voices to midi settings
-        instr = s.instMid [ip]          # get the midi settings for this part
-        if instr.values (): defInstr = list(instr.values ())[0]   # default settings = first instrument
-        else:               defInstr = s.midDflt    # no instruments defined
+    def addMidiMap(s, ip, vvmap):  # map abc voices to midi settings
+        instr = s.instMid[ip]  # get the midi settings for this part
+        if instr.values():
+            defInstr = list(instr.values())[0]  # default settings = first instrument
+        else:
+            defInstr = s.midDflt  # no instruments defined
         xs = []
-        for v, vabc in vvmap.items ():  # xml voice num, abc voice num
-            ks = sorted (s.drumNotes.items ())
-            ds = [(nt, step, midi, head) for (vd, nt), (step, midi, head) in ks if v == vd] # map perc notes
-            id = s.vceInst.get (v, '')  # get the instrument-id for part with multiple instruments
-            if id in instr:             # id is defined as midi-instrument in part-list
-                   xs.append ((vabc, instr [id] + ds))  # get midi settings for id 
-            else:  xs.append ((vabc, defInstr   + ds))  # only one instrument for this part
-        xs.sort ()  # put abc voices in order
-        s.midiMap.extend ([midi for v, midi in xs])
-        snaarmap = ['E','G','B','d', 'f', 'a', "c'", "e'"]
-        diamap = '0,1-,1,1+,2,3,3,4,4,5,6,6+,7,8-,8,8+,9,10,10,11,11,12,13,13+,14'.split (',')
-        for k in sorted (s.tabmap.keys ()): # add %%map's for all tab voices
-            v, noot = k;
-            snaar, fret = s.tabmap [k];
-            if s.diafret: fret = diamap [int (fret)]
-            vabc = vvmap [v]
-            snaar = s.stafflines - int (snaar)
-            xs = s.tabVceMap.get (vabc, [])
-            xs.append ('%%%%map tab%d %s print=%s heads=kop%s\n' % (vabc, noot, snaarmap [snaar], fret))
-            s.tabVceMap [vabc] = xs
-            s.koppen [fret] = 1  # collect noteheads for SVG defs
+        for v, vabc in vvmap.items():  # xml voice num, abc voice num
+            ks = sorted(s.drumNotes.items())
+            ds = [
+                (nt, step, midi, head) for (vd, nt), (step, midi, head) in ks if v == vd
+            ]  # map perc notes
+            id = s.vceInst.get(
+                v, ""
+            )  # get the instrument-id for part with multiple instruments
+            if id in instr:  # id is defined as midi-instrument in part-list
+                xs.append((vabc, instr[id] + ds))  # get midi settings for id
+            else:
+                xs.append((vabc, defInstr + ds))  # only one instrument for this part
+        xs.sort()  # put abc voices in order
+        s.midiMap.extend([midi for v, midi in xs])
+        snaarmap = ["E", "G", "B", "d", "f", "a", "c'", "e'"]
+        diamap = (
+            "0,1-,1,1+,2,3,3,4,4,5,6,6+,7,8-,8,8+,9,10,10,11,11,12,13,13+,14".split(",")
+        )
+        for k in sorted(s.tabmap.keys()):  # add %%map's for all tab voices
+            v, noot = k
+            snaar, fret = s.tabmap[k]
+            if s.diafret:
+                fret = diamap[int(fret)]
+            vabc = vvmap[v]
+            snaar = s.stafflines - int(snaar)
+            xs = s.tabVceMap.get(vabc, [])
+            xs.append(
+                "%%%%map tab%d %s print=%s heads=kop%s\n"
+                % (vabc, noot, snaarmap[snaar], fret)
+            )
+            s.tabVceMap[vabc] = xs
+            s.koppen[fret] = 1  # collect noteheads for SVG defs
 
-    def parse (s, fobj):
-        vvmapAll = {}   # collect xml->abc voice maps (vvmap) of all parts
-        e = E.parse (fobj)
-        s.mkTitle (e)
-        s.doDefaults (e)
-        partlist = s.doPartList (e)
-        parts = e.findall ('part')
-        for ip, p in enumerate (parts):
-            maten = p.findall ('measure')
-            s.locStaffMap (p, maten)        # {voice -> staff} for this part
-            s.drumNotes = {}    # (xml voice, abc note) -> (midi note, note head)
-            s.clefOct = {}      # xml staff number -> current clef-octave-change
-            s.curClef = {}      # xml staff number -> current abc clef
-            s.stemDir = {}      # xml voice number -> current stem direction
-            s.tabmap = {}       # (xml voice, abc note) -> (string, fret)
-            s.diafret = 0       # use diatonic fretting
+    def parse(s, fobj):
+        vvmapAll = {}  # collect xml->abc voice maps (vvmap) of all parts
+        e = E.parse(fobj)
+        s.mkTitle(e)
+        s.doDefaults(e)
+        partlist = s.doPartList(e)
+        parts = e.findall("part")
+        for ip, p in enumerate(parts):
+            maten = p.findall("measure")
+            s.locStaffMap(p, maten)  # {voice -> staff} for this part
+            s.drumNotes = {}  # (xml voice, abc note) -> (midi note, note head)
+            s.clefOct = {}  # xml staff number -> current clef-octave-change
+            s.curClef = {}  # xml staff number -> current abc clef
+            s.stemDir = {}  # xml voice number -> current stem direction
+            s.tabmap = {}  # (xml voice, abc note) -> (string, fret)
+            s.diafret = 0  # use diatonic fretting
             s.stafflines = 5
-            s.msc.initVoices (newPart = 1)  # create all voices
+            s.msc.initVoices(newPart=1)  # create all voices
             aantalHerhaald = 0  # keep track of number of repititions
-            herhaalMaat = 0     # target measure of the repitition
-            divisions = []      # current value of <divisions> for each measure
-            s.msr = Measure (ip)   # various measure data
-            while s.msr.ixm < len (maten):
+            herhaalMaat = 0  # target measure of the repitition
+            divisions = []  # current value of <divisions> for each measure
+            s.msr = Measure(ip)  # various measure data
+            while s.msr.ixm < len(maten):
                 if ip == 31 and s.msr.ixm == 405:
-                    print('')
-                maat = maten [s.msr.ixm]
-                herhaal, lbrk = 0, ''
-                s.msr.reset ()
+                    print("")
+                maat = maten[s.msr.ixm]
+                herhaal, lbrk = 0, ""
+                s.msr.reset()
                 s.curalts = {}  # passing accidentals are reset each measure
-                es = list (maat)
-                for i, e in enumerate (es):
-                    if   e.tag == 'note':       s.doNote (e)
-                    elif e.tag == 'attributes': s.doAttr (e)
-                    elif e.tag == 'direction':
-                        s.doDirection (e, i, es)
-                    elif e.tag == 'sound':      s.doDirection (maat, i, es) # sound element directly in measure!
-                    elif e.tag == 'harmony':    s.doHarmony (e, i, es)
-                    elif e.tag == 'barline':
-                        herhaal = s.doBarline (e)
-                    elif e.tag == 'backup':
-                        dt = int (e.findtext ('duration'))
-                        if chkbug (dt, s.msr): s.msc.incTime (-dt)
-                    elif e.tag == 'forward':
-                        dt = int (e.findtext ('duration'))
-                        if chkbug (dt, s.msr): s.msc.incTime (dt)
-                    elif e.tag == 'print':  lbrk = s.doPrint (e)
-                s.msc.addBar (lbrk, s.msr)
-                divisions.append (s.msr.divs)
+                es = list(maat)
+                for i, e in enumerate(es):
+                    if e.tag == "note":
+                        s.doNote(e)
+                    elif e.tag == "attributes":
+                        s.doAttr(e)
+                    elif e.tag == "direction":
+                        s.doDirection(e, i, es)
+                    elif e.tag == "sound":
+                        s.doDirection(maat, i, es)  # sound element directly in measure!
+                    elif e.tag == "harmony":
+                        s.doHarmony(e, i, es)
+                    elif e.tag == "barline":
+                        herhaal = s.doBarline(e)
+                    elif e.tag == "backup":
+                        dt = int(e.findtext("duration"))
+                        if chkbug(dt, s.msr):
+                            s.msc.incTime(-dt)
+                    elif e.tag == "forward":
+                        dt = int(e.findtext("duration"))
+                        if chkbug(dt, s.msr):
+                            s.msc.incTime(dt)
+                    elif e.tag == "print":
+                        lbrk = s.doPrint(e)
+                s.msc.addBar(lbrk, s.msr)
+                divisions.append(s.msr.divs)
                 if herhaal == 1:
                     herhaalMaat = s.msr.ixm
                     s.msr.ixm += 1
@@ -1526,84 +2185,177 @@ class Parser:
                         aantalHerhaald += 1
                     else:
                         aantalHerhaald = 0  # reset
-                        s.msr.ixm += 1      # just continue
-                else: s.msr.ixm += 1        # on to the next measure
-            for rv in s.repeat_str.values ():   # close hanging measure-repeats without stop
-                rv [0] = '[I:repeat %s %d]' % (rv [1], 1)
-            vvmap = s.msc.outVoices (divisions, ip, s.isSib)
-            s.addStaffMap (vvmap)           # update global staff map
-            s.addMidiMap (ip, vvmap)
-            vvmapAll.update (vvmap)
-        if vvmapAll:            # skip output if no part has any notes
-            abcOut.mkHeader (s.gStfMap, partlist, s.midiMap, s.tabVceMap, s.koppen)
-            abcOut.writeall ()
-        else: info ('nothing written, %s has no notes ...' % abcOut.fnmext)
+                        s.msr.ixm += 1  # just continue
+                else:
+                    s.msr.ixm += 1  # on to the next measure
+            for (
+                rv
+            ) in s.repeat_str.values():  # close hanging measure-repeats without stop
+                rv[0] = "[I:repeat %s %d]" % (rv[1], 1)
+            vvmap = s.msc.outVoices(divisions, ip, s.isSib)
+            s.addStaffMap(vvmap)  # update global staff map
+            s.addMidiMap(ip, vvmap)
+            vvmapAll.update(vvmap)
+        if vvmapAll:  # skip output if no part has any notes
+            abcOut.mkHeader(s.gStfMap, partlist, s.midiMap, s.tabVceMap, s.koppen)
+            abcOut.writeall()
+        else:
+            info("nothing written, %s has no notes ..." % abcOut.fnmext)
 
-#----------------
+
+# ----------------
 # Main Program
-#----------------
-if __name__ == '__main__':
+# ----------------
+if __name__ == "__main__":
     from optparse import OptionParser
     from glob import glob
-    from zipfile import ZipFile 
-    ustr = '%prog [-h] [-u] [-m] [-c C] [-d D] [-n CPL] [-b BPL] [-o DIR] [-v V]\n'
-    ustr += '[-x] [-p PFMT] [-t] [-s] [-i] [--v1] [--noped] [--stems] <file1> [<file2> ...]'
-    parser = OptionParser (usage=ustr, version=str(VERSION))
-    parser.add_option ("-u", action="store_true", help="unfold simple repeats")
-    parser.add_option ("-m", action="store", help="0 -> no %%MIDI, 1 -> minimal %%MIDI, 2-> all %%MIDI", default=0)
-    parser.add_option ("-c", action="store", type="int", help="set credit text filter to C", default=0, metavar='C')
-    parser.add_option ("-d", action="store", type="int", help="set L:1/D", default=0, metavar='D')  # ??????????????L
-    parser.add_option ("-n", action="store", type="int", help="CPL: max number of characters per line (default 100)", default=0, metavar='CPL')
-    parser.add_option ("-b", action="store", type="int", help="BPL: max number of bars per line", default=0, metavar='BPL')
-    parser.add_option ("-o", action="store", help="store abc files in DIR", default='', metavar='DIR')
-    parser.add_option ("-v", action="store", type="int", help="set volta typesetting behaviour to V", default=0, metavar='V')
-    parser.add_option ("-x", action="store_true", help="output no line breaks")
-    parser.add_option ("-p", action="store", help="pageformat PFMT (cm) = scale, pageheight, pagewidth, leftmargin, rightmargin, topmargin, botmargin", default='', metavar='PFMT')
-    parser.add_option ("-j", action="store_true", help="switch for compatibility with javascript version")
-    parser.add_option ("-t", action="store_true", help="translate perc- and tab-staff to ABC code with %%map, %%voicemap")
-    parser.add_option ("-s", action="store_true", help="shift node heads 3 units left in a tab staff")
-    parser.add_option ("--v1", action="store_true", help="start-stop directions allways to first voice of staff")
-    parser.add_option ("--noped", action="store_false", help="skip all pedal directions", dest='ped', default=True)
-    parser.add_option ("--stems", action="store_true", help="translate stem directions", dest='stm', default=False)
-    parser.add_option ("-i", action="store_true", help="read xml file from standard input")
-    options, args = parser.parse_args ()
-    if options.n < 0: parser.error ('only values >= 0')
-    if options.b < 0: parser.error ('only values >= 0')
-    if options.d and options.d not in [2**n for n in range (10)]:
-        parser.error ('D should be on of %s' % ','.join ([str(2**n) for n in range (10)]))
-    options.p = options.p and options.p.split (',') or [] # ==> [] | [string]
-    if len (args) == 0 and not options.i: parser.error ('no input file given')
+    from zipfile import ZipFile
+
+    ustr = "%prog [-h] [-u] [-m] [-c C] [-d D] [-n CPL] [-b BPL] [-o DIR] [-v V]\n"
+    ustr += (
+        "[-x] [-p PFMT] [-t] [-s] [-i] [--v1] [--noped] [--stems] <file1> [<file2> ...]"
+    )
+    parser = OptionParser(usage=ustr, version=str(VERSION))
+    parser.add_option("-u", action="store_true", help="unfold simple repeats")
+    parser.add_option(
+        "-m",
+        action="store",
+        help="0 -> no %%MIDI, 1 -> minimal %%MIDI, 2-> all %%MIDI",
+        default=0,
+    )
+    parser.add_option(
+        "-c",
+        action="store",
+        type="int",
+        help="set credit text filter to C",
+        default=0,
+        metavar="C",
+    )
+    parser.add_option(
+        "-d", action="store", type="int", help="set L:1/D", default=0, metavar="D"
+    )  # ??????????????L
+    parser.add_option(
+        "-n",
+        action="store",
+        type="int",
+        help="CPL: max number of characters per line (default 100)",
+        default=0,
+        metavar="CPL",
+    )
+    parser.add_option(
+        "-b",
+        action="store",
+        type="int",
+        help="BPL: max number of bars per line",
+        default=0,
+        metavar="BPL",
+    )
+    parser.add_option(
+        "-o", action="store", help="store abc files in DIR", default="", metavar="DIR"
+    )
+    parser.add_option(
+        "-v",
+        action="store",
+        type="int",
+        help="set volta typesetting behaviour to V",
+        default=0,
+        metavar="V",
+    )
+    parser.add_option("-x", action="store_true", help="output no line breaks")
+    parser.add_option(
+        "-p",
+        action="store",
+        help="pageformat PFMT (cm) = scale, pageheight, pagewidth, leftmargin, rightmargin, topmargin, botmargin",
+        default="",
+        metavar="PFMT",
+    )
+    parser.add_option(
+        "-j",
+        action="store_true",
+        help="switch for compatibility with javascript version",
+    )
+    parser.add_option(
+        "-t",
+        action="store_true",
+        help="translate perc- and tab-staff to ABC code with %%map, %%voicemap",
+    )
+    parser.add_option(
+        "-s", action="store_true", help="shift node heads 3 units left in a tab staff"
+    )
+    parser.add_option(
+        "--v1",
+        action="store_true",
+        help="start-stop directions allways to first voice of staff",
+    )
+    parser.add_option(
+        "--noped",
+        action="store_false",
+        help="skip all pedal directions",
+        dest="ped",
+        default=True,
+    )
+    parser.add_option(
+        "--stems",
+        action="store_true",
+        help="translate stem directions",
+        dest="stm",
+        default=False,
+    )
+    parser.add_option(
+        "-i", action="store_true", help="read xml file from standard input"
+    )
+    options, args = parser.parse_args()
+    if options.n < 0:
+        parser.error("only values >= 0")
+    if options.b < 0:
+        parser.error("only values >= 0")
+    if options.d and options.d not in [2**n for n in range(10)]:
+        parser.error("D should be on of %s" % ",".join([str(2**n) for n in range(10)]))
+    options.p = options.p and options.p.split(",") or []  # ==> [] | [string]
+    if len(args) == 0 and not options.i:
+        parser.error("no input file given")
     pad = options.o
     if pad:
-        if not os.path.exists (pad): os.mkdir (pad)
-        if not os.path.isdir (pad): parser.error ('%s is not a directory' % pad)
+        if not os.path.exists(pad):
+            os.mkdir(pad)
+        if not os.path.isdir(pad):
+            parser.error("%s is not a directory" % pad)
     fnmext_list = []
-    for i in args: fnmext_list += glob (i)
-    if options.i: fnmext_list = ['stdin.xml']
-    if not fnmext_list: parser.error ('none of the input files exist')
-    for X, fnmext in enumerate (fnmext_list):
-        fnm, ext = os.path.splitext (fnmext)
-        if ext.lower () not in ('.xml','.mxl','.musicxml'):
-            info ('skipped input file %s, it should have extension .xml or .mxl' % fnmext)
+    for i in args:
+        fnmext_list += glob(i)
+    if options.i:
+        fnmext_list = ["stdin.xml"]
+    if not fnmext_list:
+        parser.error("none of the input files exist")
+    for X, fnmext in enumerate(fnmext_list):
+        fnm, ext = os.path.splitext(fnmext)
+        if ext.lower() not in (".xml", ".mxl", ".musicxml"):
+            info(
+                "skipped input file %s, it should have extension .xml or .mxl" % fnmext
+            )
             continue
-        if os.path.isdir (fnmext):
-            info ('skipped directory %s. Only files are accepted' % fnmext)
+        if os.path.isdir(fnmext):
+            info("skipped directory %s. Only files are accepted" % fnmext)
             continue
-        if fnmext == 'stdin.xml':
+        if fnmext == "stdin.xml":
             fobj = sys.stdin
-        elif ext.lower () == '.mxl':        # extract .xml file from .mxl file
+        elif ext.lower() == ".mxl":  # extract .xml file from .mxl file
             z = ZipFile(fnmext)
-            for n in z.namelist():          # assume there is always an xml file in a mxl archive !!
-                if (n[:4] != 'META') and (n[-4:].lower() == '.xml'):
-                    fobj = z.open (n)
-                    break   # assume only one MusicXML file per archive
+            for (
+                n
+            ) in z.namelist():  # assume there is always an xml file in a mxl archive !!
+                if (n[:4] != "META") and (n[-4:].lower() == ".xml"):
+                    fobj = z.open(n)
+                    break  # assume only one MusicXML file per archive
         else:
-            fobj = open (fnmext, 'rb')      # open regular xml file
+            fobj = open(fnmext, "rb")  # open regular xml file
 
-        abcOut = ABCoutput (fnm + '.abc', pad, X, options)  # create global ABC output object
-        psr = Parser (options)  # xml parser
+        abcOut = ABCoutput(
+            fnm + ".abc", pad, X, options
+        )  # create global ABC output object
+        psr = Parser(options)  # xml parser
         try:
-            psr.parse (fobj)    # parse file fobj and write abc to <fnm>.abc
+            psr.parse(fobj)  # parse file fobj and write abc to <fnm>.abc
         except:
-            etype, value, traceback = sys.exc_info ()   # works in python 2 & 3
-            info ('** %s occurred: %s in %s' % (etype, value, fnmext), 0)
+            etype, value, traceback = sys.exc_info()  # works in python 2 & 3
+            info("** %s occurred: %s in %s" % (etype, value, fnmext), 0)

--- a/finetune/config.py
+++ b/finetune/config.py
@@ -1,38 +1,47 @@
-import os
-
 # Configuration for the data
-DATA_TRAIN_INDEX_PATH = "" 
-DATA_EVAL_INDEX_PATH  = ""
+DATA_TRAIN_INDEX_PATH = ""
+DATA_EVAL_INDEX_PATH = ""
 
 # Configuration for the model
-PATCH_STREAM = True                                             # Stream training / inference
-PATCH_SIZE = 16                                                # Patch Size
-PATCH_LENGTH = 1024                                             # Patch Length
-CHAR_NUM_LAYERS = 6                                             # Number of layers in the decoder
-PATCH_NUM_LAYERS = 20                                           # Number of layers in the encoder
-HIDDEN_SIZE = 1280                                               # Hidden Size
+PATCH_STREAM = True  # Stream training / inference
+PATCH_SIZE = 16  # Patch Size
+PATCH_LENGTH = 1024  # Patch Length
+CHAR_NUM_LAYERS = 6  # Number of layers in the decoder
+PATCH_NUM_LAYERS = 20  # Number of layers in the encoder
+HIDDEN_SIZE = 1280  # Hidden Size
 
 # Configuration for the training
-BATCH_SIZE = 1         
-LEARNING_RATE = 1e-5   
-NUM_EPOCHS = 64                                                 # Number of epochs to train for (if early stopping doesn't intervene)
-ACCUMULATION_STEPS = 1                                          # Accumulation steps to simulate large batch size
-PATCH_SAMPLING_BATCH_SIZE = 0                                   # Batch size for patch during training, 0 for full conaudio
-LOAD_FROM_CHECKPOINT = False                                    # Whether to load weights from a checkpoint
-WANDB_LOGGING = False                                           # Whether to log to wandb
-WANDB_KEY = '<your_wandb_key>'
+BATCH_SIZE = 1
+LEARNING_RATE = 1e-5
+NUM_EPOCHS = 64  # Number of epochs to train for (if early stopping doesn't intervene)
+ACCUMULATION_STEPS = 1  # Accumulation steps to simulate large batch size
+PATCH_SAMPLING_BATCH_SIZE = (
+    0  # Batch size for patch during training, 0 for full conaudio
+)
+LOAD_FROM_CHECKPOINT = False  # Whether to load weights from a checkpoint
+WANDB_LOGGING = False  # Whether to log to wandb
+WANDB_KEY = "<your_wandb_key>"
 
-PRETRAINED_PATH = ""                # Path of pretrained weights
-EXP_TAG = ''                                            # Experiment tag for name differentiation
-NAME =  EXP_TAG + \
-        "_p_size_" + str(PATCH_SIZE) + \
-        "_p_length_" + str(PATCH_LENGTH) + \
-        "_p_layers_" + str(PATCH_NUM_LAYERS) + \
-        "_c_layers_" + str(CHAR_NUM_LAYERS) + \
-        "_h_size_" + str(HIDDEN_SIZE) + \
-        "_lr_" + str(LEARNING_RATE) + \
-        "_batch_" + str(BATCH_SIZE)
+PRETRAINED_PATH = ""  # Path of pretrained weights
+EXP_TAG = ""  # Experiment tag for name differentiation
+NAME = (
+    EXP_TAG
+    + "_p_size_"
+    + str(PATCH_SIZE)
+    + "_p_length_"
+    + str(PATCH_LENGTH)
+    + "_p_layers_"
+    + str(PATCH_NUM_LAYERS)
+    + "_c_layers_"
+    + str(CHAR_NUM_LAYERS)
+    + "_h_size_"
+    + str(HIDDEN_SIZE)
+    + "_lr_"
+    + str(LEARNING_RATE)
+    + "_batch_"
+    + str(BATCH_SIZE)
+)
 
-WEIGHTS_PATH = "weights_notagen_" + NAME + ".pth"                  # Path to save weights
-LOGS_PATH    = "logs_notagen_"    + NAME + ".txt"                     # Path to save logs
+WEIGHTS_PATH = "weights_notagen_" + NAME + ".pth"  # Path to save weights
+LOGS_PATH = "logs_notagen_" + NAME + ".txt"  # Path to save logs
 WANDB_NAME = NAME

--- a/finetune/train-gen.py
+++ b/finetune/train-gen.py
@@ -1,7 +1,6 @@
 import os
 import gc
 import time
-import math
 import json
 import wandb
 import torch
@@ -14,26 +13,26 @@ from tqdm import tqdm
 from copy import deepcopy
 from torch.cuda.amp import autocast, GradScaler
 from torch.utils.data import Dataset, DataLoader
-from transformers import GPT2Config, LlamaConfig, get_scheduler, get_constant_schedule_with_warmup
+from transformers import GPT2Config, get_constant_schedule_with_warmup
 import torch.distributed as dist
 from torch.nn.parallel import DistributedDataParallel as DDP
 from torch.utils.data.distributed import DistributedSampler
 
 Index2Key = {index: key for key, index in Key2index.items() if index not in [1, 11]}
-Mode2Key = {mode: key for key, mode_list in Key2Mode.items() for mode in mode_list }
+Mode2Key = {mode: key for key, mode_list in Key2Mode.items() for mode in mode_list}
 
 # Set up distributed training
-world_size = int(os.environ['WORLD_SIZE']) if 'WORLD_SIZE' in os.environ else 1
-global_rank = int(os.environ['RANK']) if 'RANK' in os.environ else 0
-local_rank = int(os.environ['LOCAL_RANK']) if 'LOCAL_RANK' in os.environ else 0
+world_size = int(os.environ["WORLD_SIZE"]) if "WORLD_SIZE" in os.environ else 1
+global_rank = int(os.environ["RANK"]) if "RANK" in os.environ else 0
+local_rank = int(os.environ["LOCAL_RANK"]) if "LOCAL_RANK" in os.environ else 0
 
 if world_size > 1:
     torch.cuda.set_device(local_rank)
     device = torch.device("cuda", local_rank)
-    dist.init_process_group(backend='nccl') if world_size > 1 else None
+    dist.init_process_group(backend="nccl") if world_size > 1 else None
 else:
     device = torch.device("cuda") if torch.cuda.is_available() else torch.device("cpu")
-    
+
 # Set random seed
 seed = 0 + global_rank
 random.seed(seed)
@@ -47,28 +46,40 @@ batch_size = BATCH_SIZE
 
 patchilizer = Patchilizer()
 
-patch_config = GPT2Config(num_hidden_layers=PATCH_NUM_LAYERS, 
-                    max_length=PATCH_LENGTH, 
-                    max_position_embeddings=PATCH_LENGTH,
-                    n_embd=HIDDEN_SIZE,
-                    num_attention_heads=HIDDEN_SIZE//64,
-                    vocab_size=1)
-char_config = GPT2Config(num_hidden_layers=CHAR_NUM_LAYERS, 
-                            max_length=PATCH_SIZE+1, 
-                            max_position_embeddings=PATCH_SIZE+1,
-                            hidden_size=HIDDEN_SIZE,
-                            num_attention_heads=HIDDEN_SIZE//64,
-                            vocab_size=128)
+patch_config = GPT2Config(
+    num_hidden_layers=PATCH_NUM_LAYERS,
+    max_length=PATCH_LENGTH,
+    max_position_embeddings=PATCH_LENGTH,
+    n_embd=HIDDEN_SIZE,
+    num_attention_heads=HIDDEN_SIZE // 64,
+    vocab_size=1,
+)
+char_config = GPT2Config(
+    num_hidden_layers=CHAR_NUM_LAYERS,
+    max_length=PATCH_SIZE + 1,
+    max_position_embeddings=PATCH_SIZE + 1,
+    hidden_size=HIDDEN_SIZE,
+    num_attention_heads=HIDDEN_SIZE // 64,
+    vocab_size=128,
+)
 
 model = NotaGenLMHeadModel(encoder_config=patch_config, decoder_config=char_config)
 
 model = model.to(device)
 
 # print parameter number
-print("Parameter Number: "+str(sum(p.numel() for p in model.parameters() if p.requires_grad)))
+print(
+    "Parameter Number: "
+    + str(sum(p.numel() for p in model.parameters() if p.requires_grad))
+)
 
 if world_size > 1:
-    model = DDP(model, device_ids=[local_rank], output_device=local_rank,  find_unused_parameters=True)
+    model = DDP(
+        model,
+        device_ids=[local_rank],
+        output_device=local_rank,
+        find_unused_parameters=True,
+    )
 
 scaler = GradScaler()
 is_autocast = True
@@ -83,24 +94,32 @@ def clear_unused_tensors():
             model_tensors = {id(p) for p in model.module.parameters()}
         else:
             model_tensors = {id(p) for p in model.parameters()}
-        
+
         # Get the set of tensor ids used by the optimizer
         optimizer_tensors = {
-            id(state) 
-            for state_dict in optimizer.state.values() 
+            id(state)
+            for state_dict in optimizer.state.values()
             for state in state_dict.values()
             if isinstance(state, torch.Tensor)  # Ensure only tensors are considered
         }
 
         # List of all CUDA tensors currently in memory
-        tensors = [obj for obj in gc.get_objects() if isinstance(obj, torch.Tensor) and obj.is_cuda]
-        
+        tensors = [
+            obj
+            for obj in gc.get_objects()
+            if isinstance(obj, torch.Tensor) and obj.is_cuda
+        ]
+
         # Create weak references to avoid interfering with garbage collection
         tensor_refs = [weakref.ref(tensor) for tensor in tensors]
 
         for tensor_ref in tensor_refs:
             tensor = tensor_ref()  # Dereference the weak reference
-            if tensor is not None and id(tensor) not in model_tensors and id(tensor) not in optimizer_tensors:
+            if (
+                tensor is not None
+                and id(tensor) not in model_tensors
+                and id(tensor) not in optimizer_tensors
+            ):
                 # Mark the tensor for deletion
                 tensor.detach_()  # Detach from computation graph
                 del tensor  # Delete the tensor reference
@@ -112,13 +131,19 @@ def clear_unused_tensors():
         gc.collect()  # Force a garbage collection
         torch.cuda.empty_cache()  # Clear the CUDA cache
 
+
 def collate_batch(input_batches):
-    
+
     input_patches, input_masks = zip(*input_batches)
-    input_patches = torch.nn.utils.rnn.pad_sequence(input_patches, batch_first=True, padding_value=0)
-    input_masks = torch.nn.utils.rnn.pad_sequence(input_masks, batch_first=True, padding_value=0)
+    input_patches = torch.nn.utils.rnn.pad_sequence(
+        input_patches, batch_first=True, padding_value=0
+    )
+    input_masks = torch.nn.utils.rnn.pad_sequence(
+        input_masks, batch_first=True, padding_value=0
+    )
 
     return input_patches.to(device), input_masks.to(device)
+
 
 def split_into_minibatches(input_patches, input_masks, minibatch_size):
     minibatches = []
@@ -129,6 +154,7 @@ def split_into_minibatches(input_patches, input_masks, minibatch_size):
         minibatches.append((minibatch_patches, minibatch_masks))
     return minibatches
 
+
 class NotaGenDataset(Dataset):
     def __init__(self, filenames):
         self.filenames = filenames
@@ -138,32 +164,34 @@ class NotaGenDataset(Dataset):
 
     def __getitem__(self, idx):
 
-        filepath = self.filenames[idx]['path']
-        ori_key = Mode2Key[self.filenames[idx]['key']]
+        filepath = self.filenames[idx]["path"]
+        ori_key = Mode2Key[self.filenames[idx]["key"]]
 
         # choose a key to transpose, according to a probility distribution
         ori_key_index = Key2index[ori_key]
         available_index = [(ori_key_index + offset) % 12 for offset in range(-3, 4)]
-        index_prob = [1/16, 2/16, 3/16, 4/16, 3/16, 2/16, 1/16]
-        index_prob_range = [0] + [sum(index_prob[0 : i + 1]) for i in range(len(index_prob))]
+        index_prob = [1 / 16, 2 / 16, 3 / 16, 4 / 16, 3 / 16, 2 / 16, 1 / 16]
+        index_prob_range = [0] + [
+            sum(index_prob[0 : i + 1]) for i in range(len(index_prob))
+        ]
         random_number = random.random()
         for i in range(len(index_prob_range) - 1):
             if index_prob_range[i] <= random_number < index_prob_range[i + 1]:
                 des_key_index = available_index[i]
         if des_key_index == 1:
-            des_key = 'Db' if random.random() < 0.8 else 'C#'   
+            des_key = "Db" if random.random() < 0.8 else "C#"
         elif des_key_index == 11:
-            des_key = 'B' if random.random() < 0.8 else 'Cb'
+            des_key = "B" if random.random() < 0.8 else "Cb"
         elif des_key_index == 6:
-            des_key = 'F#' if random.random() < 0.5 else 'Gb'
+            des_key = "F#" if random.random() < 0.5 else "Gb"
         else:
             des_key = Index2Key[des_key_index]
 
         folder = os.path.dirname(filepath)
         name = os.path.split(filepath)[-1]
-        des_filepath = os.path.join(folder, des_key, name + '_' + des_key + '.abc')
-        
-        with open(des_filepath, 'r', encoding='utf-8') as f:
+        des_filepath = os.path.join(folder, des_key, name + "_" + des_key + ".abc")
+
+        with open(des_filepath, "r", encoding="utf-8") as f:
             abc_text = f.read()
 
         file_bytes = patchilizer.encode_train(abc_text)
@@ -171,7 +199,7 @@ class NotaGenDataset(Dataset):
 
         file_bytes = torch.tensor(file_bytes, dtype=torch.long)
         file_masks = torch.tensor(file_masks, dtype=torch.long)
-        
+
         return file_bytes, file_masks
 
 
@@ -195,10 +223,12 @@ def train_epoch(epoch):
     total_train_loss = 0
     iter_idx = 1
     model.train()
-    train_steps = (epoch-1)*len(train_set)
+    train_steps = (epoch - 1) * len(train_set)
 
     for batch in tqdm_train_set:
-        minibatches = split_into_minibatches(batch[0], batch[1], BATCH_SIZE//ACCUMULATION_STEPS)
+        minibatches = split_into_minibatches(
+            batch[0], batch[1], BATCH_SIZE // ACCUMULATION_STEPS
+        )
         for minibatch in minibatches:
             with autocast():
                 loss = process_one_batch(minibatch) / ACCUMULATION_STEPS
@@ -206,21 +236,24 @@ def train_epoch(epoch):
             total_train_loss += loss.item()
         scaler.step(optimizer)
         scaler.update()
-        
+
         lr_scheduler.step()
         model.zero_grad(set_to_none=True)
-        tqdm_train_set.set_postfix({str(global_rank)+'_train_loss': total_train_loss / iter_idx})
+        tqdm_train_set.set_postfix(
+            {str(global_rank) + "_train_loss": total_train_loss / iter_idx}
+        )
         train_steps += 1
 
         # Log the training loss to wandb
-        if global_rank==0 and WANDB_LOGGING:
+        if global_rank == 0 and WANDB_LOGGING:
             wandb.log({"train_loss": total_train_loss / iter_idx}, step=train_steps)
 
         iter_idx += 1
         if iter_idx % 1000 == 0:
             clear_unused_tensors()
-        
-    return total_train_loss / (iter_idx-1)
+
+    return total_train_loss / (iter_idx - 1)
+
 
 # do one epoch for eval
 def eval_epoch():
@@ -229,34 +262,38 @@ def eval_epoch():
     total_eval_bpb = 0
     iter_idx = 1
     model.eval()
-  
+
     # Evaluate data for one epoch
-    for batch in tqdm_eval_set: 
-        minibatches = split_into_minibatches(batch[0], batch[1], BATCH_SIZE//ACCUMULATION_STEPS)
+    for batch in tqdm_eval_set:
+        minibatches = split_into_minibatches(
+            batch[0], batch[1], BATCH_SIZE // ACCUMULATION_STEPS
+        )
         for minibatch in minibatches:
             with torch.no_grad():
                 loss = process_one_batch(minibatch) / ACCUMULATION_STEPS
             total_eval_loss += loss.item()
-        tqdm_eval_set.set_postfix({str(global_rank)+'_eval_loss': total_eval_loss / iter_idx})
+        tqdm_eval_set.set_postfix(
+            {str(global_rank) + "_eval_loss": total_eval_loss / iter_idx}
+        )
         iter_idx += 1
-    return total_eval_loss / (iter_idx-1)
+    return total_eval_loss / (iter_idx - 1)
+
 
 # train and eval
 if __name__ == "__main__":
-    
+
     # Initialize wandb
-    if WANDB_LOGGING and global_rank==0:
+    if WANDB_LOGGING and global_rank == 0:
         wandb.login(key=WANDB_KEY)
-        wandb.init(project="notagen",
-                   name=WANDB_NAME)
-    
+        wandb.init(project="notagen", name=WANDB_NAME)
+
     # load data
     with open(DATA_TRAIN_INDEX_PATH, "r", encoding="utf-8") as f:
         print("Loading Data...")
         train_files = []
         for line in f:
             train_files.append(json.loads(line))
-    
+
     with open(DATA_EVAL_INDEX_PATH, "r", encoding="utf-8") as f:
         print("Loading Data...")
         eval_files = []
@@ -265,26 +302,44 @@ if __name__ == "__main__":
 
     if len(eval_files) == 0:
         train_files, eval_files = split_data(train_files)
-       
+
     train_batch_nums = int(len(train_files) / batch_size)
     eval_batch_nums = int(len(eval_files) / batch_size)
 
     random.shuffle(train_files)
     random.shuffle(eval_files)
 
-    train_files = train_files[:train_batch_nums*batch_size]
-    eval_files = eval_files[:eval_batch_nums*batch_size]
+    train_files = train_files[: train_batch_nums * batch_size]
+    eval_files = eval_files[: eval_batch_nums * batch_size]
 
     train_set = NotaGenDataset(train_files)
     eval_set = NotaGenDataset(eval_files)
 
-    train_sampler = DistributedSampler(train_set, num_replicas=world_size, rank=local_rank)
-    eval_sampler = DistributedSampler(eval_set, num_replicas=world_size, rank=local_rank)
+    train_sampler = DistributedSampler(
+        train_set, num_replicas=world_size, rank=local_rank
+    )
+    eval_sampler = DistributedSampler(
+        eval_set, num_replicas=world_size, rank=local_rank
+    )
 
-    train_set = DataLoader(train_set, batch_size=batch_size, collate_fn=collate_batch, sampler=train_sampler, shuffle = (train_sampler is None))
-    eval_set = DataLoader(eval_set, batch_size=batch_size, collate_fn=collate_batch, sampler=eval_sampler, shuffle = (train_sampler is None))
+    train_set = DataLoader(
+        train_set,
+        batch_size=batch_size,
+        collate_fn=collate_batch,
+        sampler=train_sampler,
+        shuffle=(train_sampler is None),
+    )
+    eval_set = DataLoader(
+        eval_set,
+        batch_size=batch_size,
+        collate_fn=collate_batch,
+        sampler=eval_sampler,
+        shuffle=(train_sampler is None),
+    )
 
-    lr_scheduler = get_constant_schedule_with_warmup(optimizer=optimizer, num_warmup_steps=1000)
+    lr_scheduler = get_constant_schedule_with_warmup(
+        optimizer=optimizer, num_warmup_steps=1000
+    )
 
     model = model.to(device)
     optimizer = torch.optim.AdamW(model.parameters(), lr=LEARNING_RATE)
@@ -292,83 +347,102 @@ if __name__ == "__main__":
     if not LOAD_FROM_CHECKPOINT:
         if os.path.exists(PRETRAINED_PATH):
             # Load pre-trained checkpoint to CPU
-            checkpoint = torch.load(PRETRAINED_PATH, map_location='cpu')
-    
+            checkpoint = torch.load(PRETRAINED_PATH, map_location="cpu")
+
             # Here, model is assumed to be on GPU
             # Load state dict to CPU model first, then move the model to GPU
             if torch.cuda.device_count() > 1:
                 # If you have a DataParallel model, you need to load to model.module instead
                 cpu_model = deepcopy(model.module)
-                cpu_model.load_state_dict(checkpoint['model'])
+                cpu_model.load_state_dict(checkpoint["model"])
                 model.module.load_state_dict(cpu_model.state_dict())
             else:
                 # Load to a CPU clone of the model, then load back
                 cpu_model = deepcopy(model)
-                cpu_model.load_state_dict(checkpoint['model'])
+                cpu_model.load_state_dict(checkpoint["model"])
                 model.load_state_dict(cpu_model.state_dict())
-                
-            print(f"Successfully Loaded Pretrained Checkpoint at Epoch {checkpoint['epoch']} with Loss {checkpoint['min_eval_loss']}")
+
+            print(
+                f"Successfully Loaded Pretrained Checkpoint at Epoch {checkpoint['epoch']} with Loss {checkpoint['min_eval_loss']}"
+            )
 
             pre_epoch = 0
             best_epoch = 0
             min_eval_loss = 100
         else:
-            raise Exception('Pre-trained Checkpoint not found. Please check your pre-trained ckpt path.')
-            
+            raise Exception(
+                "Pre-trained Checkpoint not found. Please check your pre-trained ckpt path."
+            )
+
     else:
         if os.path.exists(WEIGHTS_PATH):
             # Load checkpoint to CPU
-            checkpoint = torch.load(WEIGHTS_PATH, map_location='cpu')
-    
+            checkpoint = torch.load(WEIGHTS_PATH, map_location="cpu")
+
             # Here, model is assumed to be on GPU
             # Load state dict to CPU model first, then move the model to GPU
             if torch.cuda.device_count() > 1:
                 # If you have a DataParallel model, you need to load to model.module instead
                 cpu_model = deepcopy(model.module)
-                cpu_model.load_state_dict(checkpoint['model'])
+                cpu_model.load_state_dict(checkpoint["model"])
                 model.module.load_state_dict(cpu_model.state_dict())
             else:
                 # Load to a CPU clone of the model, then load back
                 cpu_model = deepcopy(model)
-                cpu_model.load_state_dict(checkpoint['model'])
+                cpu_model.load_state_dict(checkpoint["model"])
                 model.load_state_dict(cpu_model.state_dict())
-            optimizer.load_state_dict(checkpoint['optimizer'])
-            lr_scheduler.load_state_dict(checkpoint['lr_sched'])
-            pre_epoch = checkpoint['epoch']
-            best_epoch = checkpoint['best_epoch']
-            min_eval_loss = checkpoint['min_eval_loss']
+            optimizer.load_state_dict(checkpoint["optimizer"])
+            lr_scheduler.load_state_dict(checkpoint["lr_sched"])
+            pre_epoch = checkpoint["epoch"]
+            best_epoch = checkpoint["best_epoch"]
+            min_eval_loss = checkpoint["min_eval_loss"]
             print("Successfully Loaded Checkpoint from Epoch %d" % pre_epoch)
             checkpoint = None
 
         else:
-            raise Exception('Checkpoint not found to continue training. Please check your parameter settings.')
-    
+            raise Exception(
+                "Checkpoint not found to continue training. Please check your parameter settings."
+            )
 
-    for epoch in range(1+pre_epoch, NUM_EPOCHS+1):
+    for epoch in range(1 + pre_epoch, NUM_EPOCHS + 1):
         train_sampler.set_epoch(epoch)
         eval_sampler.set_epoch(epoch)
-        print('-' * 21 + "Epoch " + str(epoch) + '-' * 21)
+        print("-" * 21 + "Epoch " + str(epoch) + "-" * 21)
         train_loss = train_epoch(epoch)
         eval_loss = eval_epoch()
-        if global_rank==0:
-            with open(LOGS_PATH,'a') as f:
-                f.write("Epoch " + str(epoch) + "\ntrain_loss: " + str(train_loss) + "\neval_loss: " +str(eval_loss) + "\ntime: " + time.asctime(time.localtime(time.time())) + "\n\n")
+        if global_rank == 0:
+            with open(LOGS_PATH, "a") as f:
+                f.write(
+                    "Epoch "
+                    + str(epoch)
+                    + "\ntrain_loss: "
+                    + str(train_loss)
+                    + "\neval_loss: "
+                    + str(eval_loss)
+                    + "\ntime: "
+                    + time.asctime(time.localtime(time.time()))
+                    + "\n\n"
+                )
             if eval_loss < min_eval_loss:
                 best_epoch = epoch
                 min_eval_loss = eval_loss
-                checkpoint = { 
-                                'model': model.module.state_dict() if hasattr(model, "module") else model.state_dict(),
-                                'optimizer': optimizer.state_dict(),
-                                'lr_sched': lr_scheduler.state_dict(),
-                                'epoch': epoch,
-                                'best_epoch': best_epoch,
-                                'min_eval_loss': min_eval_loss
-                                }
+                checkpoint = {
+                    "model": (
+                        model.module.state_dict()
+                        if hasattr(model, "module")
+                        else model.state_dict()
+                    ),
+                    "optimizer": optimizer.state_dict(),
+                    "lr_sched": lr_scheduler.state_dict(),
+                    "epoch": epoch,
+                    "best_epoch": best_epoch,
+                    "min_eval_loss": min_eval_loss,
+                }
                 torch.save(checkpoint, WEIGHTS_PATH)
-        
+
         if world_size > 1:
             dist.barrier()
 
-    if global_rank==0:
-        print("Best Eval Epoch : "+str(best_epoch))
-        print("Min Eval Loss : "+str(min_eval_loss))
+    if global_rank == 0:
+        print("Best Eval Epoch : " + str(best_epoch))
+        print("Min Eval Loss : " + str(min_eval_loss))

--- a/finetune/utils.py
+++ b/finetune/utils.py
@@ -1,20 +1,18 @@
 import torch
 import random
 import bisect
-import json
 import re
 import numpy as np
 from config import *
-from transformers import GPT2Model, GPT2LMHeadModel, LlamaModel, LlamaForCausalLM, PreTrainedModel
+from transformers import GPT2Model, GPT2LMHeadModel, PreTrainedModel
 from samplings import top_p_sampling, top_k_sampling, temperature_sampling
-from tokenizers import Tokenizer
 
 
 class Patchilizer:
     def __init__(self, stream=PATCH_STREAM):
         self.stream = stream
         self.delimiters = ["|:", "::", ":|", "[|", "||", "|]", "|"]
-        self.regexPattern = '(' + '|'.join(map(re.escape, self.delimiters)) + ')'
+        self.regexPattern = "(" + "|".join(map(re.escape, self.delimiters)) + ")"
         self.bos_token_id = 1
         self.eos_token_id = 2
         self.special_token_id = 0
@@ -34,11 +32,17 @@ class Patchilizer:
                     new_line_bars = line_bars
                 else:
                     if line_bars[0] in self.delimiters:
-                        new_line_bars = [line_bars[i] + line_bars[i + 1] for i in range(0, len(line_bars), 2)]
+                        new_line_bars = [
+                            line_bars[i] + line_bars[i + 1]
+                            for i in range(0, len(line_bars), 2)
+                        ]
                     else:
-                        new_line_bars = [line_bars[0]] + [line_bars[i] + line_bars[i + 1] for i in range(1, len(line_bars), 2)]
-                    if 'V' not in new_line_bars[-1]:
-                        new_line_bars[-2] += new_line_bars[-1]  
+                        new_line_bars = [line_bars[0]] + [
+                            line_bars[i] + line_bars[i + 1]
+                            for i in range(1, len(line_bars), 2)
+                        ]
+                    if "V" not in new_line_bars[-1]:
+                        new_line_bars[-2] += new_line_bars[-1]
                         new_line_bars = new_line_bars[:-1]
                 new_bars += new_line_bars
         except:
@@ -49,14 +53,16 @@ class Patchilizer:
     def split_patches(self, abc_text, patch_size=PATCH_SIZE, generate_last=False):
         if not generate_last and len(abc_text) % patch_size != 0:
             abc_text += chr(self.eos_token_id)
-        patches = [abc_text[i : i + patch_size] for i in range(0, len(abc_text), patch_size)]
+        patches = [
+            abc_text[i : i + patch_size] for i in range(0, len(abc_text), patch_size)
+        ]
         return patches
 
     def patch2chars(self, patch):
         """
         Convert a patch into a bar.
         """
-        bytes = ''
+        bytes = ""
         for idx in patch:
             if idx == self.eos_token_id:
                 break
@@ -64,7 +70,6 @@ class Patchilizer:
                 pass
             bytes += chr(idx)
         return bytes
-        
 
     def patchilize_metadata(self, metadata_lines):
 
@@ -73,77 +78,103 @@ class Patchilizer:
             metadata_patches += self.split_patches(line)
 
         return metadata_patches
-    
-    def patchilize_tunebody(self, tunebody_lines, encode_mode='train'):
+
+    def patchilize_tunebody(self, tunebody_lines, encode_mode="train"):
 
         tunebody_patches = []
         bars = self.split_bars(tunebody_lines)
-        if encode_mode == 'train':
+        if encode_mode == "train":
             for bar in bars:
                 tunebody_patches += self.split_patches(bar)
-        elif encode_mode == 'generate':
+        elif encode_mode == "generate":
             for bar in bars[:-1]:
                 tunebody_patches += self.split_patches(bar)
             tunebody_patches += self.split_patches(bars[-1], generate_last=True)
-       
+
         return tunebody_patches
 
-    def encode_train(self, abc_text, patch_length=PATCH_LENGTH, patch_size=PATCH_SIZE, add_special_patches=True, cut=True):
+    def encode_train(
+        self,
+        abc_text,
+        patch_length=PATCH_LENGTH,
+        patch_size=PATCH_SIZE,
+        add_special_patches=True,
+        cut=True,
+    ):
 
-        lines = abc_text.split('\n')
+        lines = abc_text.split("\n")
         lines = list(filter(None, lines))
-        lines = [line + '\n' for line in lines]
+        lines = [line + "\n" for line in lines]
 
         tunebody_index = -1
         for i, line in enumerate(lines):
-            if '[V:' in line:
+            if "[V:" in line:
                 tunebody_index = i
                 break
 
-        metadata_lines = lines[ : tunebody_index]
-        tunebody_lines = lines[tunebody_index : ]
+        metadata_lines = lines[:tunebody_index]
+        tunebody_lines = lines[tunebody_index:]
 
         if self.stream:
-            tunebody_lines = ['[r:' + str(line_index) + '/' + str(len(tunebody_lines) - line_index - 1) + ']' + line for line_index, line in
-                                enumerate(tunebody_lines)]    
+            tunebody_lines = [
+                "[r:"
+                + str(line_index)
+                + "/"
+                + str(len(tunebody_lines) - line_index - 1)
+                + "]"
+                + line
+                for line_index, line in enumerate(tunebody_lines)
+            ]
 
         metadata_patches = self.patchilize_metadata(metadata_lines)
-        tunebody_patches = self.patchilize_tunebody(tunebody_lines, encode_mode='train')
+        tunebody_patches = self.patchilize_tunebody(tunebody_lines, encode_mode="train")
 
         if add_special_patches:
-            bos_patch = chr(self.bos_token_id) * (patch_size - 1) + chr(self.eos_token_id)
-            eos_patch = chr(self.bos_token_id) + chr(self.eos_token_id) * (patch_size - 1)
+            bos_patch = chr(self.bos_token_id) * (patch_size - 1) + chr(
+                self.eos_token_id
+            )
+            eos_patch = chr(self.bos_token_id) + chr(self.eos_token_id) * (
+                patch_size - 1
+            )
 
             metadata_patches = [bos_patch] + metadata_patches
             tunebody_patches = tunebody_patches + [eos_patch]
 
         if self.stream:
             if len(metadata_patches) + len(tunebody_patches) > patch_length:
-                available_cut_indexes = [0] + [index + 1 for index, patch in enumerate(tunebody_patches) if '\n' in patch]
-                line_index_for_cut_index = list(range(len(available_cut_indexes)))  
+                available_cut_indexes = [0] + [
+                    index + 1
+                    for index, patch in enumerate(tunebody_patches)
+                    if "\n" in patch
+                ]
+                line_index_for_cut_index = list(range(len(available_cut_indexes)))
                 end_index = len(metadata_patches) + len(tunebody_patches) - patch_length
-                biggest_index = bisect.bisect_left(available_cut_indexes, end_index) 
-                available_cut_indexes = available_cut_indexes[:biggest_index + 1]
+                biggest_index = bisect.bisect_left(available_cut_indexes, end_index)
+                available_cut_indexes = available_cut_indexes[: biggest_index + 1]
 
                 if len(available_cut_indexes) == 1:
-                    choices = ['head']
+                    choices = ["head"]
                 elif len(available_cut_indexes) == 2:
-                    choices = ['head', 'tail']
+                    choices = ["head", "tail"]
                 else:
-                    choices = ['head', 'tail', 'middle']
+                    choices = ["head", "tail", "middle"]
                 choice = random.choice(choices)
-                if choice == 'head':
+                if choice == "head":
                     patches = metadata_patches + tunebody_patches[0:]
                 else:
-                    if choice == 'tail':
+                    if choice == "tail":
                         cut_index = len(available_cut_indexes) - 1
                     else:
-                        cut_index = random.choice(range(1, len(available_cut_indexes) - 1))
+                        cut_index = random.choice(
+                            range(1, len(available_cut_indexes) - 1)
+                        )
 
-                    line_index = line_index_for_cut_index[cut_index] 
-                    stream_tunebody_lines = tunebody_lines[line_index : ]
-                    
-                    stream_tunebody_patches = self.patchilize_tunebody(stream_tunebody_lines, encode_mode='train')
+                    line_index = line_index_for_cut_index[cut_index]
+                    stream_tunebody_lines = tunebody_lines[line_index:]
+
+                    stream_tunebody_patches = self.patchilize_tunebody(
+                        stream_tunebody_lines, encode_mode="train"
+                    )
                     if add_special_patches:
                         stream_tunebody_patches = stream_tunebody_patches + [eos_patch]
                     patches = metadata_patches + stream_tunebody_patches
@@ -152,52 +183,68 @@ class Patchilizer:
         else:
             patches = metadata_patches + tunebody_patches
 
-        if cut: 
-            patches = patches[ : patch_length]
-        else:  
+        if cut:
+            patches = patches[:patch_length]
+        else:
             pass
 
         # encode to ids
         id_patches = []
         for patch in patches:
-            id_patch = [ord(c) for c in patch] + [self.special_token_id] * (patch_size - len(patch))
+            id_patch = [ord(c) for c in patch] + [self.special_token_id] * (
+                patch_size - len(patch)
+            )
             id_patches.append(id_patch)
 
         return id_patches
 
-    def encode_generate(self, abc_code, patch_length=PATCH_LENGTH, patch_size=PATCH_SIZE, add_special_patches=True):
+    def encode_generate(
+        self,
+        abc_code,
+        patch_length=PATCH_LENGTH,
+        patch_size=PATCH_SIZE,
+        add_special_patches=True,
+    ):
 
-        lines = abc_code.split('\n')
+        lines = abc_code.split("\n")
         lines = list(filter(None, lines))
-    
+
         tunebody_index = None
         for i, line in enumerate(lines):
-            if line.startswith('[V:') or line.startswith('[r:'):
+            if line.startswith("[V:") or line.startswith("[r:"):
                 tunebody_index = i
                 break
-    
-        metadata_lines = lines[ : tunebody_index]
-        tunebody_lines = lines[tunebody_index : ]   
-    
-        metadata_lines = [line + '\n' for line in metadata_lines]
+
+        metadata_lines = lines[:tunebody_index]
+        tunebody_lines = lines[tunebody_index:]
+
+        metadata_lines = [line + "\n" for line in metadata_lines]
         if self.stream:
-            if not abc_code.endswith('\n'): 
-                tunebody_lines = [tunebody_lines[i] + '\n' for i in range(len(tunebody_lines) - 1)] + [tunebody_lines[-1]]
+            if not abc_code.endswith("\n"):
+                tunebody_lines = [
+                    tunebody_lines[i] + "\n" for i in range(len(tunebody_lines) - 1)
+                ] + [tunebody_lines[-1]]
             else:
-                tunebody_lines = [tunebody_lines[i] + '\n' for i in range(len(tunebody_lines))]
+                tunebody_lines = [
+                    tunebody_lines[i] + "\n" for i in range(len(tunebody_lines))
+                ]
         else:
-            tunebody_lines = [line + '\n' for line in tunebody_lines]
-    
+            tunebody_lines = [line + "\n" for line in tunebody_lines]
+
         metadata_patches = self.patchilize_metadata(metadata_lines)
-        tunebody_patches = self.patchilize_tunebody(tunebody_lines, encode_mode='generate')
-    
+        tunebody_patches = self.patchilize_tunebody(
+            tunebody_lines, encode_mode="generate"
+        )
+
         if add_special_patches:
-            bos_patch = chr(self.bos_token_id) * (patch_size - 1) + chr(self.eos_token_id)
+            bos_patch = chr(self.bos_token_id) * (patch_size - 1) + chr(
+                self.eos_token_id
+            )
 
             metadata_patches = [bos_patch] + metadata_patches
-    
+
         patches = metadata_patches + tunebody_patches
-        patches = patches[ : patch_length]
+        patches = patches[:patch_length]
 
         # encode to ids
         id_patches = []
@@ -205,34 +252,33 @@ class Patchilizer:
             if len(patch) < PATCH_SIZE and patch[-1] != chr(self.eos_token_id):
                 id_patch = [ord(c) for c in patch]
             else:
-                id_patch = [ord(c) for c in patch] + [self.special_token_id] * (patch_size - len(patch))
+                id_patch = [ord(c) for c in patch] + [self.special_token_id] * (
+                    patch_size - len(patch)
+                )
             id_patches.append(id_patch)
-        
+
         return id_patches
 
     def decode(self, patches):
         """
         Decode patches into music.
         """
-        return ''.join(self.patch2chars(patch) for patch in patches)
-
-        
+        return "".join(self.patch2chars(patch) for patch in patches)
 
 
 class PatchLevelDecoder(PreTrainedModel):
     """
-    A Patch-level Decoder model for generating patch features in an auto-regressive manner. 
+    A Patch-level Decoder model for generating patch features in an auto-regressive manner.
     It inherits PreTrainedModel from transformers.
     """
+
     def __init__(self, config):
         super().__init__(config)
         self.patch_embedding = torch.nn.Linear(PATCH_SIZE * 128, config.n_embd)
         torch.nn.init.normal_(self.patch_embedding.weight, std=0.02)
         self.base = GPT2Model(config)
 
-    def forward(self,
-                patches: torch.Tensor,
-                masks=None) -> torch.Tensor:
+    def forward(self, patches: torch.Tensor, masks=None) -> torch.Tensor:
         """
         The forward pass of the patch-level decoder model.
         :param patches: the patches to be encoded
@@ -243,11 +289,10 @@ class PatchLevelDecoder(PreTrainedModel):
         patches = patches.reshape(len(patches), -1, PATCH_SIZE * (128))
         patches = self.patch_embedding(patches.to(self.device))
 
-        if masks==None:
+        if masks == None:
             return self.base(inputs_embeds=patches)
         else:
-            return self.base(inputs_embeds=patches,
-                             attention_mask=masks)
+            return self.base(inputs_embeds=patches, attention_mask=masks)
 
 
 class CharLevelDecoder(PreTrainedModel):
@@ -255,6 +300,7 @@ class CharLevelDecoder(PreTrainedModel):
     A Char-level Decoder model for generating the chars within each patch in an auto-regressive manner
     based on the encoded patch features. It inherits PreTrainedModel from transformers.
     """
+
     def __init__(self, config):
         super().__init__(config)
         self.special_token_id = 0
@@ -262,9 +308,7 @@ class CharLevelDecoder(PreTrainedModel):
 
         self.base = GPT2LMHeadModel(config)
 
-    def forward(self,
-                encoded_patches: torch.Tensor,
-                target_patches: torch.Tensor):
+    def forward(self, encoded_patches: torch.Tensor, target_patches: torch.Tensor):
         """
         The forward pass of the char-level decoder model.
         :param encoded_patches: the encoded patches
@@ -272,7 +316,13 @@ class CharLevelDecoder(PreTrainedModel):
         :return: the output of the model
         """
         # preparing the labels for model training
-        target_patches = torch.cat((torch.ones_like(target_patches[:,0:1])*self.bos_token_id, target_patches), dim=1)
+        target_patches = torch.cat(
+            (
+                torch.ones_like(target_patches[:, 0:1]) * self.bos_token_id,
+                target_patches,
+            ),
+            dim=1,
+        )
         # print('target_patches shape:', target_patches.shape)
 
         target_masks = target_patches == self.special_token_id
@@ -283,53 +333,61 @@ class CharLevelDecoder(PreTrainedModel):
         target_masks = target_masks.masked_fill_(labels == -100, 0)
 
         # select patches
-        if PATCH_SAMPLING_BATCH_SIZE!=0 and PATCH_SAMPLING_BATCH_SIZE<target_patches.shape[0]:
+        if (
+            PATCH_SAMPLING_BATCH_SIZE != 0
+            and PATCH_SAMPLING_BATCH_SIZE < target_patches.shape[0]
+        ):
             indices = list(range(len(target_patches)))
             random.shuffle(indices)
             selected_indices = sorted(indices[:PATCH_SAMPLING_BATCH_SIZE])
 
-            target_patches = target_patches[selected_indices,:]
-            target_masks = target_masks[selected_indices,:]
-            encoded_patches = encoded_patches[selected_indices,:]
+            target_patches = target_patches[selected_indices, :]
+            target_masks = target_masks[selected_indices, :]
+            encoded_patches = encoded_patches[selected_indices, :]
 
         # get input embeddings
-        inputs_embeds = torch.nn.functional.embedding(target_patches, self.base.transformer.wte.weight)
+        inputs_embeds = torch.nn.functional.embedding(
+            target_patches, self.base.transformer.wte.weight
+        )
 
         # concatenate the encoded patches with the input embeddings
-        inputs_embeds = torch.cat((encoded_patches.unsqueeze(1), inputs_embeds[:,1:,:]), dim=1)
+        inputs_embeds = torch.cat(
+            (encoded_patches.unsqueeze(1), inputs_embeds[:, 1:, :]), dim=1
+        )
 
-        output = self.base(inputs_embeds=inputs_embeds, 
-                         attention_mask=target_masks,
-                         labels=labels)
-                         # output_hidden_states=True=True)
+        output = self.base(
+            inputs_embeds=inputs_embeds, attention_mask=target_masks, labels=labels
+        )
+        # output_hidden_states=True=True)
 
         return output
 
-    def generate(self,
-                 encoded_patch: torch.Tensor,   # [hidden_size]
-                 tokens: torch.Tensor): # [1]
+    def generate(
+        self, encoded_patch: torch.Tensor, tokens: torch.Tensor  # [hidden_size]
+    ):  # [1]
         """
         The generate function for generating a patch based on the encoded patch and already generated tokens.
         :param encoded_patch: the encoded patch
         :param tokens: already generated tokens in the patch
         :return: the probability distribution of next token
         """
-        encoded_patch = encoded_patch.reshape(1, 1, -1) # [1, 1, hidden_size]
+        encoded_patch = encoded_patch.reshape(1, 1, -1)  # [1, 1, hidden_size]
         tokens = tokens.reshape(1, -1)
 
         # Get input embeddings
         tokens = torch.nn.functional.embedding(tokens, self.base.transformer.wte.weight)
 
         # Concatenate the encoded patch with the input embeddings
-        tokens = torch.cat((encoded_patch, tokens[:,1:,:]), dim=1)
-        
+        tokens = torch.cat((encoded_patch, tokens[:, 1:, :]), dim=1)
+
         # Get output from model
         outputs = self.base(inputs_embeds=tokens)
-        
+
         # Get probabilities of next token
         probs = torch.nn.functional.softmax(outputs.logits.squeeze(0)[-1], dim=-1)
 
         return probs
+
 
 def safe_normalize_probs(probs):
     epsilon = 1e-12
@@ -344,6 +402,7 @@ def safe_normalize_probs(probs):
         probs[0] = 1.0
     return probs
 
+
 class NotaGenLMHeadModel(PreTrainedModel):
     """
     NotaGen is a language model with a hierarchical structure.
@@ -352,6 +411,7 @@ class NotaGenLMHeadModel(PreTrainedModel):
     The char-level decoder is used to generate the chars within each patch in an auto-regressive manner.
     It inherits PreTrainedModel from transformers.
     """
+
     def __init__(self, encoder_config, decoder_config):
         super().__init__(encoder_config)
         self.special_token_id = 0
@@ -360,9 +420,7 @@ class NotaGenLMHeadModel(PreTrainedModel):
         self.patch_level_decoder = PatchLevelDecoder(encoder_config)
         self.char_level_decoder = CharLevelDecoder(decoder_config)
 
-    def forward(self,
-                patches: torch.Tensor,
-                masks: torch.Tensor):
+    def forward(self, patches: torch.Tensor, masks: torch.Tensor):
         """
         The forward pass of the bGPT model.
         :param patches: the patches to be encoded
@@ -371,20 +429,16 @@ class NotaGenLMHeadModel(PreTrainedModel):
         """
         patches = patches.reshape(len(patches), -1, PATCH_SIZE)
         encoded_patches = self.patch_level_decoder(patches, masks)["last_hidden_state"]
-        
+
         left_shift_masks = masks * (masks.flip(1).cumsum(1).flip(1) > 1)
         masks[:, 0] = 0
-        
+
         encoded_patches = encoded_patches[left_shift_masks == 1]
-        patches = patches[masks == 1]        
+        patches = patches[masks == 1]
 
         return self.char_level_decoder(encoded_patches, patches)
-        
-    def generate(self,
-                 patches: torch.Tensor,
-                 top_k=0,
-                 top_p=1,
-                 temperature=1.0):
+
+    def generate(self, patches: torch.Tensor, top_k=0, top_p=1, temperature=1.0):
         """
         The generate function for generating patches based on patches.
         :param patches: the patches to be encoded
@@ -394,30 +448,41 @@ class NotaGenLMHeadModel(PreTrainedModel):
         :return: the generated patches
         """
         if patches.shape[-1] % PATCH_SIZE != 0:
-            tokens = patches[:,:,-(patches.shape[-1]%PATCH_SIZE):].squeeze(0, 1)
-            tokens = torch.cat((torch.tensor([self.bos_token_id], device=self.device), tokens), dim=-1)
-            patches = patches[:,:,:-(patches.shape[-1]%PATCH_SIZE)]
+            tokens = patches[:, :, -(patches.shape[-1] % PATCH_SIZE) :].squeeze(0, 1)
+            tokens = torch.cat(
+                (torch.tensor([self.bos_token_id], device=self.device), tokens), dim=-1
+            )
+            patches = patches[:, :, : -(patches.shape[-1] % PATCH_SIZE)]
         else:
-            tokens =  torch.tensor([self.bos_token_id], device=self.device)
+            tokens = torch.tensor([self.bos_token_id], device=self.device)
 
-        patches = patches.reshape(len(patches), -1, PATCH_SIZE) # [bs, seq, patch_size]
-        encoded_patches = self.patch_level_decoder(patches)["last_hidden_state"]    # [bs, seq, hidden_size]
-        generated_patch = []            
+        patches = patches.reshape(len(patches), -1, PATCH_SIZE)  # [bs, seq, patch_size]
+        encoded_patches = self.patch_level_decoder(patches)[
+            "last_hidden_state"
+        ]  # [bs, seq, hidden_size]
+        generated_patch = []
 
         while True:
-            prob = self.char_level_decoder.generate(encoded_patches[0][-1], tokens).cpu().detach().numpy()  # [128]
+            prob = (
+                self.char_level_decoder.generate(encoded_patches[0][-1], tokens)
+                .cpu()
+                .detach()
+                .numpy()
+            )  # [128]
             prob = safe_normalize_probs(prob)
-            prob = top_k_sampling(prob, top_k=top_k, return_probs=True) # [128]
+            prob = top_k_sampling(prob, top_k=top_k, return_probs=True)  # [128]
             prob = safe_normalize_probs(prob)
-            prob = top_p_sampling(prob, top_p=top_p, return_probs=True) # [128]
+            prob = top_p_sampling(prob, top_p=top_p, return_probs=True)  # [128]
             prob = safe_normalize_probs(prob)
-            token = temperature_sampling(prob, temperature=temperature) # int
+            token = temperature_sampling(prob, temperature=temperature)  # int
             char = chr(token)
             generated_patch.append(token)
 
-            if len(tokens) >= PATCH_SIZE:# or token == self.eos_token_id:
+            if len(tokens) >= PATCH_SIZE:  # or token == self.eos_token_id:
                 break
             else:
-                tokens = torch.cat((tokens, torch.tensor([token], device=self.device)), dim=0)
-        
+                tokens = torch.cat(
+                    (tokens, torch.tensor([token], device=self.device)), dim=0
+                )
+
         return generated_patch

--- a/gradio/abc2xml.py
+++ b/gradio/abc2xml.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # coding=latin-1
-'''
+"""
 Copyright (C) 2012-2018: Willem G. Vree
 Contributions: Nils Liberg, Nicolas Froment, Norman Schmidt, Reinier Maliepaard, Martin Tarenskeen,
                Paul Villiger, Alexander Scheutzow, Herbert Schneider, David Randolph, Michael Strasser
@@ -11,21 +11,28 @@ Lesser GNU General Public License as published by the Free Software Foundation;
 This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
 without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 See the Lesser GNU General Public License for more details. <http://www.gnu.org/licenses/lgpl.html>.
-'''
+"""
 
 from functools import reduce
-from pyparsing import Word, OneOrMore, Optional, Literal, NotAny, MatchFirst
+from pyparsing import Word, OneOrMore, Optional, Literal, MatchFirst
 from pyparsing import Group, oneOf, Suppress, ZeroOrMore, Combine, FollowedBy
-from pyparsing import srange, CharsNotIn, StringEnd, LineEnd, White, Regex
-from pyparsing import nums, alphas, alphanums, ParseException, Forward
-try:    import xml.etree.cElementTree as E
-except: import xml.etree.ElementTree as E
-import types, sys, os, re, datetime
+from pyparsing import srange, CharsNotIn, StringEnd, Regex
+from pyparsing import nums, alphanums, ParseException, Forward
+
+try:
+    import xml.etree.cElementTree as E
+except:
+    import xml.etree.ElementTree as E
+import types
+import sys
+import os
+import re
+import datetime
 
 VERSION = 245
 
 python3 = sys.version_info[0] > 2
-lmap = lambda f, xs: list (map (f, xs))   # eager map for python 3
+lmap = lambda f, xs: list(map(f, xs))  # eager map for python 3
 if python3:
     int_type = int
     list_type = list
@@ -40,2213 +47,3491 @@ else:
     stdin = sys.stdin
 
 info_list = []  # diagnostic messages
-def info (s, warn=1):
-    x = (warn and '-- ' or '') + s
-    info_list.append (x + '\n')         # collect messages
-    if __name__ == '__main__':          # only write to stdout when called as main progeam
-        try: sys.stderr.write (x + '\n')
-        except: sys.stderr.write (repr (x) + '\n')
 
-def getInfo (): # get string of diagnostic messages, then clear messages
+
+def info(s, warn=1):
+    x = (warn and "-- " or "") + s
+    info_list.append(x + "\n")  # collect messages
+    if __name__ == "__main__":  # only write to stdout when called as main progeam
+        try:
+            sys.stderr.write(x + "\n")
+        except:
+            sys.stderr.write(repr(x) + "\n")
+
+
+def getInfo():  # get string of diagnostic messages, then clear messages
     global info_list
-    xs = ''.join (info_list)
+    xs = "".join(info_list)
     info_list = []
     return xs
 
-def abc_grammar ():     # header, voice and lyrics grammar for ABC
-    #-----------------------------------------------------------------
+
+def abc_grammar():  # header, voice and lyrics grammar for ABC
+    # -----------------------------------------------------------------
     # expressions that catch and skip some syntax errors (see corresponding parse expressions)
-    #-----------------------------------------------------------------
-    b1 = Word (u"-,'<>\u2019#", exact=1)    # catch misplaced chars in chords
-    b2 = Regex ('[^H-Wh-w~=]*')             # same in user defined symbol definition
-    b3 = Regex ('[^=]*')                    # same, second part
+    # -----------------------------------------------------------------
+    b1 = Word("-,'<>\u2019#", exact=1)  # catch misplaced chars in chords
+    b2 = Regex("[^H-Wh-w~=]*")  # same in user defined symbol definition
+    b3 = Regex("[^=]*")  # same, second part
 
-    #-----------------------------------------------------------------
+    # -----------------------------------------------------------------
     # ABC header (field_str elements are matched later with reg. epr's)
-    #-----------------------------------------------------------------
+    # -----------------------------------------------------------------
 
-    number = Word (nums).setParseAction (lambda t: int (t[0]))
-    field_str = Regex (r'[^]]*')  # match anything until end of field
-    field_str.setParseAction (lambda t: t[0].strip ())  # and strip spacing
+    number = Word(nums).setParseAction(lambda t: int(t[0]))
+    field_str = Regex(r"[^]]*")  # match anything until end of field
+    field_str.setParseAction(lambda t: t[0].strip())  # and strip spacing
 
-    userdef_symbol  = Word (srange ('[H-Wh-w~]'), exact=1)
-    fieldId = oneOf ('K L M Q P I T C O A Z N G H R B D F S E r Y') # info fields
-    X_field = Literal ('X') + Suppress (':') + field_str
-    U_field = Literal ('U') + Suppress (':') + b2 + Optional (userdef_symbol, 'H') + b3 + Suppress ('=') + field_str
-    V_field = Literal ('V') + Suppress (':') + Word (alphanums + '_') + field_str
-    inf_fld = fieldId + Suppress (':') + field_str
-    ifield = Suppress ('[') + (X_field | U_field | V_field | inf_fld) + Suppress (']')
-    abc_header = OneOrMore (ifield) + StringEnd ()
+    userdef_symbol = Word(srange("[H-Wh-w~]"), exact=1)
+    fieldId = oneOf("K L M Q P I T C O A Z N G H R B D F S E r Y")  # info fields
+    X_field = Literal("X") + Suppress(":") + field_str
+    U_field = (
+        Literal("U")
+        + Suppress(":")
+        + b2
+        + Optional(userdef_symbol, "H")
+        + b3
+        + Suppress("=")
+        + field_str
+    )
+    V_field = Literal("V") + Suppress(":") + Word(alphanums + "_") + field_str
+    inf_fld = fieldId + Suppress(":") + field_str
+    ifield = Suppress("[") + (X_field | U_field | V_field | inf_fld) + Suppress("]")
+    abc_header = OneOrMore(ifield) + StringEnd()
 
-    #---------------------------------------------------------------------------------
+    # ---------------------------------------------------------------------------------
     # I:score with recursive part groups and {* grand staff marker
-    #---------------------------------------------------------------------------------
+    # ---------------------------------------------------------------------------------
 
-    voiceId = Suppress (Optional ('*')) + Word (alphanums + '_')
-    voice_gr = Suppress ('(') + OneOrMore (voiceId | Suppress ('|')) + Suppress (')')
-    simple_part = voiceId | voice_gr | Suppress ('|')
-    grand_staff = oneOf ('{* {') + OneOrMore (simple_part) + Suppress ('}')
-    part = Forward ()
-    part_seq = OneOrMore (part | Suppress ('|'))
-    brace_gr = Suppress ('{') + part_seq + Suppress ('}')
-    bracket_gr = Suppress ('[') + part_seq + Suppress (']')
-    part <<= MatchFirst (simple_part | grand_staff | brace_gr | bracket_gr | Suppress ('|'))
-    abc_scoredef = Suppress (oneOf ('staves score')) + OneOrMore (part)
+    voiceId = Suppress(Optional("*")) + Word(alphanums + "_")
+    voice_gr = Suppress("(") + OneOrMore(voiceId | Suppress("|")) + Suppress(")")
+    simple_part = voiceId | voice_gr | Suppress("|")
+    grand_staff = oneOf("{* {") + OneOrMore(simple_part) + Suppress("}")
+    part = Forward()
+    part_seq = OneOrMore(part | Suppress("|"))
+    brace_gr = Suppress("{") + part_seq + Suppress("}")
+    bracket_gr = Suppress("[") + part_seq + Suppress("]")
+    part <<= MatchFirst(
+        simple_part | grand_staff | brace_gr | bracket_gr | Suppress("|")
+    )
+    abc_scoredef = Suppress(oneOf("staves score")) + OneOrMore(part)
 
-    #----------------------------------------
+    # ----------------------------------------
     # ABC lyric lines (white space sensitive)
-    #----------------------------------------
+    # ----------------------------------------
 
-    skip_note   = oneOf ('* -')
-    extend_note = Literal ('_')
-    measure_end = Literal ('|')
-    syl_str     = CharsNotIn ('*-_| \t\n\\]')
-    syl_chars   = Combine (OneOrMore (syl_str | Regex (r'\\.')))
-    white       = Word (' \t')
-    syllable    = syl_chars + Optional ('-')
-    lyr_elem    = (syllable | skip_note | extend_note | measure_end) + Optional (white).suppress ()
-    lyr_line    = Optional (white).suppress () + ZeroOrMore (lyr_elem)
-    
-    syllable.setParseAction (lambda t: pObj ('syl', t))
-    skip_note.setParseAction (lambda t: pObj ('skip', t))
-    extend_note.setParseAction (lambda t: pObj ('ext', t))
-    measure_end.setParseAction (lambda t: pObj ('sbar', t))
-    lyr_line_wsp = lyr_line.leaveWhitespace ()   # parse actions must be set before calling leaveWhitespace
+    skip_note = oneOf("* -")
+    extend_note = Literal("_")
+    measure_end = Literal("|")
+    syl_str = CharsNotIn("*-_| \t\n\\]")
+    syl_chars = Combine(OneOrMore(syl_str | Regex(r"\\.")))
+    white = Word(" \t")
+    syllable = syl_chars + Optional("-")
+    lyr_elem = (syllable | skip_note | extend_note | measure_end) + Optional(
+        white
+    ).suppress()
+    lyr_line = Optional(white).suppress() + ZeroOrMore(lyr_elem)
 
-    #---------------------------------------------------------------------------------
+    syllable.setParseAction(lambda t: pObj("syl", t))
+    skip_note.setParseAction(lambda t: pObj("skip", t))
+    extend_note.setParseAction(lambda t: pObj("ext", t))
+    measure_end.setParseAction(lambda t: pObj("sbar", t))
+    lyr_line_wsp = (
+        lyr_line.leaveWhitespace()
+    )  # parse actions must be set before calling leaveWhitespace
+
+    # ---------------------------------------------------------------------------------
     # ABC voice (not white space sensitive, beams detected in note/rest parse actions)
-    #---------------------------------------------------------------------------------
+    # ---------------------------------------------------------------------------------
 
-    inline_field =  Suppress ('[') + (inf_fld | U_field | V_field) + Suppress (']')
-    lyr_fld = Suppress ('[') + Suppress ('w') + Suppress (':') + lyr_line_wsp + Suppress (']')  # lyric line
-    lyr_blk = OneOrMore (lyr_fld)       # verses
-    fld_or_lyr = inline_field | lyr_blk # inline field or block of lyric verses
+    inline_field = Suppress("[") + (inf_fld | U_field | V_field) + Suppress("]")
+    lyr_fld = (
+        Suppress("[") + Suppress("w") + Suppress(":") + lyr_line_wsp + Suppress("]")
+    )  # lyric line
+    lyr_blk = OneOrMore(lyr_fld)  # verses
+    fld_or_lyr = inline_field | lyr_blk  # inline field or block of lyric verses
 
-    note_length = Optional (number, 1) + Group (ZeroOrMore ('/')) + Optional (number, 2)
-    octaveHigh = OneOrMore ("'").setParseAction (lambda t: len(t))
-    octaveLow = OneOrMore (',').setParseAction (lambda t: -len(t))
-    octave  = octaveHigh | octaveLow
+    note_length = Optional(number, 1) + Group(ZeroOrMore("/")) + Optional(number, 2)
+    octaveHigh = OneOrMore("'").setParseAction(lambda t: len(t))
+    octaveLow = OneOrMore(",").setParseAction(lambda t: -len(t))
+    octave = octaveHigh | octaveLow
 
-    basenote = oneOf ('C D E F G A B c d e f g a b y')  # includes spacer for parse efficiency
-    accidental = oneOf ('^^ __ ^ _ =')
-    rest_sym  = oneOf ('x X z Z')
-    slur_beg = oneOf ("( (, (' .( .(, .('") + ~Word (nums)    # no tuplet_start
-    slur_ends = OneOrMore (oneOf (') .)'))
+    basenote = oneOf(
+        "C D E F G A B c d e f g a b y"
+    )  # includes spacer for parse efficiency
+    accidental = oneOf("^^ __ ^ _ =")
+    rest_sym = oneOf("x X z Z")
+    slur_beg = oneOf("( (, (' .( .(, .('") + ~Word(nums)  # no tuplet_start
+    slur_ends = OneOrMore(oneOf(") .)"))
 
-    long_decoration = Combine (oneOf ('! +') + CharsNotIn ('!+ \n') + oneOf ('! +'))
-    staccato        = Literal ('.') + ~Literal ('|')    # avoid dotted barline
-    pizzicato       = Literal ('!+!')   # special case: plus sign is old style deco marker
-    decoration      = slur_beg | staccato | userdef_symbol | long_decoration | pizzicato
-    decorations     = OneOrMore (decoration)
+    long_decoration = Combine(oneOf("! +") + CharsNotIn("!+ \n") + oneOf("! +"))
+    staccato = Literal(".") + ~Literal("|")  # avoid dotted barline
+    pizzicato = Literal("!+!")  # special case: plus sign is old style deco marker
+    decoration = slur_beg | staccato | userdef_symbol | long_decoration | pizzicato
+    decorations = OneOrMore(decoration)
 
-    tie = oneOf ('.- -')
-    rest = Optional (accidental) + rest_sym + note_length
-    pitch = Optional (accidental) + basenote + Optional (octave, 0)
-    note = pitch + note_length + Optional (tie) + Optional (slur_ends)
-    dec_note = Optional (decorations) + pitch + note_length + Optional (tie) + Optional (slur_ends)
+    tie = oneOf(".- -")
+    rest = Optional(accidental) + rest_sym + note_length
+    pitch = Optional(accidental) + basenote + Optional(octave, 0)
+    note = pitch + note_length + Optional(tie) + Optional(slur_ends)
+    dec_note = (
+        Optional(decorations)
+        + pitch
+        + note_length
+        + Optional(tie)
+        + Optional(slur_ends)
+    )
     chord_note = dec_note | rest | b1
-    grace_notes = Forward ()
-    chord = Suppress ('[') + OneOrMore (chord_note | grace_notes) + Suppress (']') + note_length + Optional (tie) + Optional (slur_ends)
+    grace_notes = Forward()
+    chord = (
+        Suppress("[")
+        + OneOrMore(chord_note | grace_notes)
+        + Suppress("]")
+        + note_length
+        + Optional(tie)
+        + Optional(slur_ends)
+    )
     stem = note | chord | rest
 
-    broken = Combine (OneOrMore ('<') | OneOrMore ('>'))
+    broken = Combine(OneOrMore("<") | OneOrMore(">"))
 
-    tuplet_num   = Suppress ('(') + number
-    tuplet_into  = Suppress (':') + Optional (number, 0)
-    tuplet_notes = Suppress (':') + Optional (number, 0)
-    tuplet_start = tuplet_num + Optional (tuplet_into + Optional (tuplet_notes))
+    tuplet_num = Suppress("(") + number
+    tuplet_into = Suppress(":") + Optional(number, 0)
+    tuplet_notes = Suppress(":") + Optional(number, 0)
+    tuplet_start = tuplet_num + Optional(tuplet_into + Optional(tuplet_notes))
 
-    acciaccatura    = Literal ('/')
-    grace_stem      = Optional (decorations) + stem
-    grace_notes     <<= Group (Suppress ('{') + Optional (acciaccatura) + OneOrMore (grace_stem) + Suppress ('}'))
+    acciaccatura = Literal("/")
+    grace_stem = Optional(decorations) + stem
+    grace_notes <<= Group(
+        Suppress("{") + Optional(acciaccatura) + OneOrMore(grace_stem) + Suppress("}")
+    )
 
-    text_expression  = Optional (oneOf ('^ _ < > @'), '^') + Optional (CharsNotIn ('"'), "")
-    chord_accidental = oneOf ('# b =')
-    triad            = oneOf ('ma Maj maj M mi min m aug dim o + -')
-    seventh          = oneOf ('7 ma7 Maj7 M7 maj7 mi7 min7 m7 dim7 o7 -7 aug7 +7 m7b5 mi7b5')
-    sixth            = oneOf ('6 ma6 M6 mi6 min6 m6')
-    ninth            = oneOf ('9 ma9 M9 maj9 Maj9 mi9 min9 m9')
-    elevn            = oneOf ('11 ma11 M11 maj11 Maj11 mi11 min11 m11')
-    thirt            = oneOf ('13 ma13 M13 maj13 Maj13 mi13 min13 m13')
-    suspended        = oneOf ('sus sus2 sus4')
-    chord_degree     = Combine (Optional (chord_accidental) + oneOf ('2 4 5 6 7 9 11 13'))
-    chord_kind       = Optional (seventh | sixth | ninth | elevn | thirt | triad) + Optional (suspended)
-    chord_root       = oneOf ('C D E F G A B') + Optional (chord_accidental)
-    chord_bass       = oneOf ('C D E F G A B') + Optional (chord_accidental) # needs a different parse action
-    chordsym         = chord_root + chord_kind + ZeroOrMore (chord_degree) + Optional (Suppress ('/') + chord_bass)
-    chord_sym        = chordsym + Optional (Literal ('(') + CharsNotIn (')') + Literal (')')).suppress ()
-    chord_or_text    = Suppress ('"') + (chord_sym ^ text_expression) + Suppress ('"')
+    text_expression = Optional(oneOf("^ _ < > @"), "^") + Optional(CharsNotIn('"'), "")
+    chord_accidental = oneOf("# b =")
+    triad = oneOf("ma Maj maj M mi min m aug dim o + -")
+    seventh = oneOf("7 ma7 Maj7 M7 maj7 mi7 min7 m7 dim7 o7 -7 aug7 +7 m7b5 mi7b5")
+    sixth = oneOf("6 ma6 M6 mi6 min6 m6")
+    ninth = oneOf("9 ma9 M9 maj9 Maj9 mi9 min9 m9")
+    elevn = oneOf("11 ma11 M11 maj11 Maj11 mi11 min11 m11")
+    thirt = oneOf("13 ma13 M13 maj13 Maj13 mi13 min13 m13")
+    suspended = oneOf("sus sus2 sus4")
+    chord_degree = Combine(Optional(chord_accidental) + oneOf("2 4 5 6 7 9 11 13"))
+    chord_kind = Optional(seventh | sixth | ninth | elevn | thirt | triad) + Optional(
+        suspended
+    )
+    chord_root = oneOf("C D E F G A B") + Optional(chord_accidental)
+    chord_bass = oneOf("C D E F G A B") + Optional(
+        chord_accidental
+    )  # needs a different parse action
+    chordsym = (
+        chord_root
+        + chord_kind
+        + ZeroOrMore(chord_degree)
+        + Optional(Suppress("/") + chord_bass)
+    )
+    chord_sym = (
+        chordsym + Optional(Literal("(") + CharsNotIn(")") + Literal(")")).suppress()
+    )
+    chord_or_text = Suppress('"') + (chord_sym ^ text_expression) + Suppress('"')
 
-    volta_nums = Optional ('[').suppress () + Combine (Word (nums) + ZeroOrMore (oneOf (', -') + Word (nums)))
-    volta_text = Literal ('[').suppress () + Regex (r'"[^"]+"')
+    volta_nums = Optional("[").suppress() + Combine(
+        Word(nums) + ZeroOrMore(oneOf(", -") + Word(nums))
+    )
+    volta_text = Literal("[").suppress() + Regex(r'"[^"]+"')
     volta = volta_nums | volta_text
-    invisible_barline = oneOf ('[|] []')
-    dashed_barline = oneOf (': .|')
-    double_rep = Literal (':') + FollowedBy (':')   # otherwise ambiguity with dashed barline
-    voice_overlay = Combine (OneOrMore ('&'))
-    bare_volta = FollowedBy (Literal ('[') + Word (nums))   # no barline, but volta follows (volta is parsed in next measure)
-    bar_left = (oneOf ('[|: |: [: :') + Optional (volta)) | Optional ('|').suppress () + volta | oneOf ('| [|')
-    bars = ZeroOrMore (':') + ZeroOrMore ('[') + OneOrMore (oneOf ('| ]'))
-    bar_right = invisible_barline | double_rep | Combine (bars) | dashed_barline | voice_overlay | bare_volta
-    
-    errors =  ~bar_right + Optional (Word (' \n')) + CharsNotIn (':&|', exact=1)
-    linebreak = Literal ('$') | ~decorations + Literal ('!')    # no need for I:linebreak !!!
-    element = fld_or_lyr | broken | decorations | stem | chord_or_text | grace_notes | tuplet_start | linebreak | errors
-    measure      = Group (ZeroOrMore (inline_field) + Optional (bar_left) + ZeroOrMore (element) + bar_right + Optional (linebreak) + Optional (lyr_blk))
-    noBarMeasure = Group (ZeroOrMore (inline_field) + Optional (bar_left) + OneOrMore (element) + Optional (linebreak) + Optional (lyr_blk))
-    abc_voice = ZeroOrMore (measure) + Optional (noBarMeasure | Group (bar_left)) + ZeroOrMore (inline_field).suppress () + StringEnd ()
+    invisible_barline = oneOf("[|] []")
+    dashed_barline = oneOf(": .|")
+    double_rep = Literal(":") + FollowedBy(
+        ":"
+    )  # otherwise ambiguity with dashed barline
+    voice_overlay = Combine(OneOrMore("&"))
+    bare_volta = FollowedBy(
+        Literal("[") + Word(nums)
+    )  # no barline, but volta follows (volta is parsed in next measure)
+    bar_left = (
+        (oneOf("[|: |: [: :") + Optional(volta))
+        | Optional("|").suppress() + volta
+        | oneOf("| [|")
+    )
+    bars = ZeroOrMore(":") + ZeroOrMore("[") + OneOrMore(oneOf("| ]"))
+    bar_right = (
+        invisible_barline
+        | double_rep
+        | Combine(bars)
+        | dashed_barline
+        | voice_overlay
+        | bare_volta
+    )
 
-    #----------------------------------------
+    errors = ~bar_right + Optional(Word(" \n")) + CharsNotIn(":&|", exact=1)
+    linebreak = Literal("$") | ~decorations + Literal(
+        "!"
+    )  # no need for I:linebreak !!!
+    element = (
+        fld_or_lyr
+        | broken
+        | decorations
+        | stem
+        | chord_or_text
+        | grace_notes
+        | tuplet_start
+        | linebreak
+        | errors
+    )
+    measure = Group(
+        ZeroOrMore(inline_field)
+        + Optional(bar_left)
+        + ZeroOrMore(element)
+        + bar_right
+        + Optional(linebreak)
+        + Optional(lyr_blk)
+    )
+    noBarMeasure = Group(
+        ZeroOrMore(inline_field)
+        + Optional(bar_left)
+        + OneOrMore(element)
+        + Optional(linebreak)
+        + Optional(lyr_blk)
+    )
+    abc_voice = (
+        ZeroOrMore(measure)
+        + Optional(noBarMeasure | Group(bar_left))
+        + ZeroOrMore(inline_field).suppress()
+        + StringEnd()
+    )
+
+    # ----------------------------------------
     # I:percmap note [step] [midi] [note-head]
-    #----------------------------------------
+    # ----------------------------------------
 
-    white2 = (white | StringEnd ()).suppress ()
-    w3 = Optional (white2)
-    percid = Word (alphanums + '-')
-    step = basenote + Optional (octave, 0)
-    pitchg = Group (Optional (accidental, '') + step + FollowedBy (white2))
-    stepg = Group (step + FollowedBy (white2)) | Literal ('*')
-    midi = (Literal ('*') | number | pitchg | percid)
-    nhd = Optional (Combine (percid + Optional ('+')), '')
-    perc_wsp = Literal ('percmap') + w3 + pitchg + w3 + Optional (stepg, '*') + w3 + Optional (midi, '*') + w3 + nhd
-    abc_percmap = perc_wsp.leaveWhitespace ()
+    white2 = (white | StringEnd()).suppress()
+    w3 = Optional(white2)
+    percid = Word(alphanums + "-")
+    step = basenote + Optional(octave, 0)
+    pitchg = Group(Optional(accidental, "") + step + FollowedBy(white2))
+    stepg = Group(step + FollowedBy(white2)) | Literal("*")
+    midi = Literal("*") | number | pitchg | percid
+    nhd = Optional(Combine(percid + Optional("+")), "")
+    perc_wsp = (
+        Literal("percmap")
+        + w3
+        + pitchg
+        + w3
+        + Optional(stepg, "*")
+        + w3
+        + Optional(midi, "*")
+        + w3
+        + nhd
+    )
+    abc_percmap = perc_wsp.leaveWhitespace()
 
-    #----------------------------------------------------------------
+    # ----------------------------------------------------------------
     # Parse actions to convert all relevant results into an abstract
     # syntax tree where all tree nodes are instances of pObj
-    #----------------------------------------------------------------
+    # ----------------------------------------------------------------
 
-    ifield.setParseAction (lambda t: pObj ('field', t))
-    grand_staff.setParseAction (lambda t: pObj ('grand', t, 1)) # 1 = keep ordered list of results
-    brace_gr.setParseAction (lambda t: pObj ('bracegr', t, 1))
-    bracket_gr.setParseAction (lambda t: pObj ('bracketgr', t, 1))
-    voice_gr.setParseAction (lambda t: pObj ('voicegr', t, 1))
-    voiceId.setParseAction (lambda t: pObj ('vid', t, 1))
-    abc_scoredef.setParseAction (lambda t: pObj ('score', t, 1))
-    note_length.setParseAction (lambda t: pObj ('dur', (t[0], (t[2] << len (t[1])) >> 1)))
-    chordsym.setParseAction (lambda t: pObj ('chordsym', t))
-    chord_root.setParseAction (lambda t: pObj ('root', t))
-    chord_kind.setParseAction (lambda t: pObj ('kind', t))
-    chord_degree.setParseAction (lambda t: pObj ('degree', t))
-    chord_bass.setParseAction (lambda t: pObj ('bass', t))
-    text_expression.setParseAction (lambda t: pObj ('text', t))
-    inline_field.setParseAction (lambda t: pObj ('inline', t))
-    lyr_fld.setParseAction (lambda t: pObj ('lyr_fld', t, 1))
-    lyr_blk.setParseAction (lambda t: pObj ('lyr_blk', t, 1)) # 1 = keep ordered list of lyric lines
-    grace_notes.setParseAction (doGrace)
-    acciaccatura.setParseAction (lambda t: pObj ('accia', t))
-    note.setParseAction (noteActn)
-    rest.setParseAction (restActn)
-    decorations.setParseAction (lambda t: pObj ('deco', t))
-    pizzicato.setParseAction (lambda t: ['!plus!']) # translate !+!
-    slur_ends.setParseAction (lambda t: pObj ('slurs', t))
-    chord.setParseAction (lambda t: pObj ('chord', t, 1))
-    dec_note.setParseAction (noteActn)
-    tie.setParseAction (lambda t: pObj ('tie', t))
-    pitch.setParseAction (lambda t: pObj ('pitch', t))
-    bare_volta.setParseAction (lambda t: ['|']) # return barline that user forgot
-    dashed_barline.setParseAction (lambda t: ['.|'])
-    bar_right.setParseAction (lambda t: pObj ('rbar', t))
-    bar_left.setParseAction (lambda t: pObj ('lbar', t))
-    broken.setParseAction (lambda t: pObj ('broken', t))
-    tuplet_start.setParseAction (lambda t: pObj ('tup', t))
-    linebreak.setParseAction (lambda t: pObj ('linebrk', t))
-    measure.setParseAction (doMaat)
-    noBarMeasure.setParseAction (doMaat)
-    b1.setParseAction (errorWarn)
-    b2.setParseAction (errorWarn)
-    b3.setParseAction (errorWarn)
-    errors.setParseAction (errorWarn)
+    ifield.setParseAction(lambda t: pObj("field", t))
+    grand_staff.setParseAction(
+        lambda t: pObj("grand", t, 1)
+    )  # 1 = keep ordered list of results
+    brace_gr.setParseAction(lambda t: pObj("bracegr", t, 1))
+    bracket_gr.setParseAction(lambda t: pObj("bracketgr", t, 1))
+    voice_gr.setParseAction(lambda t: pObj("voicegr", t, 1))
+    voiceId.setParseAction(lambda t: pObj("vid", t, 1))
+    abc_scoredef.setParseAction(lambda t: pObj("score", t, 1))
+    note_length.setParseAction(lambda t: pObj("dur", (t[0], (t[2] << len(t[1])) >> 1)))
+    chordsym.setParseAction(lambda t: pObj("chordsym", t))
+    chord_root.setParseAction(lambda t: pObj("root", t))
+    chord_kind.setParseAction(lambda t: pObj("kind", t))
+    chord_degree.setParseAction(lambda t: pObj("degree", t))
+    chord_bass.setParseAction(lambda t: pObj("bass", t))
+    text_expression.setParseAction(lambda t: pObj("text", t))
+    inline_field.setParseAction(lambda t: pObj("inline", t))
+    lyr_fld.setParseAction(lambda t: pObj("lyr_fld", t, 1))
+    lyr_blk.setParseAction(
+        lambda t: pObj("lyr_blk", t, 1)
+    )  # 1 = keep ordered list of lyric lines
+    grace_notes.setParseAction(doGrace)
+    acciaccatura.setParseAction(lambda t: pObj("accia", t))
+    note.setParseAction(noteActn)
+    rest.setParseAction(restActn)
+    decorations.setParseAction(lambda t: pObj("deco", t))
+    pizzicato.setParseAction(lambda t: ["!plus!"])  # translate !+!
+    slur_ends.setParseAction(lambda t: pObj("slurs", t))
+    chord.setParseAction(lambda t: pObj("chord", t, 1))
+    dec_note.setParseAction(noteActn)
+    tie.setParseAction(lambda t: pObj("tie", t))
+    pitch.setParseAction(lambda t: pObj("pitch", t))
+    bare_volta.setParseAction(lambda t: ["|"])  # return barline that user forgot
+    dashed_barline.setParseAction(lambda t: [".|"])
+    bar_right.setParseAction(lambda t: pObj("rbar", t))
+    bar_left.setParseAction(lambda t: pObj("lbar", t))
+    broken.setParseAction(lambda t: pObj("broken", t))
+    tuplet_start.setParseAction(lambda t: pObj("tup", t))
+    linebreak.setParseAction(lambda t: pObj("linebrk", t))
+    measure.setParseAction(doMaat)
+    noBarMeasure.setParseAction(doMaat)
+    b1.setParseAction(errorWarn)
+    b2.setParseAction(errorWarn)
+    b3.setParseAction(errorWarn)
+    errors.setParseAction(errorWarn)
 
     return abc_header, abc_voice, abc_scoredef, abc_percmap
 
-class pObj (object):    # every relevant parse result is converted into a pObj
-    def __init__ (s, name, t, seq=0):   # t = list of nested parse results
-        s.name = name   # name uniqueliy identifies this pObj
-        rest = []       # collect parse results that are not a pObj
-        attrs = {}      # new attributes
-        for x in t:     # nested pObj's become attributes of this pObj
-            if type (x) == pObj:
-                attrs [x.name] = attrs.get (x.name, []) + [x]
-            else:
-                rest.append (x)             # collect non-pObj's (mostly literals)
-        for name, xs in attrs.items ():
-            if len (xs) == 1: xs = xs[0]    # only list if more then one pObj
-            setattr (s, name, xs)           # create the new attributes
-        s.t = rest      # all nested non-pObj's (mostly literals)
-        s.objs = seq and t or []            # for nested ordered (lyric) pObj's
 
-    def __repr__ (s):   # make a nice string representation of a pObj
+class pObj(object):  # every relevant parse result is converted into a pObj
+    def __init__(s, name, t, seq=0):  # t = list of nested parse results
+        s.name = name  # name uniqueliy identifies this pObj
+        rest = []  # collect parse results that are not a pObj
+        attrs = {}  # new attributes
+        for x in t:  # nested pObj's become attributes of this pObj
+            if type(x) == pObj:
+                attrs[x.name] = attrs.get(x.name, []) + [x]
+            else:
+                rest.append(x)  # collect non-pObj's (mostly literals)
+        for name, xs in attrs.items():
+            if len(xs) == 1:
+                xs = xs[0]  # only list if more then one pObj
+            setattr(s, name, xs)  # create the new attributes
+        s.t = rest  # all nested non-pObj's (mostly literals)
+        s.objs = seq and t or []  # for nested ordered (lyric) pObj's
+
+    def __repr__(s):  # make a nice string representation of a pObj
         r = []
-        for nm in dir (s):
-            if nm.startswith ('_'): continue # skip build in attributes
-            elif nm == 'name': continue     # redundant
+        for nm in dir(s):
+            if nm.startswith("_"):
+                continue  # skip build in attributes
+            elif nm == "name":
+                continue  # redundant
             else:
-                x = getattr (s, nm)
-                if not x: continue          # s.t may be empty (list of non-pObj's)
-                if type (x) == list_type:  r.extend (x)
-                else:                           r.append (x)
+                x = getattr(s, nm)
+                if not x:
+                    continue  # s.t may be empty (list of non-pObj's)
+                if type(x) == list_type:
+                    r.extend(x)
+                else:
+                    r.append(x)
         xs = []
-        for x in r:     # recursively call __repr__ and convert all strings to latin-1
-            if isinstance (x, str_type): xs.append (x)          # string -> no recursion
-            else:                        xs.append (repr (x))   # pObj -> recursive call
-        return '(' + s.name + ' ' +','.join (xs) + ')'
+        for x in r:  # recursively call __repr__ and convert all strings to latin-1
+            if isinstance(x, str_type):
+                xs.append(x)  # string -> no recursion
+            else:
+                xs.append(repr(x))  # pObj -> recursive call
+        return "(" + s.name + " " + ",".join(xs) + ")"
 
-global prevloc                  # global to remember previous match position of a note/rest
+
+global prevloc  # global to remember previous match position of a note/rest
 prevloc = 0
-def detectBeamBreak (line, loc, t):
-    global prevloc              # location in string 'line' of previous note match
-    xs = line[prevloc:loc+1]    # string between previous and current note match
-    xs = xs.lstrip ()           # first note match starts on a space!
-    prevloc = loc               # location in string 'line' of current note match
-    b = pObj ('bbrk', [' ' in xs])      # space somewhere between two notes -> beambreak
-    t.insert (0, b)             # insert beambreak as a nested parse result
 
-def noteActn (line, loc, t):    # detect beambreak between previous and current note/rest
-    if 'y' in t[0].t: return [] # discard spacer
-    detectBeamBreak (line, loc, t)      # adds beambreak to parse result t as side effect
-    return pObj ('note', t)
 
-def restActn (line, loc, t):    # detect beambreak between previous and current note/rest
-    detectBeamBreak (line, loc, t)  # adds beambreak to parse result t as side effect
-    return pObj ('rest', t)
+def detectBeamBreak(line, loc, t):
+    global prevloc  # location in string 'line' of previous note match
+    xs = line[prevloc : loc + 1]  # string between previous and current note match
+    xs = xs.lstrip()  # first note match starts on a space!
+    prevloc = loc  # location in string 'line' of current note match
+    b = pObj("bbrk", [" " in xs])  # space somewhere between two notes -> beambreak
+    t.insert(0, b)  # insert beambreak as a nested parse result
 
-def errorWarn (line, loc, t):   # warning for misplaced symbols and skip them
-    if not t[0]: return []      # only warn if catched string not empty
-    info ('**misplaced symbol: %s' % t[0], warn=0)
-    lineCopy = line [:]
+
+def noteActn(line, loc, t):  # detect beambreak between previous and current note/rest
+    if "y" in t[0].t:
+        return []  # discard spacer
+    detectBeamBreak(line, loc, t)  # adds beambreak to parse result t as side effect
+    return pObj("note", t)
+
+
+def restActn(line, loc, t):  # detect beambreak between previous and current note/rest
+    detectBeamBreak(line, loc, t)  # adds beambreak to parse result t as side effect
+    return pObj("rest", t)
+
+
+def errorWarn(line, loc, t):  # warning for misplaced symbols and skip them
+    if not t[0]:
+        return []  # only warn if catched string not empty
+    info("**misplaced symbol: %s" % t[0], warn=0)
+    lineCopy = line[:]
     if loc > 40:
-        lineCopy = line [loc - 40: loc + 40]
+        lineCopy = line[loc - 40 : loc + 40]
         loc = 40
-    info (lineCopy.replace ('\n', ' '), warn=0)
-    info (loc * '-' + '^', warn=0)
+    info(lineCopy.replace("\n", " "), warn=0)
+    info(loc * "-" + "^", warn=0)
     return []
 
-#-------------------------------------------------------------
-# transformations of a measure (called by parse action doMaat)
-#-------------------------------------------------------------
 
-def simplify (a, b):    # divide a and b by their greatest common divisor
+# -------------------------------------------------------------
+# transformations of a measure (called by parse action doMaat)
+# -------------------------------------------------------------
+
+
+def simplify(a, b):  # divide a and b by their greatest common divisor
     x, y = a, b
-    while b: a, b = b, a % b
+    while b:
+        a, b = b, a % b
     return x // a, y // a
 
-def doBroken (prev, brk, x):
-    if not prev: info ('error in broken rhythm: %s' % x); return    # no changes
-    nom1, den1 = prev.dur.t # duration of first note/chord
-    nom2, den2 = x.dur.t    # duration of second note/chord
-    if  brk == '>':
-        nom1, den1  = simplify (3 * nom1, 2 * den1)
-        nom2, den2  = simplify (1 * nom2, 2 * den2)
-    elif brk == '<':
-        nom1, den1  = simplify (1 * nom1, 2 * den1)
-        nom2, den2  = simplify (3 * nom2, 2 * den2)
-    elif brk == '>>':
-        nom1, den1  = simplify (7 * nom1, 4 * den1)
-        nom2, den2  = simplify (1 * nom2, 4 * den2)
-    elif brk == '<<':
-        nom1, den1  = simplify (1 * nom1, 4 * den1)
-        nom2, den2  = simplify (7 * nom2, 4 * den2)
-    else: return            # give up
-    prev.dur.t = nom1, den1 # change duration of previous note/chord
-    x.dur.t = nom2, den2    # and current note/chord
 
-def convertBroken (t):  # convert broken rhythms to normal note durations
-    prev = None # the last note/chord before the broken symbol
-    brk = ''    # the broken symbol
-    remove = [] # indexes to broken symbols (to be deleted) in measure
-    for i, x in enumerate (t):  # scan all elements in measure
-        if x.name == 'note' or x.name == 'chord' or x.name == 'rest':
-            if brk:                 # a broken symbol was encountered before
-                doBroken (prev, brk, x) # change duration previous note/chord/rest and current one
-                brk = ''
+def doBroken(prev, brk, x):
+    if not prev:
+        info("error in broken rhythm: %s" % x)
+        return  # no changes
+    nom1, den1 = prev.dur.t  # duration of first note/chord
+    nom2, den2 = x.dur.t  # duration of second note/chord
+    if brk == ">":
+        nom1, den1 = simplify(3 * nom1, 2 * den1)
+        nom2, den2 = simplify(1 * nom2, 2 * den2)
+    elif brk == "<":
+        nom1, den1 = simplify(1 * nom1, 2 * den1)
+        nom2, den2 = simplify(3 * nom2, 2 * den2)
+    elif brk == ">>":
+        nom1, den1 = simplify(7 * nom1, 4 * den1)
+        nom2, den2 = simplify(1 * nom2, 4 * den2)
+    elif brk == "<<":
+        nom1, den1 = simplify(1 * nom1, 4 * den1)
+        nom2, den2 = simplify(7 * nom2, 4 * den2)
+    else:
+        return  # give up
+    prev.dur.t = nom1, den1  # change duration of previous note/chord
+    x.dur.t = nom2, den2  # and current note/chord
+
+
+def convertBroken(t):  # convert broken rhythms to normal note durations
+    prev = None  # the last note/chord before the broken symbol
+    brk = ""  # the broken symbol
+    remove = []  # indexes to broken symbols (to be deleted) in measure
+    for i, x in enumerate(t):  # scan all elements in measure
+        if x.name == "note" or x.name == "chord" or x.name == "rest":
+            if brk:  # a broken symbol was encountered before
+                doBroken(
+                    prev, brk, x
+                )  # change duration previous note/chord/rest and current one
+                brk = ""
             else:
-                prev = x            # remember the last note/chord/rest
-        elif x.name == 'broken':
-            brk = x.t[0]            # remember the broken symbol (=string)
-            remove.insert (0, i)    # and its index, highest index first
-    for i in remove: del t[i]       # delete broken symbols from high to low
+                prev = x  # remember the last note/chord/rest
+        elif x.name == "broken":
+            brk = x.t[0]  # remember the broken symbol (=string)
+            remove.insert(0, i)  # and its index, highest index first
+    for i in remove:
+        del t[i]  # delete broken symbols from high to low
 
-def ptc2midi (n):       # convert parsed pitch attribute to a midi number
-    pt = getattr (n, 'pitch', '')
+
+def ptc2midi(n):  # convert parsed pitch attribute to a midi number
+    pt = getattr(n, "pitch", "")
     if pt:
         p = pt.t
-        if len (p) == 3: acc, step, oct = p
-        else:       acc = ''; step, oct = p
-        nUp = step.upper ()
-        oct = (4 if nUp == step else 5) + int (oct)
-        midi = oct * 12 + [0,2,4,5,7,9,11]['CDEFGAB'.index (nUp)] + {'^':1,'_':-1}.get (acc, 0) + 12
-    else: midi = 130    # all non pitch objects first
+        if len(p) == 3:
+            acc, step, oct = p
+        else:
+            acc = ""
+            step, oct = p
+        nUp = step.upper()
+        oct = (4 if nUp == step else 5) + int(oct)
+        midi = (
+            oct * 12
+            + [0, 2, 4, 5, 7, 9, 11]["CDEFGAB".index(nUp)]
+            + {"^": 1, "_": -1}.get(acc, 0)
+            + 12
+        )
+    else:
+        midi = 130  # all non pitch objects first
     return midi
 
-def convertChord (t):   # convert chord to sequence of notes in musicXml-style
+
+def convertChord(t):  # convert chord to sequence of notes in musicXml-style
     ins = []
-    for i, x in enumerate (t):
-        if x.name == 'chord':
-            if hasattr (x, 'rest') and not hasattr (x, 'note'): # chords containing only rests
-                if type (x.rest) == list_type: x.rest = x.rest[0] # more rests == one rest
-                ins.insert (0, (i, [x.rest]))   # just output a single rest, no chord
+    for i, x in enumerate(t):
+        if x.name == "chord":
+            if hasattr(x, "rest") and not hasattr(
+                x, "note"
+            ):  # chords containing only rests
+                if type(x.rest) == list_type:
+                    x.rest = x.rest[0]  # more rests == one rest
+                ins.insert(0, (i, [x.rest]))  # just output a single rest, no chord
                 continue
-            num1, den1 = x.dur.t                # chord duration
-            tie = getattr (x, 'tie', None)      # chord tie
-            slurs = getattr (x, 'slurs', [])    # slur endings
-            if type (x.note) != list_type: x.note = [x.note]    # when chord has only one note ...
-            elms = []; j = 0                    # sort chord notes, highest first
-            nss = sorted (x.objs, key = ptc2midi, reverse=1) if mxm.orderChords else x.objs
-            for nt in nss:   # all chord elements (note | decorations | rest | grace note)
-                if nt.name == 'note':
-                    num2, den2 = nt.dur.t           # note duration * chord duration
-                    nt.dur.t = simplify (num1 * num2, den1 * den2)
-                    if tie: nt.tie = tie            # tie on all chord notes
-                    if j == 0 and slurs: nt.slurs = slurs   # slur endings only on first chord note
-                    if j > 0: nt.chord = pObj ('chord', [1]) # label all but first as chord notes
-                    else:                           # remember all pitches of the chord in the first note
-                        pitches = [n.pitch for n in x.note] # to implement conversion of erroneous ties to slurs
-                        nt.pitches = pObj ('pitches', pitches)
+            num1, den1 = x.dur.t  # chord duration
+            tie = getattr(x, "tie", None)  # chord tie
+            slurs = getattr(x, "slurs", [])  # slur endings
+            if type(x.note) != list_type:
+                x.note = [x.note]  # when chord has only one note ...
+            elms = []
+            j = 0  # sort chord notes, highest first
+            nss = sorted(x.objs, key=ptc2midi, reverse=1) if mxm.orderChords else x.objs
+            for (
+                nt
+            ) in nss:  # all chord elements (note | decorations | rest | grace note)
+                if nt.name == "note":
+                    num2, den2 = nt.dur.t  # note duration * chord duration
+                    nt.dur.t = simplify(num1 * num2, den1 * den2)
+                    if tie:
+                        nt.tie = tie  # tie on all chord notes
+                    if j == 0 and slurs:
+                        nt.slurs = slurs  # slur endings only on first chord note
+                    if j > 0:
+                        nt.chord = pObj(
+                            "chord", [1]
+                        )  # label all but first as chord notes
+                    else:  # remember all pitches of the chord in the first note
+                        pitches = [
+                            n.pitch for n in x.note
+                        ]  # to implement conversion of erroneous ties to slurs
+                        nt.pitches = pObj("pitches", pitches)
                     j += 1
-                if nt.name not in ['dur','tie','slurs','rest']: elms.append (nt)
-            ins.insert (0, (i, elms))           # chord position, [note|decotation|grace note]
-    for i, notes in ins:                        # insert from high to low
-        for nt in reversed (notes):
-            t.insert (i+1, nt)                  # insert chord notes after chord
-        del t[i]                                # remove chord itself
+                if nt.name not in ["dur", "tie", "slurs", "rest"]:
+                    elms.append(nt)
+            ins.insert(0, (i, elms))  # chord position, [note|decotation|grace note]
+    for i, notes in ins:  # insert from high to low
+        for nt in reversed(notes):
+            t.insert(i + 1, nt)  # insert chord notes after chord
+        del t[i]  # remove chord itself
 
-def doMaat (t):             # t is a Group() result -> the measure is in t[0]
-    convertBroken (t[0])    # remove all broken rhythms and convert to normal durations
-    convertChord (t[0])     # replace chords by note sequences in musicXML style
 
-def doGrace (t):        # t is a Group() result -> the grace sequence is in t[0]
-    convertChord (t[0]) # a grace sequence may have chords
-    for nt in t[0]:     # flag all notes within the grace sequence
-        if nt.name == 'note': nt.grace = 1 # set grace attribute
-    return t[0]         # ungroup the parse result
-#--------------------
+def doMaat(t):  # t is a Group() result -> the measure is in t[0]
+    convertBroken(t[0])  # remove all broken rhythms and convert to normal durations
+    convertChord(t[0])  # replace chords by note sequences in musicXML style
+
+
+def doGrace(t):  # t is a Group() result -> the grace sequence is in t[0]
+    convertChord(t[0])  # a grace sequence may have chords
+    for nt in t[0]:  # flag all notes within the grace sequence
+        if nt.name == "note":
+            nt.grace = 1  # set grace attribute
+    return t[0]  # ungroup the parse result
+
+
+# --------------------
 # musicXML generation
-#----------------------------------
+# ----------------------------------
 
-def compChordTab ():    # avoid some typing work: returns mapping constant {ABC chordsyms -> musicXML kind}
-    maj, min, aug, dim, dom, ch7, ch6, ch9, ch11, ch13, hd = 'major minor augmented diminished dominant -seventh -sixth -ninth -11th -13th half-diminished'.split ()
-    triad   = zip ('ma Maj maj M mi min m aug dim o + -'.split (), [maj, maj, maj, maj, min, min, min, aug, dim, dim, aug, min])
-    seventh = zip ('7 ma7 Maj7 M7 maj7 mi7 min7 m7 dim7 o7 -7 aug7 +7 m7b5 mi7b5'.split (),
-                   [dom, maj+ch7, maj+ch7, maj+ch7, maj+ch7, min+ch7, min+ch7, min+ch7, dim+ch7, dim+ch7, min+ch7, aug+ch7, aug+ch7, hd, hd])
-    sixth   = zip ('6 ma6 M6 mi6 min6 m6'.split (), [maj+ch6, maj+ch6, maj+ch6, min+ch6, min+ch6, min+ch6])
-    ninth   = zip ('9 ma9 M9 maj9 Maj9 mi9 min9 m9'.split (), [dom+ch9, maj+ch9, maj+ch9, maj+ch9, maj+ch9, min+ch9, min+ch9, min+ch9])
-    elevn   = zip ('11 ma11 M11 maj11 Maj11 mi11 min11 m11'.split (), [dom+ch11, maj+ch11, maj+ch11, maj+ch11, maj+ch11, min+ch11, min+ch11, min+ch11])
-    thirt   = zip ('13 ma13 M13 maj13 Maj13 mi13 min13 m13'.split (), [dom+ch13, maj+ch13, maj+ch13, maj+ch13, maj+ch13, min+ch13, min+ch13, min+ch13])
-    sus     = zip ('sus sus4 sus2'.split (), ['suspended-fourth', 'suspended-fourth', 'suspended-second'])
-    return dict (list (triad) + list (seventh) + list (sixth) + list (ninth) + list (elevn) + list (thirt) + list (sus))
 
-def addElem (parent, child, level):
+def compChordTab():  # avoid some typing work: returns mapping constant {ABC chordsyms -> musicXML kind}
+    maj, min, aug, dim, dom, ch7, ch6, ch9, ch11, ch13, hd = (
+        "major minor augmented diminished dominant -seventh -sixth -ninth -11th -13th half-diminished".split()
+    )
+    triad = zip(
+        "ma Maj maj M mi min m aug dim o + -".split(),
+        [maj, maj, maj, maj, min, min, min, aug, dim, dim, aug, min],
+    )
+    seventh = zip(
+        "7 ma7 Maj7 M7 maj7 mi7 min7 m7 dim7 o7 -7 aug7 +7 m7b5 mi7b5".split(),
+        [
+            dom,
+            maj + ch7,
+            maj + ch7,
+            maj + ch7,
+            maj + ch7,
+            min + ch7,
+            min + ch7,
+            min + ch7,
+            dim + ch7,
+            dim + ch7,
+            min + ch7,
+            aug + ch7,
+            aug + ch7,
+            hd,
+            hd,
+        ],
+    )
+    sixth = zip(
+        "6 ma6 M6 mi6 min6 m6".split(),
+        [maj + ch6, maj + ch6, maj + ch6, min + ch6, min + ch6, min + ch6],
+    )
+    ninth = zip(
+        "9 ma9 M9 maj9 Maj9 mi9 min9 m9".split(),
+        [
+            dom + ch9,
+            maj + ch9,
+            maj + ch9,
+            maj + ch9,
+            maj + ch9,
+            min + ch9,
+            min + ch9,
+            min + ch9,
+        ],
+    )
+    elevn = zip(
+        "11 ma11 M11 maj11 Maj11 mi11 min11 m11".split(),
+        [
+            dom + ch11,
+            maj + ch11,
+            maj + ch11,
+            maj + ch11,
+            maj + ch11,
+            min + ch11,
+            min + ch11,
+            min + ch11,
+        ],
+    )
+    thirt = zip(
+        "13 ma13 M13 maj13 Maj13 mi13 min13 m13".split(),
+        [
+            dom + ch13,
+            maj + ch13,
+            maj + ch13,
+            maj + ch13,
+            maj + ch13,
+            min + ch13,
+            min + ch13,
+            min + ch13,
+        ],
+    )
+    sus = zip(
+        "sus sus4 sus2".split(),
+        ["suspended-fourth", "suspended-fourth", "suspended-second"],
+    )
+    return dict(
+        list(triad)
+        + list(seventh)
+        + list(sixth)
+        + list(ninth)
+        + list(elevn)
+        + list(thirt)
+        + list(sus)
+    )
+
+
+def addElem(parent, child, level):
     indent = 2
-    chldrn = list (parent)
+    chldrn = list(parent)
     if chldrn:
-        chldrn[-1].tail += indent * ' '
+        chldrn[-1].tail += indent * " "
     else:
-        parent.text = '\n' + level * indent * ' '
-    parent.append (child)
-    child.tail = '\n' + (level-1) * indent * ' '
+        parent.text = "\n" + level * indent * " "
+    parent.append(child)
+    child.tail = "\n" + (level - 1) * indent * " "
 
-def addElemT (parent, tag, text, level):
-    e = E.Element (tag)
+
+def addElemT(parent, tag, text, level):
+    e = E.Element(tag)
     e.text = text
-    addElem (parent, e, level)
+    addElem(parent, e, level)
     return e
-    
-def mkTmod (tmnum, tmden, lev):
-    tmod = E.Element ('time-modification')
-    addElemT (tmod, 'actual-notes', str (tmnum), lev + 1)
-    addElemT (tmod, 'normal-notes', str (tmden), lev + 1)
+
+
+def mkTmod(tmnum, tmden, lev):
+    tmod = E.Element("time-modification")
+    addElemT(tmod, "actual-notes", str(tmnum), lev + 1)
+    addElemT(tmod, "normal-notes", str(tmden), lev + 1)
     return tmod
 
-def addDirection (parent, elems, lev, gstaff, subelms=[], placement='below', cue_on=0):
-    dir = E.Element ('direction', placement=placement)
-    addElem (parent, dir, lev)
-    if type (elems) != list_type: elems = [(elems, subelms)]    # ugly hack to provide for multiple direction types
-    for elem, subelms in elems: # add direction types
-        typ = E.Element ('direction-type')
-        addElem (dir, typ, lev + 1)
-        addElem (typ, elem, lev + 2)
-        for subel in subelms: addElem (elem, subel, lev + 3)
-    if cue_on: addElem (dir, E.Element ('level', size='cue'), lev + 1)
-    if gstaff: addElemT (dir, 'staff', str (gstaff), lev + 1)
+
+def addDirection(parent, elems, lev, gstaff, subelms=[], placement="below", cue_on=0):
+    dir = E.Element("direction", placement=placement)
+    addElem(parent, dir, lev)
+    if type(elems) != list_type:
+        elems = [(elems, subelms)]  # ugly hack to provide for multiple direction types
+    for elem, subelms in elems:  # add direction types
+        typ = E.Element("direction-type")
+        addElem(dir, typ, lev + 1)
+        addElem(typ, elem, lev + 2)
+        for subel in subelms:
+            addElem(elem, subel, lev + 3)
+    if cue_on:
+        addElem(dir, E.Element("level", size="cue"), lev + 1)
+    if gstaff:
+        addElemT(dir, "staff", str(gstaff), lev + 1)
     return dir
 
-def removeElems (root_elem, parent_str, elem_str):
-    for p in root_elem.findall (parent_str):
-        e = p.find (elem_str)
-        if e != None: p.remove (e)
 
-def alignLyr (vce, lyrs):
-    empty_el = pObj ('leeg', '*')
-    for k, lyr in enumerate (lyrs): # lyr = one full line of lyrics
-        i = 0               # syl counter
-        for elem in vce:    # reiterate the voice block for each lyrics line
-            if elem.name == 'note' and not (hasattr (elem, 'chord') or hasattr (elem, 'grace')):
-                if i >= len (lyr): lr = empty_el
-                else: lr = lyr [i]
-                lr.t[0] = lr.t[0].replace ('%5d',']')
-                elem.objs.append (lr)
-                if lr.name != 'sbar': i += 1
-            if elem.name == 'rbar' and i < len (lyr) and lyr[i].name == 'sbar': i += 1
+def removeElems(root_elem, parent_str, elem_str):
+    for p in root_elem.findall(parent_str):
+        e = p.find(elem_str)
+        if e != None:
+            p.remove(e)
+
+
+def alignLyr(vce, lyrs):
+    empty_el = pObj("leeg", "*")
+    for k, lyr in enumerate(lyrs):  # lyr = one full line of lyrics
+        i = 0  # syl counter
+        for elem in vce:  # reiterate the voice block for each lyrics line
+            if elem.name == "note" and not (
+                hasattr(elem, "chord") or hasattr(elem, "grace")
+            ):
+                if i >= len(lyr):
+                    lr = empty_el
+                else:
+                    lr = lyr[i]
+                lr.t[0] = lr.t[0].replace("%5d", "]")
+                elem.objs.append(lr)
+                if lr.name != "sbar":
+                    i += 1
+            if elem.name == "rbar" and i < len(lyr) and lyr[i].name == "sbar":
+                i += 1
     return vce
 
-slur_move = re.compile (r'(?<![!+])([}><][<>]?)(\)+)')  # (?<!...) means: not preceeded by ...
-mm_rest = re.compile (r'([XZ])(\d+)')
-bar_space = re.compile (r'([:|][ |\[\]]+[:|])')         # barlines with spaces
-def fixSlurs (x):   # repair slurs when after broken sign or grace-close
-    def f (mo):     # replace a multi-measure rest by single measure rests
-        n = int (mo.group (2))
-        return (n * (mo.group (1) + '|')) [:-1]
-    def g (mo):     # squash spaces in barline expressions
-        return mo.group (1).replace (' ','')
-    x = mm_rest.sub (f, x)
-    x = bar_space.sub (g, x)
-    return slur_move.sub (r'\2\1', x)
 
-def splitHeaderVoices (abctext):
-    escField = lambda x: '[' + x.replace (']',r'%5d') + ']' # hope nobody uses %5d in a field
-    r1 = re.compile (r'%.*$')           # comments
-    r2 = re.compile (r'^([A-Zw]:.*$)|\[[A-Zw]:[^]]*]$')     # information field, including lyrics
-    r3 = re.compile (r'^%%(?=[^%])')    # directive: ^%% folowed by not a %
-    xs, nx, mcont, fcont = [], 0, 0, 0  # result lines, X-encountered, music continuation, field continuation
-    mln = fln = ''                      # music line, field line
-    for x in abctext.splitlines ():
-        x = x.strip ()
-        if not x and nx == 1: break     # end of tune (empty line)
-        if x.startswith ('X:'):
-            if nx == 1: break           # second tune starts without an empty line !!
-            nx = 1                      # start first tune
-        x = r3.sub ('I:', x)            # replace %% -> I:
-        x2 = r1.sub ('', x)             # remove comment
-        while x2.endswith ('*') and not (x2.startswith ('w:') or x2.startswith ('+:') or 'percmap' in x2):
-            x2 = x2[:-1]                # remove old syntax for right adjusting
-        if not x2: continue             # empty line
-        if x2[:2] == 'W:':
-            field = x2 [2:].strip ()
-            ftype = mxm.metaMap.get ('W', 'W')  # respect the (user defined --meta) mapping of various ABC fields to XML meta data types
-            c = mxm.metadata.get (ftype, '')
-            mxm.metadata [ftype] = c + '\n' + field if c else field   # concatenate multiple info fields with new line as separator
-            continue                    # skip W: lyrics
-        if x2[:2] == '+:':              # field continuation
+slur_move = re.compile(
+    r"(?<![!+])([}><][<>]?)(\)+)"
+)  # (?<!...) means: not preceeded by ...
+mm_rest = re.compile(r"([XZ])(\d+)")
+bar_space = re.compile(r"([:|][ |\[\]]+[:|])")  # barlines with spaces
+
+
+def fixSlurs(x):  # repair slurs when after broken sign or grace-close
+    def f(mo):  # replace a multi-measure rest by single measure rests
+        n = int(mo.group(2))
+        return (n * (mo.group(1) + "|"))[:-1]
+
+    def g(mo):  # squash spaces in barline expressions
+        return mo.group(1).replace(" ", "")
+
+    x = mm_rest.sub(f, x)
+    x = bar_space.sub(g, x)
+    return slur_move.sub(r"\2\1", x)
+
+
+def splitHeaderVoices(abctext):
+    escField = (
+        lambda x: "[" + x.replace("]", r"%5d") + "]"
+    )  # hope nobody uses %5d in a field
+    r1 = re.compile(r"%.*$")  # comments
+    r2 = re.compile(
+        r"^([A-Zw]:.*$)|\[[A-Zw]:[^]]*]$"
+    )  # information field, including lyrics
+    r3 = re.compile(r"^%%(?=[^%])")  # directive: ^%% folowed by not a %
+    xs, nx, mcont, fcont = (
+        [],
+        0,
+        0,
+        0,
+    )  # result lines, X-encountered, music continuation, field continuation
+    mln = fln = ""  # music line, field line
+    for x in abctext.splitlines():
+        x = x.strip()
+        if not x and nx == 1:
+            break  # end of tune (empty line)
+        if x.startswith("X:"):
+            if nx == 1:
+                break  # second tune starts without an empty line !!
+            nx = 1  # start first tune
+        x = r3.sub("I:", x)  # replace %% -> I:
+        x2 = r1.sub("", x)  # remove comment
+        while x2.endswith("*") and not (
+            x2.startswith("w:") or x2.startswith("+:") or "percmap" in x2
+        ):
+            x2 = x2[:-1]  # remove old syntax for right adjusting
+        if not x2:
+            continue  # empty line
+        if x2[:2] == "W:":
+            field = x2[2:].strip()
+            ftype = mxm.metaMap.get(
+                "W", "W"
+            )  # respect the (user defined --meta) mapping of various ABC fields to XML meta data types
+            c = mxm.metadata.get(ftype, "")
+            mxm.metadata[ftype] = (
+                c + "\n" + field if c else field
+            )  # concatenate multiple info fields with new line as separator
+            continue  # skip W: lyrics
+        if x2[:2] == "+:":  # field continuation
             fln += x2[2:]
             continue
-        ro = r2.match (x2)              # single field on a line
-        if ro:                          # field -> inline_field, escape all ']'
-            if fcont:                   # old style \-info-continuation active
-                fcont = x2 [-1] == '\\' # possible further \-info-continuation
-                fln += re.sub (r'^.:(.*?)\\*$', r'\1', x2) # add continuation, remove .: and \
+        ro = r2.match(x2)  # single field on a line
+        if ro:  # field -> inline_field, escape all ']'
+            if fcont:  # old style \-info-continuation active
+                fcont = x2[-1] == "\\"  # possible further \-info-continuation
+                fln += re.sub(
+                    r"^.:(.*?)\\*$", r"\1", x2
+                )  # add continuation, remove .: and \
                 continue
-            if fln: mln += escField (fln)
-            if x2.startswith ('['): x2 = x2.strip ('[]')
-            fcont = x2 [-1] == '\\'     # first encounter of old style \-info-continuation
-            fln = x2.rstrip ('\\')      # remove continuation from field and inline brackets
-            continue
-        if nx == 1:                     # x2 is a new music line
-            fcont = 0                   # stop \-continuations (-> only adjacent \-info-continuations are joined)
             if fln:
-                mln +=  escField (fln)
-                fln = ''
+                mln += escField(fln)
+            if x2.startswith("["):
+                x2 = x2.strip("[]")
+            fcont = x2[-1] == "\\"  # first encounter of old style \-info-continuation
+            fln = x2.rstrip("\\")  # remove continuation from field and inline brackets
+            continue
+        if nx == 1:  # x2 is a new music line
+            fcont = 0  # stop \-continuations (-> only adjacent \-info-continuations are joined)
+            if fln:
+                mln += escField(fln)
+                fln = ""
             if mcont:
-                mcont = x2 [-1] == '\\' 
-                mln += x2.rstrip ('\\')
+                mcont = x2[-1] == "\\"
+                mln += x2.rstrip("\\")
             else:
-                if mln: xs.append (mln); mln = ''
-                mcont = x2 [-1] == '\\'
-                mln = x2.rstrip ('\\')
-            if not mcont: xs.append (mln); mln = ''
-    if fln: mln += escField (fln)
-    if mln: xs.append (mln)
+                if mln:
+                    xs.append(mln)
+                    mln = ""
+                mcont = x2[-1] == "\\"
+                mln = x2.rstrip("\\")
+            if not mcont:
+                xs.append(mln)
+                mln = ""
+    if fln:
+        mln += escField(fln)
+    if mln:
+        xs.append(mln)
 
-    hs = re.split (r'(\[K:[^]]*\])', xs [0])   # look for end of header K:
-    if len (hs) == 1: header = hs[0]; xs [0] = ''               # no K: present
-    else: header = hs [0] + hs [1]; xs [0] = ''.join (hs[2:])   # h[1] is the first K:
-    abctext = '\n'.join (xs)                    # the rest is body text
-    hfs, vfs = [], []
-    for x in header[1:-1].split (']['):
-        if x[0] == 'V': vfs.append (x)          # filter voice- and midi-definitions
-        elif x[:6] == 'I:MIDI': vfs.append (x)  # from the header to vfs
-        elif x[:9] == 'I:percmap': vfs.append (x)  # and also percmap
-        else: hfs.append (x)                    # all other fields stay in header
-    header = '[' + ']['.join (hfs) + ']'        # restore the header
-    abctext = ('[' + ']['.join (vfs) + ']' if vfs else '') + abctext    # prepend voice/midi from header before abctext
-
-    xs = abctext.split ('[V:')
-    if len (xs) == 1: abctext = '[V:1]' + abctext # abc has no voice defs at all
-    elif re.sub (r'\[[A-Z]:[^]]*\]', '', xs[0]).strip ():   # remove inline fields from starting text, if any
-        abctext = '[V:1]' + abctext     # abc with voices has no V: at start
-
-    r1 = re.compile (r'\[V:\s*(\S*)[ \]]') # get voice id from V: field (skip spaces betwee V: and ID)
-    vmap = {}                           # {voice id -> [voice abc string]}
-    vorder = {}                         # mark document order of voices
-    xs = re.split (r'(\[V:[^]]*\])', abctext)   # split on every V-field (V-fields included in split result list)
-    if len (xs) == 1: raise ValueError ('bugs ...')
+    hs = re.split(r"(\[K:[^]]*\])", xs[0])  # look for end of header K:
+    if len(hs) == 1:
+        header = hs[0]
+        xs[0] = ""  # no K: present
     else:
-        pm = re.findall (r'\[P:.\]', xs[0])         # all P:-marks after K: but before first V:
-        if pm: xs[2] = ''.join (pm) + xs[2]         # prepend P:-marks to the text of the first voice
-        header += re.sub (r'\[P:.\]', '', xs[0])    # clear all P:-marks from text between K: and first V: and put text in the header
+        header = hs[0] + hs[1]
+        xs[0] = "".join(hs[2:])  # h[1] is the first K:
+    abctext = "\n".join(xs)  # the rest is body text
+    hfs, vfs = [], []
+    for x in header[1:-1].split("]["):
+        if x[0] == "V":
+            vfs.append(x)  # filter voice- and midi-definitions
+        elif x[:6] == "I:MIDI":
+            vfs.append(x)  # from the header to vfs
+        elif x[:9] == "I:percmap":
+            vfs.append(x)  # and also percmap
+        else:
+            hfs.append(x)  # all other fields stay in header
+    header = "[" + "][".join(hfs) + "]"  # restore the header
+    abctext = (
+        "[" + "][".join(vfs) + "]" if vfs else ""
+    ) + abctext  # prepend voice/midi from header before abctext
+
+    xs = abctext.split("[V:")
+    if len(xs) == 1:
+        abctext = "[V:1]" + abctext  # abc has no voice defs at all
+    elif re.sub(
+        r"\[[A-Z]:[^]]*\]", "", xs[0]
+    ).strip():  # remove inline fields from starting text, if any
+        abctext = "[V:1]" + abctext  # abc with voices has no V: at start
+
+    r1 = re.compile(
+        r"\[V:\s*(\S*)[ \]]"
+    )  # get voice id from V: field (skip spaces betwee V: and ID)
+    vmap = {}  # {voice id -> [voice abc string]}
+    vorder = {}  # mark document order of voices
+    xs = re.split(
+        r"(\[V:[^]]*\])", abctext
+    )  # split on every V-field (V-fields included in split result list)
+    if len(xs) == 1:
+        raise ValueError("bugs ...")
+    else:
+        pm = re.findall(r"\[P:.\]", xs[0])  # all P:-marks after K: but before first V:
+        if pm:
+            xs[2] = (
+                "".join(pm) + xs[2]
+            )  # prepend P:-marks to the text of the first voice
+        header += re.sub(
+            r"\[P:.\]", "", xs[0]
+        )  # clear all P:-marks from text between K: and first V: and put text in the header
         i = 1
-        while i < len (xs):             # xs = ['', V-field, voice abc, V-field, voice abc, ...]
-            vce, abc = xs[i:i+2]
-            id = r1.search (vce).group (1)                  # get voice ID from V-field
-            if not id: id, vce = '1', '[V:1]'               # voice def has no ID
-            vmap[id] = vmap.get (id, []) + [vce, abc]       # collect abc-text for each voice id (include V-fields)
-            if id not in vorder: vorder [id] = i            # store document order of first occurrence of voice id
+        while i < len(xs):  # xs = ['', V-field, voice abc, V-field, voice abc, ...]
+            vce, abc = xs[i : i + 2]
+            id = r1.search(vce).group(1)  # get voice ID from V-field
+            if not id:
+                id, vce = "1", "[V:1]"  # voice def has no ID
+            vmap[id] = vmap.get(id, []) + [
+                vce,
+                abc,
+            ]  # collect abc-text for each voice id (include V-fields)
+            if id not in vorder:
+                vorder[id] = i  # store document order of first occurrence of voice id
             i += 2
     voices = []
-    ixs = sorted ([(i, id) for id, i in vorder.items ()])   # restore document order of voices
+    ixs = sorted(
+        [(i, id) for id, i in vorder.items()]
+    )  # restore document order of voices
     for i, id in ixs:
-        voice = ''.join (vmap [id])     # all abc of one voice
-        voice = fixSlurs (voice)        # put slurs right after the notes
-        voices.append ((id, voice))
+        voice = "".join(vmap[id])  # all abc of one voice
+        voice = fixSlurs(voice)  # put slurs right after the notes
+        voices.append((id, voice))
     return header, voices
 
-def mergeMeasure (m1, m2, slur_offset, voice_offset, rOpt, is_grand=0, is_overlay=0):
-    slurs = m2.findall ('note/notations/slur')
+
+def mergeMeasure(m1, m2, slur_offset, voice_offset, rOpt, is_grand=0, is_overlay=0):
+    slurs = m2.findall("note/notations/slur")
     for slr in slurs:
-        slrnum = int (slr.get ('number')) + slur_offset 
-        slr.set ('number', str (slrnum))    # make unique slurnums in m2
-    vs = m2.findall ('note/voice')          # set all voice number elements in m2
-    for v in vs: v.text  = str (voice_offset + int (v.text))
-    ls = m1.findall ('note/lyric')          # all lyric elements in m1
-    lnum_max = max ([int (l.get ('number')) for l in ls] + [0]) # highest lyric number in m1
-    ls = m2.findall ('note/lyric')          # update lyric elements in m2
+        slrnum = int(slr.get("number")) + slur_offset
+        slr.set("number", str(slrnum))  # make unique slurnums in m2
+    vs = m2.findall("note/voice")  # set all voice number elements in m2
+    for v in vs:
+        v.text = str(voice_offset + int(v.text))
+    ls = m1.findall("note/lyric")  # all lyric elements in m1
+    lnum_max = max(
+        [int(l.get("number")) for l in ls] + [0]
+    )  # highest lyric number in m1
+    ls = m2.findall("note/lyric")  # update lyric elements in m2
     for el in ls:
-        n = int (el.get ('number'))
-        el.set ('number', str (n + lnum_max))
-    ns = m1.findall ('note')    # determine the total duration of m1, subtract all backups
-    dur1 = sum (int (n.find ('duration').text) for n in ns
-                if n.find ('grace') == None and n.find ('chord') == None)
-    dur1 -= sum (int (b.text) for b in m1.findall ('backup/duration'))
+        n = int(el.get("number"))
+        el.set("number", str(n + lnum_max))
+    ns = m1.findall("note")  # determine the total duration of m1, subtract all backups
+    dur1 = sum(
+        int(n.find("duration").text)
+        for n in ns
+        if n.find("grace") == None and n.find("chord") == None
+    )
+    dur1 -= sum(int(b.text) for b in m1.findall("backup/duration"))
     repbar, nns, es = 0, 0, []  # nns = number of real notes in m2
-    for e in list (m2): # scan all elements of m2
-        if e.tag == 'attributes':
-            if not is_grand: continue # no attribute merging for normal voices
-            else: nns += 1      # but we do merge (clef) attributes for a grand staff
-        if e.tag == 'print': continue
-        if e.tag == 'note' and (rOpt or e.find ('rest') == None): nns += 1
-        if e.tag == 'barline' and e.find ('repeat') != None: repbar = e;
-        es.append (e)           # buffer elements to be merged
-    if nns > 0:                 # only merge if m2 contains any real notes
-        if dur1 > 0:            # only insert backup if duration of m1 > 0
-            b = E.Element ('backup')
-            addElem (m1, b, level=3)
-            addElemT (b, 'duration', str (dur1), level=4)
-        for e in es: addElem (m1, e, level=3)   # merge buffered elements of m2
-    elif is_overlay and repbar: addElem (m1, repbar, level=3)   # merge repeat in empty overlay
+    for e in list(m2):  # scan all elements of m2
+        if e.tag == "attributes":
+            if not is_grand:
+                continue  # no attribute merging for normal voices
+            else:
+                nns += 1  # but we do merge (clef) attributes for a grand staff
+        if e.tag == "print":
+            continue
+        if e.tag == "note" and (rOpt or e.find("rest") == None):
+            nns += 1
+        if e.tag == "barline" and e.find("repeat") != None:
+            repbar = e
+        es.append(e)  # buffer elements to be merged
+    if nns > 0:  # only merge if m2 contains any real notes
+        if dur1 > 0:  # only insert backup if duration of m1 > 0
+            b = E.Element("backup")
+            addElem(m1, b, level=3)
+            addElemT(b, "duration", str(dur1), level=4)
+        for e in es:
+            addElem(m1, e, level=3)  # merge buffered elements of m2
+    elif is_overlay and repbar:
+        addElem(m1, repbar, level=3)  # merge repeat in empty overlay
 
-def mergePartList (parts, rOpt, is_grand=0):    # merge parts, make grand staff when is_grand true
 
-    def delAttrs (part):                # for the time being we only keep clef attributes
-        xs = [(m, e) for m in part.findall ('measure') for e in m.findall ('attributes')]
+def mergePartList(
+    parts, rOpt, is_grand=0
+):  # merge parts, make grand staff when is_grand true
+
+    def delAttrs(part):  # for the time being we only keep clef attributes
+        xs = [(m, e) for m in part.findall("measure") for e in m.findall("attributes")]
         for m, e in xs:
-            for c in list (e):
-                if c.tag == 'clef': continue    # keep clef attribute
-                if c.tag == 'staff-details': continue    # keep staff-details attribute
-                e.remove (c)                    # delete all other attrinutes for higher staff numbers
-            if len (list (e)) == 0: m.remove (e)    # remove empty attributes element
+            for c in list(e):
+                if c.tag == "clef":
+                    continue  # keep clef attribute
+                if c.tag == "staff-details":
+                    continue  # keep staff-details attribute
+                e.remove(c)  # delete all other attrinutes for higher staff numbers
+            if len(list(e)) == 0:
+                m.remove(e)  # remove empty attributes element
 
     p1 = parts[0]
     for p2 in parts[1:]:
-        if is_grand: delAttrs (p2)                          # delete all attributes except clef
-        for i in range (len (p1) + 1, len (p2) + 1):        # second part longer than first one
-            maat = E.Element ('measure', number = str(i))   # append empty measures
-            addElem (p1, maat, 2)
-        slurs = p1.findall ('measure/note/notations/slur')  # find highest slur num in first part
-        slur_max = max ([int (slr.get ('number')) for slr in slurs] + [0])
-        vs = p1.findall ('measure/note/voice')              # all voice number elements in first part
-        vnum_max = max ([int (v.text) for v in vs] + [0])   # highest voice number in first part
-        for im, m2 in enumerate (p2.findall ('measure')):   # merge all measures of p2 into p1
-            mergeMeasure (p1[im], m2, slur_max, vnum_max, rOpt, is_grand) # may change slur numbers in p1
+        if is_grand:
+            delAttrs(p2)  # delete all attributes except clef
+        for i in range(len(p1) + 1, len(p2) + 1):  # second part longer than first one
+            maat = E.Element("measure", number=str(i))  # append empty measures
+            addElem(p1, maat, 2)
+        slurs = p1.findall(
+            "measure/note/notations/slur"
+        )  # find highest slur num in first part
+        slur_max = max([int(slr.get("number")) for slr in slurs] + [0])
+        vs = p1.findall("measure/note/voice")  # all voice number elements in first part
+        vnum_max = max(
+            [int(v.text) for v in vs] + [0]
+        )  # highest voice number in first part
+        for im, m2 in enumerate(
+            p2.findall("measure")
+        ):  # merge all measures of p2 into p1
+            mergeMeasure(
+                p1[im], m2, slur_max, vnum_max, rOpt, is_grand
+            )  # may change slur numbers in p1
     return p1
 
-def mergeParts (parts, vids, staves, rOpt, is_grand=0):
-    if not staves: return parts, vids   # no voice mapping
+
+def mergeParts(parts, vids, staves, rOpt, is_grand=0):
+    if not staves:
+        return parts, vids  # no voice mapping
     partsnew, vidsnew = [], []
     for voice_ids in staves:
         pixs = []
         for vid in voice_ids:
-            if vid in vids: pixs.append (vids.index (vid))
-            else: info ('score partname %s does not exist' % vid)
+            if vid in vids:
+                pixs.append(vids.index(vid))
+            else:
+                info("score partname %s does not exist" % vid)
         if pixs:
             xparts = [parts[pix] for pix in pixs]
-            if len (xparts) > 1: mergedpart = mergePartList (xparts, rOpt, is_grand)
-            else:                mergedpart = xparts [0]
-            partsnew.append (mergedpart)
-            vidsnew.append (vids [pixs[0]])
+            if len(xparts) > 1:
+                mergedpart = mergePartList(xparts, rOpt, is_grand)
+            else:
+                mergedpart = xparts[0]
+            partsnew.append(mergedpart)
+            vidsnew.append(vids[pixs[0]])
     return partsnew, vidsnew
 
-def mergePartMeasure (part, msre, ovrlaynum, rOpt): # merge msre into last measure of part, only for overlays
-    slur_offset = 0;    # slur numbers determined by the slurstack size (as in a single voice)
-    last_msre = list (part)[-1] # last measure in part
-    mergeMeasure (last_msre, msre, slur_offset, ovrlaynum, rOpt, is_overlay=1) # voice offset = s.overlayVNum
 
-def pushSlur (boogStapel, stem):
-    if stem not in boogStapel: boogStapel [stem] = [] # initialize slurstack for stem
-    boognum = sum (map (len, boogStapel.values ())) + 1  # number of open slurs in all (overlay) voices
-    boogStapel [stem].append (boognum)
+def mergePartMeasure(
+    part, msre, ovrlaynum, rOpt
+):  # merge msre into last measure of part, only for overlays
+    slur_offset = (
+        0  # slur numbers determined by the slurstack size (as in a single voice)
+    )
+    last_msre = list(part)[-1]  # last measure in part
+    mergeMeasure(
+        last_msre, msre, slur_offset, ovrlaynum, rOpt, is_overlay=1
+    )  # voice offset = s.overlayVNum
+
+
+def pushSlur(boogStapel, stem):
+    if stem not in boogStapel:
+        boogStapel[stem] = []  # initialize slurstack for stem
+    boognum = (
+        sum(map(len, boogStapel.values())) + 1
+    )  # number of open slurs in all (overlay) voices
+    boogStapel[stem].append(boognum)
     return boognum
 
-def setFristVoiceNameFromGroup (vids, vdefs): # vids = [vid], vdef = {vid -> (name, subname, voicedef)}
+
+def setFristVoiceNameFromGroup(
+    vids, vdefs
+):  # vids = [vid], vdef = {vid -> (name, subname, voicedef)}
     vids = [v for v in vids if v in vdefs]  # only consider defined voices
-    if not vids: return vdefs
-    vid0 = vids [0]                         # first vid of the group
-    _, _, vdef0 = vdefs [vid0]              # keep de voice definition (vdef0) when renaming vid0
+    if not vids:
+        return vdefs
+    vid0 = vids[0]  # first vid of the group
+    _, _, vdef0 = vdefs[vid0]  # keep de voice definition (vdef0) when renaming vid0
     for vid in vids:
-        nm, snm, vdef = vdefs [vid]
-        if nm:                              # first non empty name encountered will become
-            vdefs [vid0] = nm, snm, vdef0   # name of merged group == name of first voice in group (vid0)
+        nm, snm, vdef = vdefs[vid]
+        if nm:  # first non empty name encountered will become
+            vdefs[vid0] = (
+                nm,
+                snm,
+                vdef0,
+            )  # name of merged group == name of first voice in group (vid0)
             break
     return vdefs
 
-def mkGrand (p, vdefs):             # transform parse subtree into list needed for s.grands
+
+def mkGrand(p, vdefs):  # transform parse subtree into list needed for s.grands
     xs = []
-    for i, x in enumerate (p.objs): # changing p.objs [i] alters the tree. changing x has no effect on the tree.
-        if type (x) == pObj:
-            us = mkGrand (x, vdefs) # first get transformation results of current pObj
-            if x.name == 'grand':   # x.objs contains ordered list of nested parse results within x
-                vids = [y.objs[0] for y in x.objs[1:]]  # the voice ids in the grand staff
-                nms = [vdefs [u][0] for u in vids if u in vdefs] # the names of those voices
-                accept = sum ([1 for nm in nms if nm]) == 1 # accept as grand staff when only one of the voices has a name
-                if accept or us[0] == '{*':
-                    xs.append (us[1:])      # append voice ids as a list (discard first item '{' or '{*')
-                    vdefs = setFristVoiceNameFromGroup (vids, vdefs)
-                    p.objs [i] = x.objs[1]  # replace voices by first one in the grand group (this modifies the parse tree)
+    for i, x in enumerate(
+        p.objs
+    ):  # changing p.objs [i] alters the tree. changing x has no effect on the tree.
+        if type(x) == pObj:
+            us = mkGrand(x, vdefs)  # first get transformation results of current pObj
+            if (
+                x.name == "grand"
+            ):  # x.objs contains ordered list of nested parse results within x
+                vids = [
+                    y.objs[0] for y in x.objs[1:]
+                ]  # the voice ids in the grand staff
+                nms = [
+                    vdefs[u][0] for u in vids if u in vdefs
+                ]  # the names of those voices
+                accept = (
+                    sum([1 for nm in nms if nm]) == 1
+                )  # accept as grand staff when only one of the voices has a name
+                if accept or us[0] == "{*":
+                    xs.append(
+                        us[1:]
+                    )  # append voice ids as a list (discard first item '{' or '{*')
+                    vdefs = setFristVoiceNameFromGroup(vids, vdefs)
+                    p.objs[i] = x.objs[
+                        1
+                    ]  # replace voices by first one in the grand group (this modifies the parse tree)
                 else:
-                    xs.extend (us[1:])      # extend current result with all voice ids of rejected grand staff
-            else: xs.extend (us)    # extend current result with transformed pObj
-        else: xs.append (p.t[0])    # append the non pObj (== voice id string)
-    return xs
-
-def mkStaves (p, vdefs):            # transform parse tree into list needed for s.staves
-    xs = []
-    for i, x in enumerate (p.objs): # structure and comments identical to mkGrand
-        if type (x) == pObj:
-            us = mkStaves (x, vdefs)
-            if x.name == 'voicegr':
-                xs.append (us)
-                vids = [y.objs[0] for y in x.objs]
-                vdefs = setFristVoiceNameFromGroup (vids, vdefs)
-                p.objs [i] = x.objs[0]
+                    xs.extend(
+                        us[1:]
+                    )  # extend current result with all voice ids of rejected grand staff
             else:
-                xs.extend (us)
+                xs.extend(us)  # extend current result with transformed pObj
         else:
-            if p.t[0] not in '{*':  xs.append (p.t[0])
+            xs.append(p.t[0])  # append the non pObj (== voice id string)
     return xs
 
-def mkGroups (p):                   # transform parse tree into list needed for s.groups
+
+def mkStaves(p, vdefs):  # transform parse tree into list needed for s.staves
+    xs = []
+    for i, x in enumerate(p.objs):  # structure and comments identical to mkGrand
+        if type(x) == pObj:
+            us = mkStaves(x, vdefs)
+            if x.name == "voicegr":
+                xs.append(us)
+                vids = [y.objs[0] for y in x.objs]
+                vdefs = setFristVoiceNameFromGroup(vids, vdefs)
+                p.objs[i] = x.objs[0]
+            else:
+                xs.extend(us)
+        else:
+            if p.t[0] not in "{*":
+                xs.append(p.t[0])
+    return xs
+
+
+def mkGroups(p):  # transform parse tree into list needed for s.groups
     xs = []
     for x in p.objs:
-        if type (x) == pObj:
-            if x.name == 'vid': xs.extend (mkGroups (x))
-            elif x.name == 'bracketgr': xs.extend (['['] + mkGroups (x) + [']'])
-            elif x.name == 'bracegr':   xs.extend (['{'] + mkGroups (x) + ['}'])
-            else: xs.extend (mkGroups (x) + ['}'])  # x.name == 'grand' == rejected grand staff
+        if type(x) == pObj:
+            if x.name == "vid":
+                xs.extend(mkGroups(x))
+            elif x.name == "bracketgr":
+                xs.extend(["["] + mkGroups(x) + ["]"])
+            elif x.name == "bracegr":
+                xs.extend(["{"] + mkGroups(x) + ["}"])
+            else:
+                xs.extend(
+                    mkGroups(x) + ["}"]
+                )  # x.name == 'grand' == rejected grand staff
         else:
-            xs.append (p.t[0])
+            xs.append(p.t[0])
     return xs
 
-def stepTrans (step, soct, clef):   # [A-G] (1...8)
-    if clef.startswith ('bass'):
-        nm7 = 'C,D,E,F,G,A,B'.split (',')
-        n = 14 + nm7.index (step) - 12  # two octaves extra to avoid negative numbers
-        step, soct = nm7 [n % 7], soct + n // 7 - 2  # subtract two octaves again
+
+def stepTrans(step, soct, clef):  # [A-G] (1...8)
+    if clef.startswith("bass"):
+        nm7 = "C,D,E,F,G,A,B".split(",")
+        n = 14 + nm7.index(step) - 12  # two octaves extra to avoid negative numbers
+        step, soct = nm7[n % 7], soct + n // 7 - 2  # subtract two octaves again
     return step, soct
 
-def reduceMids (parts, vidsnew, midiInst):       # remove redundant instruments from a part
-    for pid, part in zip (vidsnew, parts):
+
+def reduceMids(parts, vidsnew, midiInst):  # remove redundant instruments from a part
+    for pid, part in zip(vidsnew, parts):
         mids, repls, has_perc = {}, {}, 0
-        for ipid, ivid, ch, prg, vol, pan in sorted (list (midiInst.values ())):
-            if ipid != pid: continue                # only instruments from part pid
-            if ch == '10': has_perc = 1; continue   # only consider non percussion instruments
-            instId, inst = 'I%s-%s' % (ipid, ivid), (ch, prg)
-            if inst in mids:                        # midi instrument already defined in this part
-                repls [instId]  = mids [inst]       # remember to replace instId by inst (see below)
-                del midiInst [instId]               # instId is redundant
-            else: mids [inst] = instId              # collect unique instruments in this part
-        if len (mids) < 2 and not has_perc:         # only one instrument used -> no instrument tags needed in notes
-            removeElems (part, 'measure/note', 'instrument')    # no instrument tag needed for one- or no-instrument parts
+        for ipid, ivid, ch, prg, vol, pan in sorted(list(midiInst.values())):
+            if ipid != pid:
+                continue  # only instruments from part pid
+            if ch == "10":
+                has_perc = 1
+                continue  # only consider non percussion instruments
+            instId, inst = "I%s-%s" % (ipid, ivid), (ch, prg)
+            if inst in mids:  # midi instrument already defined in this part
+                repls[instId] = mids[
+                    inst
+                ]  # remember to replace instId by inst (see below)
+                del midiInst[instId]  # instId is redundant
+            else:
+                mids[inst] = instId  # collect unique instruments in this part
+        if (
+            len(mids) < 2 and not has_perc
+        ):  # only one instrument used -> no instrument tags needed in notes
+            removeElems(
+                part, "measure/note", "instrument"
+            )  # no instrument tag needed for one- or no-instrument parts
         else:
-            for e in part.findall ('measure/note/instrument'):
-                id = e.get ('id')                   # replace all redundant instrument Id's
-                if id in repls: e.set ('id', repls [id])
+            for e in part.findall("measure/note/instrument"):
+                id = e.get("id")  # replace all redundant instrument Id's
+                if id in repls:
+                    e.set("id", repls[id])
+
 
 class stringAlloc:
-    def __init__ (s):
-        s.snaarVrij = []    # [[(t1, t2) ...] for each string ]
-        s.snaarIx = []      # index in snaarVrij for each string
-        s.curstaff = -1     # staff being allocated
-    def beginZoek (s):      # reset snaarIx at start of each voice
+    def __init__(s):
+        s.snaarVrij = []  # [[(t1, t2) ...] for each string ]
+        s.snaarIx = []  # index in snaarVrij for each string
+        s.curstaff = -1  # staff being allocated
+
+    def beginZoek(s):  # reset snaarIx at start of each voice
         s.snaarIx = []
-        for i in range (len (s.snaarVrij)): s.snaarIx.append (0)
-    def setlines (s, stflines, stfnum):
-        if stfnum != s.curstaff:    # initialize for new staff
+        for i in range(len(s.snaarVrij)):
+            s.snaarIx.append(0)
+
+    def setlines(s, stflines, stfnum):
+        if stfnum != s.curstaff:  # initialize for new staff
             s.curstaff = stfnum
             s.snaarVrij = []
-            for i in range (stflines): s.snaarVrij.append ([])
-            s.beginZoek ()
-    def isVrij (s, snaar, t1, t2):  # see if string snaar is free between t1 and t2
-        xs = s.snaarVrij [snaar]
-        for i in range (s.snaarIx [snaar], len (xs)):
-            tb, te = xs [i]
-            if t1 >= te: continue   # te_prev < t1 <= te
-            if t1 >= tb: s.snaarIx [snaar] = i; return 0    # tb <= t1 < te
-            if t2 > tb: s.snaarIx [snaar] = i; return 0     # t1 < tb < t2
-            s.snaarIx [snaar] = i;  # remember position for next call
-            xs.insert (i, (t1,t2))  # te_prev < t1 < t2 < tb
+            for i in range(stflines):
+                s.snaarVrij.append([])
+            s.beginZoek()
+
+    def isVrij(s, snaar, t1, t2):  # see if string snaar is free between t1 and t2
+        xs = s.snaarVrij[snaar]
+        for i in range(s.snaarIx[snaar], len(xs)):
+            tb, te = xs[i]
+            if t1 >= te:
+                continue  # te_prev < t1 <= te
+            if t1 >= tb:
+                s.snaarIx[snaar] = i
+                return 0  # tb <= t1 < te
+            if t2 > tb:
+                s.snaarIx[snaar] = i
+                return 0  # t1 < tb < t2
+            s.snaarIx[snaar] = i  # remember position for next call
+            xs.insert(i, (t1, t2))  # te_prev < t1 < t2 < tb
             return 1
-        xs.append ((t1,t2))
-        s.snaarIx [snaar] = len (xs) - 1
+        xs.append((t1, t2))
+        s.snaarIx[snaar] = len(xs) - 1
         return 1
-    def bezet (s, snaar, t1, t2):   # force allocation of note (t1,t2) on string snaar
-        xs = s.snaarVrij [snaar]
-        for i, (tb, te) in enumerate (xs):
-            if t1 >= te: continue   # te_prev < t1 <= te
-            xs.insert (i, (t1, t2))
+
+    def bezet(s, snaar, t1, t2):  # force allocation of note (t1,t2) on string snaar
+        xs = s.snaarVrij[snaar]
+        for i, (tb, te) in enumerate(xs):
+            if t1 >= te:
+                continue  # te_prev < t1 <= te
+            xs.insert(i, (t1, t2))
             return
-        xs.append ((t1,t2))
+        xs.append((t1, t2))
+
 
 class MusicXml:
-    typeMap = {1:'long', 2:'breve', 4:'whole', 8:'half', 16:'quarter', 32:'eighth', 64:'16th', 128:'32nd', 256:'64th'}
-    dynaMap = {'p':1,'pp':1,'ppp':1,'pppp':1,'f':1,'ff':1,'fff':1,'ffff':1,'mp':1,'mf':1,'sfz':1}
-    tempoMap = {'larghissimo':40, 'moderato':104, 'adagissimo':44, 'allegretto':112, 'lentissimo':48, 'allegro':120, 'largo':56,
-            'vivace':168, 'adagio':59, 'vivo':180, 'lento':62, 'presto':192, 'larghetto':66, 'allegrissimo':208, 'adagietto':76,
-            'vivacissimo':220, 'andante':88, 'prestissimo':240, 'andantino':96}
-    wedgeMap = {'>(':1, '>)':1, '<(':1,'<)':1,'crescendo(':1,'crescendo)':1,'diminuendo(':1,'diminuendo)':1}
-    artMap = {'.':'staccato','>':'accent','accent':'accent','wedge':'staccatissimo','tenuto':'tenuto',
-              'breath':'breath-mark','marcato':'strong-accent','^':'strong-accent','slide':'scoop'}
-    ornMap = {'trill':'trill-mark','T':'trill-mark','turn':'turn','uppermordent':'inverted-mordent','lowermordent':'mordent',
-              'pralltriller':'inverted-mordent','mordent':'mordent','turn':'turn','invertedturn':'inverted-turn'}
-    tecMap = {'upbow':'up-bow', 'downbow':'down-bow', 'plus':'stopped','open':'open-string','snap':'snap-pizzicato',
-              'thumb':'thumb-position'}
-    capoMap = {'fine':('Fine','fine','yes'), 'D.S.':('D.S.','dalsegno','segno'), 'D.C.':('D.C.','dacapo','yes'),'dacapo':('D.C.','dacapo','yes'),
-               'dacoda':('To Coda','tocoda','coda'), 'coda':('coda','coda','coda'), 'segno':('segno','segno','segno')}
-    sharpness = ['Fb', 'Cb','Gb','Db','Ab','Eb','Bb','F','C','G','D','A', 'E', 'B', 'F#','C#','G#','D#','A#','E#','B#']
-    offTab = {'maj':8, 'm':11, 'min':11, 'mix':9, 'dor':10, 'phr':12, 'lyd':7, 'loc':13}
-    modTab = {'maj':'major', 'm':'minor', 'min':'minor', 'mix':'mixolydian', 'dor':'dorian', 'phr':'phrygian', 'lyd':'lydian', 'loc':'locrian'}
-    clefMap = { 'alto1':('C','1'), 'alto2':('C','2'), 'alto':('C','3'), 'alto4':('C','4'), 'tenor':('C','4'),
-                'bass3':('F','3'), 'bass':('F','4'), 'treble':('G','2'), 'perc':('percussion',''), 'none':('',''), 'tab':('TAB','5')}
-    clefLineMap = {'B':'treble', 'G':'alto1', 'E':'alto2', 'C':'alto', 'A':'tenor', 'F':'bass3', 'D':'bass'}
-    alterTab = {'=':'0', '_':'-1', '__':'-2', '^':'1', '^^':'2'}
-    accTab = {'=':'natural', '_':'flat', '__':'flat-flat', '^':'sharp', '^^':'sharp-sharp'}
-    chordTab = compChordTab ()
-    uSyms = {'~':'roll', 'H':'fermata','L':'>','M':'lowermordent','O':'coda',
-             'P':'uppermordent','S':'segno','T':'trill','u':'upbow','v':'downbow'}
-    pageFmtDef = [0.75,297,210,18,18,10,10] # the abcm2ps page formatting defaults for A4
-    metaTab = {'O':'origin', 'A':'area', 'Z':'transcription', 'N':'notes', 'G':'group', 'H':'history', 'R':'rhythm',
-                'B':'book', 'D':'discography', 'F':'fileurl', 'S':'source', 'P':'partmap', 'W':'lyrics'}
-    metaMap = {'C':'composer'}  # mapping of composer is fixed
-    metaTypes = {'composer':1,'lyricist':1,'poet':1,'arranger':1,'translator':1, 'rights':1} # valid MusicXML meta data types
-    tuningDef = 'E2,A2,D3,G3,B3,E4'.split (',') # default string tuning (guitar)
+    typeMap = {
+        1: "long",
+        2: "breve",
+        4: "whole",
+        8: "half",
+        16: "quarter",
+        32: "eighth",
+        64: "16th",
+        128: "32nd",
+        256: "64th",
+    }
+    dynaMap = {
+        "p": 1,
+        "pp": 1,
+        "ppp": 1,
+        "pppp": 1,
+        "f": 1,
+        "ff": 1,
+        "fff": 1,
+        "ffff": 1,
+        "mp": 1,
+        "mf": 1,
+        "sfz": 1,
+    }
+    tempoMap = {
+        "larghissimo": 40,
+        "moderato": 104,
+        "adagissimo": 44,
+        "allegretto": 112,
+        "lentissimo": 48,
+        "allegro": 120,
+        "largo": 56,
+        "vivace": 168,
+        "adagio": 59,
+        "vivo": 180,
+        "lento": 62,
+        "presto": 192,
+        "larghetto": 66,
+        "allegrissimo": 208,
+        "adagietto": 76,
+        "vivacissimo": 220,
+        "andante": 88,
+        "prestissimo": 240,
+        "andantino": 96,
+    }
+    wedgeMap = {
+        ">(": 1,
+        ">)": 1,
+        "<(": 1,
+        "<)": 1,
+        "crescendo(": 1,
+        "crescendo)": 1,
+        "diminuendo(": 1,
+        "diminuendo)": 1,
+    }
+    artMap = {
+        ".": "staccato",
+        ">": "accent",
+        "accent": "accent",
+        "wedge": "staccatissimo",
+        "tenuto": "tenuto",
+        "breath": "breath-mark",
+        "marcato": "strong-accent",
+        "^": "strong-accent",
+        "slide": "scoop",
+    }
+    ornMap = {
+        "trill": "trill-mark",
+        "T": "trill-mark",
+        "turn": "turn",
+        "uppermordent": "inverted-mordent",
+        "lowermordent": "mordent",
+        "pralltriller": "inverted-mordent",
+        "mordent": "mordent",
+        "turn": "turn",
+        "invertedturn": "inverted-turn",
+    }
+    tecMap = {
+        "upbow": "up-bow",
+        "downbow": "down-bow",
+        "plus": "stopped",
+        "open": "open-string",
+        "snap": "snap-pizzicato",
+        "thumb": "thumb-position",
+    }
+    capoMap = {
+        "fine": ("Fine", "fine", "yes"),
+        "D.S.": ("D.S.", "dalsegno", "segno"),
+        "D.C.": ("D.C.", "dacapo", "yes"),
+        "dacapo": ("D.C.", "dacapo", "yes"),
+        "dacoda": ("To Coda", "tocoda", "coda"),
+        "coda": ("coda", "coda", "coda"),
+        "segno": ("segno", "segno", "segno"),
+    }
+    sharpness = [
+        "Fb",
+        "Cb",
+        "Gb",
+        "Db",
+        "Ab",
+        "Eb",
+        "Bb",
+        "F",
+        "C",
+        "G",
+        "D",
+        "A",
+        "E",
+        "B",
+        "F#",
+        "C#",
+        "G#",
+        "D#",
+        "A#",
+        "E#",
+        "B#",
+    ]
+    offTab = {
+        "maj": 8,
+        "m": 11,
+        "min": 11,
+        "mix": 9,
+        "dor": 10,
+        "phr": 12,
+        "lyd": 7,
+        "loc": 13,
+    }
+    modTab = {
+        "maj": "major",
+        "m": "minor",
+        "min": "minor",
+        "mix": "mixolydian",
+        "dor": "dorian",
+        "phr": "phrygian",
+        "lyd": "lydian",
+        "loc": "locrian",
+    }
+    clefMap = {
+        "alto1": ("C", "1"),
+        "alto2": ("C", "2"),
+        "alto": ("C", "3"),
+        "alto4": ("C", "4"),
+        "tenor": ("C", "4"),
+        "bass3": ("F", "3"),
+        "bass": ("F", "4"),
+        "treble": ("G", "2"),
+        "perc": ("percussion", ""),
+        "none": ("", ""),
+        "tab": ("TAB", "5"),
+    }
+    clefLineMap = {
+        "B": "treble",
+        "G": "alto1",
+        "E": "alto2",
+        "C": "alto",
+        "A": "tenor",
+        "F": "bass3",
+        "D": "bass",
+    }
+    alterTab = {"=": "0", "_": "-1", "__": "-2", "^": "1", "^^": "2"}
+    accTab = {
+        "=": "natural",
+        "_": "flat",
+        "__": "flat-flat",
+        "^": "sharp",
+        "^^": "sharp-sharp",
+    }
+    chordTab = compChordTab()
+    uSyms = {
+        "~": "roll",
+        "H": "fermata",
+        "L": ">",
+        "M": "lowermordent",
+        "O": "coda",
+        "P": "uppermordent",
+        "S": "segno",
+        "T": "trill",
+        "u": "upbow",
+        "v": "downbow",
+    }
+    pageFmtDef = [
+        0.75,
+        297,
+        210,
+        18,
+        18,
+        10,
+        10,
+    ]  # the abcm2ps page formatting defaults for A4
+    metaTab = {
+        "O": "origin",
+        "A": "area",
+        "Z": "transcription",
+        "N": "notes",
+        "G": "group",
+        "H": "history",
+        "R": "rhythm",
+        "B": "book",
+        "D": "discography",
+        "F": "fileurl",
+        "S": "source",
+        "P": "partmap",
+        "W": "lyrics",
+    }
+    metaMap = {"C": "composer"}  # mapping of composer is fixed
+    metaTypes = {
+        "composer": 1,
+        "lyricist": 1,
+        "poet": 1,
+        "arranger": 1,
+        "translator": 1,
+        "rights": 1,
+    }  # valid MusicXML meta data types
+    tuningDef = "E2,A2,D3,G3,B3,E4".split(",")  # default string tuning (guitar)
 
-    def __init__ (s):
-        s.pageFmtCmd = []   # set by command line option -p
-        s.reset ()
-    def reset (s, fOpt=False):
-        s.divisions = 2520  # xml duration of 1/4 note, 2^3 * 3^2 * 5 * 7 => 5,7,9 tuplets
-        s.ties = {}         # {abc pitch tuple -> alteration} for all open ties
-        s.slurstack = {}    # stack of open slur numbers per (overlay) voice
-        s.slurbeg = []      # type of slurs to start (when slurs are detected at element-level)
-        s.tmnum = 0         # time modification, numerator
-        s.tmden = 0         # time modification, denominator
-        s.ntup = 0          # number of tuplet notes remaining
-        s.trem = 0          # number of bars for tremolo
-        s.intrem = 0        # mark tremolo sequence (for duration doubling)
-        s.tupnts = []       # all tuplet modifiers with corresp. durations: [(duration, modifier), ...]
-        s.irrtup = 0        # 1 if an irregular tuplet
-        s.ntype = ''        # the normal-type of a tuplet (== duration type of a normal tuplet note)
-        s.unitL =  (1, 8)   # default unit length
-        s.unitLcur = (1, 8) # unit length of current voice
-        s.keyAlts = {}      # alterations implied by key
-        s.msreAlts = {}     # temporarily alterations
-        s.curVolta = ''     # open volta bracket
-        s.title = ''        # title of music
-        s.creator = {}      # {creator-type -> creator string}
-        s.metadata = {}     # {metadata-type -> string}
-        s.lyrdash = {}      # {lyric number -> 1 if dash between syllables}
-        s.usrSyms = s.uSyms # user defined symbols
-        s.prevNote = None   # xml element of previous beamed note to correct beams (start, continue)
-        s.prevLyric = {}    # xml element of previous lyric to add/correct extend type (start, continue)
-        s.grcbbrk = False   # remember any bbrk in a grace sequence
-        s.linebrk = 0       # 1 if next measure should start with a line break
-        s.nextdecos = []    # decorations for the next note
-        s.prevmsre = None   # the previous measure
-        s.supports_tag = 0  # issue supports-tag in xml file when abc uses explicit linebreaks
-        s.staveDefs = []    # collected %%staves or %%score instructions from score
-        s.staves = []       # staves = [[voice names to be merged into one stave]]
-        s.groups = []       # list of merged part names with interspersed {[ and }]
-        s.grands = []       # [[vid1, vid2, ..], ...] voiceIds to be merged in a grand staff
-        s.gStaffNums = {}   # map each voice id in a grand staff to a staff number
-        s.gNstaves = {}     # map each voice id in a grand staff to total number of staves
-        s.pageFmtAbc = []   # formatting from abc directives
-        s.mdur = (4,4)      # duration of one measure
-        s.gtrans = 0        # octave transposition (by clef)
-        s.midprg = ['', '', '', ''] # MIDI channel nr, program nr, volume, panning for the current part
-        s.vid = ''          # abc voice id for the current voice
-        s.pid = ''          # xml part id for the current voice
-        s.gcue_on = 0       # insert <cue/> tag in each note
-        s.percVoice = 0     # 1 if percussion enabled
-        s.percMap = {}      # (part-id, abc_pitch, xml-octave) -> (abc staff step, midi note number, xml notehead)
-        s.pMapFound = 0     # at least one I:percmap has been found
-        s.vcepid = {}       # voice_id -> part_id
-        s.midiInst = {}     # inst_id -> (part_id, voice_id, channel, midi_number), remember instruments used
-        s.capo = 0          # fret position of the capodastro
-        s.tunmid = []       # midi numbers of strings
-        s.tunTup = []       # ordered midi numbers of strings [(midi_num, string_num), ...] (midi_num from high to low)
-        s.fOpt = fOpt       # force string/fret allocations for tab staves
-        s.orderChords = 0   # order notes in a chord
-        s.chordDecos = {}   # decos that should be distributed to all chord notes for xml
-        ch10 = 'acoustic-bass-drum,35;bass-drum-1,36;side-stick,37;acoustic-snare,38;hand-clap,39;electric-snare,40;low-floor-tom,41;closed-hi-hat,42;high-floor-tom,43;pedal-hi-hat,44;low-tom,45;open-hi-hat,46;low-mid-tom,47;hi-mid-tom,48;crash-cymbal-1,49;high-tom,50;ride-cymbal-1,51;chinese-cymbal,52;ride-bell,53;tambourine,54;splash-cymbal,55;cowbell,56;crash-cymbal-2,57;vibraslap,58;ride-cymbal-2,59;hi-bongo,60;low-bongo,61;mute-hi-conga,62;open-hi-conga,63;low-conga,64;high-timbale,65;low-timbale,66;high-agogo,67;low-agogo,68;cabasa,69;maracas,70;short-whistle,71;long-whistle,72;short-guiro,73;long-guiro,74;claves,75;hi-wood-block,76;low-wood-block,77;mute-cuica,78;open-cuica,79;mute-triangle,80;open-triangle,81'
-        s.percsnd = [x.split (',') for x in ch10.split (';')]   # {name -> midi number} of standard channel 10 sound names
-        s.gTime = (0,0)     # (XML begin time, XML end time) in divisions
-        s.tabStaff = ''     # == pid (part ID) for a tab staff
+    def __init__(s):
+        s.pageFmtCmd = []  # set by command line option -p
+        s.reset()
 
-    def mkPitch (s, acc, note, oct, lev):
-        if s.percVoice: # percussion map switched off by perc=off (see doClef)
-            octq = int (oct) + s.gtrans     # honour the octave= transposition when querying percmap
-            tup = s.percMap.get ((s.pid, acc+note, octq), s.percMap.get (('', acc+note, octq), 0))
-            if tup: step, soct, midi, notehead = tup
-            else: step, soct = note, octq
-            octnum = (4 if step.upper() == step else 5) + int (soct)
-            if not tup: # add percussion map for unmapped notes in this part
-                midi = str (octnum * 12 + [0,2,4,5,7,9,11]['CDEFGAB'.index (step.upper())] + {'^':1,'_':-1}.get (acc, 0) + 12)
-                notehead = {'^':'x', '_':'circle-x'}.get (acc, 'normal')
-                if s.pMapFound: info ('no I:percmap for: %s%s in part %s, voice %s' % (acc+note, -oct*',' if oct<0 else oct*"'", s.pid, s.vid))
-                s.percMap [(s.pid, acc+note, octq)] =  (note, octq, midi, notehead)
-            else:       # correct step value for clef
-                step, octnum = stepTrans (step.upper (), octnum, s.curClef)
-            pitch = E.Element ('unpitched')
-            addElemT (pitch, 'display-step', step.upper (), lev + 1)
-            addElemT (pitch, 'display-octave', str (octnum), lev + 1)
-            return pitch, '', midi, notehead
-        nUp = note.upper ()
-        octnum = (4 if nUp == note else 5) + int (oct) + s.gtrans
-        pitch = E.Element ('pitch')
-        addElemT (pitch, 'step', nUp, lev + 1)
-        alter = ''
+    def reset(s, fOpt=False):
+        s.divisions = (
+            2520  # xml duration of 1/4 note, 2^3 * 3^2 * 5 * 7 => 5,7,9 tuplets
+        )
+        s.ties = {}  # {abc pitch tuple -> alteration} for all open ties
+        s.slurstack = {}  # stack of open slur numbers per (overlay) voice
+        s.slurbeg = (
+            []
+        )  # type of slurs to start (when slurs are detected at element-level)
+        s.tmnum = 0  # time modification, numerator
+        s.tmden = 0  # time modification, denominator
+        s.ntup = 0  # number of tuplet notes remaining
+        s.trem = 0  # number of bars for tremolo
+        s.intrem = 0  # mark tremolo sequence (for duration doubling)
+        s.tupnts = (
+            []
+        )  # all tuplet modifiers with corresp. durations: [(duration, modifier), ...]
+        s.irrtup = 0  # 1 if an irregular tuplet
+        s.ntype = (
+            ""  # the normal-type of a tuplet (== duration type of a normal tuplet note)
+        )
+        s.unitL = (1, 8)  # default unit length
+        s.unitLcur = (1, 8)  # unit length of current voice
+        s.keyAlts = {}  # alterations implied by key
+        s.msreAlts = {}  # temporarily alterations
+        s.curVolta = ""  # open volta bracket
+        s.title = ""  # title of music
+        s.creator = {}  # {creator-type -> creator string}
+        s.metadata = {}  # {metadata-type -> string}
+        s.lyrdash = {}  # {lyric number -> 1 if dash between syllables}
+        s.usrSyms = s.uSyms  # user defined symbols
+        s.prevNote = None  # xml element of previous beamed note to correct beams (start, continue)
+        s.prevLyric = (
+            {}
+        )  # xml element of previous lyric to add/correct extend type (start, continue)
+        s.grcbbrk = False  # remember any bbrk in a grace sequence
+        s.linebrk = 0  # 1 if next measure should start with a line break
+        s.nextdecos = []  # decorations for the next note
+        s.prevmsre = None  # the previous measure
+        s.supports_tag = (
+            0  # issue supports-tag in xml file when abc uses explicit linebreaks
+        )
+        s.staveDefs = []  # collected %%staves or %%score instructions from score
+        s.staves = []  # staves = [[voice names to be merged into one stave]]
+        s.groups = []  # list of merged part names with interspersed {[ and }]
+        s.grands = []  # [[vid1, vid2, ..], ...] voiceIds to be merged in a grand staff
+        s.gStaffNums = {}  # map each voice id in a grand staff to a staff number
+        s.gNstaves = {}  # map each voice id in a grand staff to total number of staves
+        s.pageFmtAbc = []  # formatting from abc directives
+        s.mdur = (4, 4)  # duration of one measure
+        s.gtrans = 0  # octave transposition (by clef)
+        s.midprg = [
+            "",
+            "",
+            "",
+            "",
+        ]  # MIDI channel nr, program nr, volume, panning for the current part
+        s.vid = ""  # abc voice id for the current voice
+        s.pid = ""  # xml part id for the current voice
+        s.gcue_on = 0  # insert <cue/> tag in each note
+        s.percVoice = 0  # 1 if percussion enabled
+        s.percMap = (
+            {}
+        )  # (part-id, abc_pitch, xml-octave) -> (abc staff step, midi note number, xml notehead)
+        s.pMapFound = 0  # at least one I:percmap has been found
+        s.vcepid = {}  # voice_id -> part_id
+        s.midiInst = (
+            {}
+        )  # inst_id -> (part_id, voice_id, channel, midi_number), remember instruments used
+        s.capo = 0  # fret position of the capodastro
+        s.tunmid = []  # midi numbers of strings
+        s.tunTup = (
+            []
+        )  # ordered midi numbers of strings [(midi_num, string_num), ...] (midi_num from high to low)
+        s.fOpt = fOpt  # force string/fret allocations for tab staves
+        s.orderChords = 0  # order notes in a chord
+        s.chordDecos = {}  # decos that should be distributed to all chord notes for xml
+        ch10 = "acoustic-bass-drum,35;bass-drum-1,36;side-stick,37;acoustic-snare,38;hand-clap,39;electric-snare,40;low-floor-tom,41;closed-hi-hat,42;high-floor-tom,43;pedal-hi-hat,44;low-tom,45;open-hi-hat,46;low-mid-tom,47;hi-mid-tom,48;crash-cymbal-1,49;high-tom,50;ride-cymbal-1,51;chinese-cymbal,52;ride-bell,53;tambourine,54;splash-cymbal,55;cowbell,56;crash-cymbal-2,57;vibraslap,58;ride-cymbal-2,59;hi-bongo,60;low-bongo,61;mute-hi-conga,62;open-hi-conga,63;low-conga,64;high-timbale,65;low-timbale,66;high-agogo,67;low-agogo,68;cabasa,69;maracas,70;short-whistle,71;long-whistle,72;short-guiro,73;long-guiro,74;claves,75;hi-wood-block,76;low-wood-block,77;mute-cuica,78;open-cuica,79;mute-triangle,80;open-triangle,81"
+        s.percsnd = [
+            x.split(",") for x in ch10.split(";")
+        ]  # {name -> midi number} of standard channel 10 sound names
+        s.gTime = (0, 0)  # (XML begin time, XML end time) in divisions
+        s.tabStaff = ""  # == pid (part ID) for a tab staff
+
+    def mkPitch(s, acc, note, oct, lev):
+        if s.percVoice:  # percussion map switched off by perc=off (see doClef)
+            octq = (
+                int(oct) + s.gtrans
+            )  # honour the octave= transposition when querying percmap
+            tup = s.percMap.get(
+                (s.pid, acc + note, octq), s.percMap.get(("", acc + note, octq), 0)
+            )
+            if tup:
+                step, soct, midi, notehead = tup
+            else:
+                step, soct = note, octq
+            octnum = (4 if step.upper() == step else 5) + int(soct)
+            if not tup:  # add percussion map for unmapped notes in this part
+                midi = str(
+                    octnum * 12
+                    + [0, 2, 4, 5, 7, 9, 11]["CDEFGAB".index(step.upper())]
+                    + {"^": 1, "_": -1}.get(acc, 0)
+                    + 12
+                )
+                notehead = {"^": "x", "_": "circle-x"}.get(acc, "normal")
+                if s.pMapFound:
+                    info(
+                        "no I:percmap for: %s%s in part %s, voice %s"
+                        % (
+                            acc + note,
+                            -oct * "," if oct < 0 else oct * "'",
+                            s.pid,
+                            s.vid,
+                        )
+                    )
+                s.percMap[(s.pid, acc + note, octq)] = (note, octq, midi, notehead)
+            else:  # correct step value for clef
+                step, octnum = stepTrans(step.upper(), octnum, s.curClef)
+            pitch = E.Element("unpitched")
+            addElemT(pitch, "display-step", step.upper(), lev + 1)
+            addElemT(pitch, "display-octave", str(octnum), lev + 1)
+            return pitch, "", midi, notehead
+        nUp = note.upper()
+        octnum = (4 if nUp == note else 5) + int(oct) + s.gtrans
+        pitch = E.Element("pitch")
+        addElemT(pitch, "step", nUp, lev + 1)
+        alter = ""
         if (note, oct) in s.ties:
-            tied_alter, _, vnum, _ = s.ties [(note,oct)]            # vnum = overlay voice number when tie started
-            if vnum == s.overlayVnum: alter = tied_alter            # tied note in the same overlay -> same alteration
+            tied_alter, _, vnum, _ = s.ties[
+                (note, oct)
+            ]  # vnum = overlay voice number when tie started
+            if vnum == s.overlayVnum:
+                alter = tied_alter  # tied note in the same overlay -> same alteration
         elif acc:
-            s.msreAlts [(nUp, octnum)] = s.alterTab [acc]
-            alter = s.alterTab [acc]                                # explicit notated alteration
-        elif (nUp, octnum) in s.msreAlts:   alter = s.msreAlts [(nUp, octnum)]  # temporary alteration
-        elif nUp in s.keyAlts:              alter = s.keyAlts [nUp] # alteration implied by the key
-        if alter: addElemT (pitch, 'alter', alter, lev + 1)
-        addElemT (pitch, 'octave', str (octnum), lev + 1)
-        return pitch, alter, '', ''
+            s.msreAlts[(nUp, octnum)] = s.alterTab[acc]
+            alter = s.alterTab[acc]  # explicit notated alteration
+        elif (nUp, octnum) in s.msreAlts:
+            alter = s.msreAlts[(nUp, octnum)]  # temporary alteration
+        elif nUp in s.keyAlts:
+            alter = s.keyAlts[nUp]  # alteration implied by the key
+        if alter:
+            addElemT(pitch, "alter", alter, lev + 1)
+        addElemT(pitch, "octave", str(octnum), lev + 1)
+        return pitch, alter, "", ""
 
-    def getNoteDecos (s, n):
-        decos = s.nextdecos             # decorations encountered so far
-        ndeco = getattr (n, 'deco', 0)  # possible decorations of notes of a chord
-        if ndeco:                       # add decorations, translate used defined symbols
-            decos += [s.usrSyms.get (d, d).strip ('!+') for d in ndeco.t]
+    def getNoteDecos(s, n):
+        decos = s.nextdecos  # decorations encountered so far
+        ndeco = getattr(n, "deco", 0)  # possible decorations of notes of a chord
+        if ndeco:  # add decorations, translate used defined symbols
+            decos += [s.usrSyms.get(d, d).strip("!+") for d in ndeco.t]
         s.nextdecos = []
-        if s.tabStaff == s.pid and s.fOpt and n.name != 'rest':  # force fret/string allocation if explicit string decoration is missing
-            if [d for d in decos if d in '0123456789'] == []: decos.append ('0')
+        if (
+            s.tabStaff == s.pid and s.fOpt and n.name != "rest"
+        ):  # force fret/string allocation if explicit string decoration is missing
+            if [d for d in decos if d in "0123456789"] == []:
+                decos.append("0")
         return decos
 
-    def mkNote (s, n, lev):
-        isgrace = getattr (n, 'grace', '')
-        ischord = getattr (n, 'chord', '')
+    def mkNote(s, n, lev):
+        isgrace = getattr(n, "grace", "")
+        ischord = getattr(n, "chord", "")
         if s.ntup >= 0 and not isgrace and not ischord:
-            s.ntup -= 1                 # count tuplet notes only on non-chord, non grace notes
+            s.ntup -= 1  # count tuplet notes only on non-chord, non grace notes
             if s.ntup == -1 and s.trem <= 0:
-                s.intrem = 0            # tremolo pair ends at first note that is not a new tremolo pair (s.trem > 0)
-        nnum, nden = n.dur.t            # abc dutation of note
-        if s.intrem: nnum += nnum       # double duration of tremolo duplets
-        if nden == 0: nden = 1          # occurs with illegal ABC like: "A2 1". Now interpreted as A2/1
-        num, den = simplify (nnum * s.unitLcur[0], nden * s.unitLcur[1])  # normalised with unit length
-        if den > 64:    # limit denominator to 64
-            num = int (round (64 * float (num) / den))  # scale note to num/64
-            num, den  = simplify (max ([num, 1]), 64)   # smallest num == 1
-            info ('duration too small: rounded to %d/%d' % (num, den))
-        if n.name == 'rest' and ('Z' in n.t or 'X' in n.t):
-              num, den = s.mdur         # duration of one measure
-        noMsrRest = not (n.name == 'rest' and (num, den) == s.mdur) # not a measure rest
-        dvs = (4 * s.divisions * num) // den    # divisions is xml-duration of 1/4
-        rdvs = dvs                      # real duration (will be 0 for chord/grace)
-        num, den = simplify (num, den * 4)      # scale by 1/4 for s.typeMap
+                s.intrem = 0  # tremolo pair ends at first note that is not a new tremolo pair (s.trem > 0)
+        nnum, nden = n.dur.t  # abc dutation of note
+        if s.intrem:
+            nnum += nnum  # double duration of tremolo duplets
+        if nden == 0:
+            nden = 1  # occurs with illegal ABC like: "A2 1". Now interpreted as A2/1
+        num, den = simplify(
+            nnum * s.unitLcur[0], nden * s.unitLcur[1]
+        )  # normalised with unit length
+        if den > 64:  # limit denominator to 64
+            num = int(round(64 * float(num) / den))  # scale note to num/64
+            num, den = simplify(max([num, 1]), 64)  # smallest num == 1
+            info("duration too small: rounded to %d/%d" % (num, den))
+        if n.name == "rest" and ("Z" in n.t or "X" in n.t):
+            num, den = s.mdur  # duration of one measure
+        noMsrRest = not (
+            n.name == "rest" and (num, den) == s.mdur
+        )  # not a measure rest
+        dvs = (4 * s.divisions * num) // den  # divisions is xml-duration of 1/4
+        rdvs = dvs  # real duration (will be 0 for chord/grace)
+        num, den = simplify(num, den * 4)  # scale by 1/4 for s.typeMap
         ndot = 0
-        if num == 3 and noMsrRest: ndot = 1; den = den // 2 # look for dotted notes
-        if num == 7 and noMsrRest: ndot = 2; den = den // 4
-        nt = E.Element ('note')
-        if isgrace:                     # a grace note (and possibly a chord note)
-            grace = E.Element ('grace')
-            if s.acciatura: grace.set ('slash', 'yes'); s.acciatura = 0
-            addElem (nt, grace, lev + 1)
-            dvs = rdvs = 0              # no (real) duration for a grace note
-            if den <= 16: den = 32      # not longer than 1/8 for a grace note
-        if s.gcue_on:                   # insert cue tag
-            cue = E.Element ('cue')
-            addElem (nt, cue, lev + 1)
-        if ischord:                     # a chord note
-            chord = E.Element ('chord')
-            addElem (nt, chord, lev + 1)
-            rdvs = 0                    # chord notes no real duration
-        if den not in s.typeMap:        # take the nearest smaller legal duration
-            info ('illegal duration %d/%d' % (nnum, nden))
-            den = min (x for x in s.typeMap.keys () if x > den)
-        xmltype = str (s.typeMap [den]) # xml needs the note type in addition to duration
-        acc, step, oct = '', 'C', '0'   # abc-notated pitch elements (accidental, pitch step, octave)
-        alter, midi, notehead = '', '', ''      # xml alteration
-        if n.name == 'rest':
-            if 'x' in n.t or 'X' in n.t: nt.set ('print-object', 'no')
-            rest = E.Element ('rest')
-            if not noMsrRest: rest.set ('measure', 'yes')
-            addElem (nt, rest, lev + 1)
+        if num == 3 and noMsrRest:
+            ndot = 1
+            den = den // 2  # look for dotted notes
+        if num == 7 and noMsrRest:
+            ndot = 2
+            den = den // 4
+        nt = E.Element("note")
+        if isgrace:  # a grace note (and possibly a chord note)
+            grace = E.Element("grace")
+            if s.acciatura:
+                grace.set("slash", "yes")
+                s.acciatura = 0
+            addElem(nt, grace, lev + 1)
+            dvs = rdvs = 0  # no (real) duration for a grace note
+            if den <= 16:
+                den = 32  # not longer than 1/8 for a grace note
+        if s.gcue_on:  # insert cue tag
+            cue = E.Element("cue")
+            addElem(nt, cue, lev + 1)
+        if ischord:  # a chord note
+            chord = E.Element("chord")
+            addElem(nt, chord, lev + 1)
+            rdvs = 0  # chord notes no real duration
+        if den not in s.typeMap:  # take the nearest smaller legal duration
+            info("illegal duration %d/%d" % (nnum, nden))
+            den = min(x for x in s.typeMap.keys() if x > den)
+        xmltype = str(s.typeMap[den])  # xml needs the note type in addition to duration
+        acc, step, oct = (
+            "",
+            "C",
+            "0",
+        )  # abc-notated pitch elements (accidental, pitch step, octave)
+        alter, midi, notehead = "", "", ""  # xml alteration
+        if n.name == "rest":
+            if "x" in n.t or "X" in n.t:
+                nt.set("print-object", "no")
+            rest = E.Element("rest")
+            if not noMsrRest:
+                rest.set("measure", "yes")
+            addElem(nt, rest, lev + 1)
         else:
-            p = n.pitch.t           # get pitch elements from parsed tokens
-            if len (p) == 3:    acc, step, oct = p
-            else:               step, oct = p
-            pitch, alter, midi, notehead = s.mkPitch (acc, step, oct, lev + 1)
-            if midi: acc = ''       # erase accidental for percussion notes
-            addElem (nt, pitch, lev + 1)
-        if s.ntup >= 0:                 # modify duration for tuplet notes
+            p = n.pitch.t  # get pitch elements from parsed tokens
+            if len(p) == 3:
+                acc, step, oct = p
+            else:
+                step, oct = p
+            pitch, alter, midi, notehead = s.mkPitch(acc, step, oct, lev + 1)
+            if midi:
+                acc = ""  # erase accidental for percussion notes
+            addElem(nt, pitch, lev + 1)
+        if s.ntup >= 0:  # modify duration for tuplet notes
             dvs = dvs * s.tmden // s.tmnum
         if dvs:
-            addElemT (nt, 'duration', str (dvs), lev + 1)   # skip when dvs == 0, requirement of musicXML
-            if not ischord: s.gTime = s.gTime [1], s.gTime [1] + dvs
-        ptup = (step, oct)              # pitch tuple without alteration to check for ties
-        tstop = ptup in s.ties and s.ties[ptup][2] == s.overlayVnum  # open tie on this pitch tuple in this overlay
+            addElemT(
+                nt, "duration", str(dvs), lev + 1
+            )  # skip when dvs == 0, requirement of musicXML
+            if not ischord:
+                s.gTime = s.gTime[1], s.gTime[1] + dvs
+        ptup = (step, oct)  # pitch tuple without alteration to check for ties
+        tstop = (
+            ptup in s.ties and s.ties[ptup][2] == s.overlayVnum
+        )  # open tie on this pitch tuple in this overlay
         if tstop:
-            tie = E.Element ('tie', type='stop')
-            addElem (nt, tie, lev + 1)
-        if getattr (n, 'tie', 0):
-            tie = E.Element ('tie', type='start')
-            addElem (nt, tie, lev + 1)
-        if (s.midprg != ['', '', '', ''] or midi) and n.name != 'rest': # only add when %%midi was present or percussion
-            instId = 'I%s-%s' % (s.pid, 'X' + midi if midi else s.vid)
-            chan, midi = ('10', midi) if midi else s.midprg [:2]
-            inst = E.Element ('instrument', id=instId)  # instrument id for midi
-            addElem (nt, inst, lev + 1)
-            if instId not in s.midiInst: s.midiInst [instId] = (s.pid, s.vid, chan, midi, s.midprg [2], s.midprg [3]) # for instrument list in mkScorePart
-        addElemT (nt, 'voice', '1', lev + 1)    # default voice, for merging later
-        if noMsrRest: addElemT (nt, 'type', xmltype, lev + 1) # add note type if not a measure rest
-        for i in range (ndot):          # add dots
-            dot = E.Element ('dot')
-            addElem (nt, dot, lev + 1)
-        decos = s.getNoteDecos (n)      # get decorations for this note
-        if acc and not tstop:           # only add accidental if note not tied
-            e = E.Element ('accidental')
-            if 'courtesy' in decos:
-                e.set ('parentheses', 'yes')
-                decos.remove ('courtesy')
-            e.text = s.accTab [acc]
-            addElem (nt, e, lev + 1)
-        tupnotation = ''                # start/stop notation element for tuplets
-        if s.ntup >= 0:                 # add time modification element for tuplet notes
-            tmod = mkTmod (s.tmnum, s.tmden, lev + 1)
-            addElem (nt, tmod, lev + 1)
-            if s.ntup > 0 and not s.tupnts: tupnotation = 'start'
-            s.tupnts.append ((rdvs, tmod))      # remember all tuplet modifiers with corresp. durations
-            if s.ntup == 0:             # last tuplet note (and possible chord notes there after)
-                if rdvs: tupnotation = 'stop'   # only insert notation in the real note (rdvs > 0)
-                s.cmpNormType (rdvs, lev + 1)   # compute and/or add normal-type elements (-> s.ntype)
+            tie = E.Element("tie", type="stop")
+            addElem(nt, tie, lev + 1)
+        if getattr(n, "tie", 0):
+            tie = E.Element("tie", type="start")
+            addElem(nt, tie, lev + 1)
+        if (
+            s.midprg != ["", "", "", ""] or midi
+        ) and n.name != "rest":  # only add when %%midi was present or percussion
+            instId = "I%s-%s" % (s.pid, "X" + midi if midi else s.vid)
+            chan, midi = ("10", midi) if midi else s.midprg[:2]
+            inst = E.Element("instrument", id=instId)  # instrument id for midi
+            addElem(nt, inst, lev + 1)
+            if instId not in s.midiInst:
+                s.midiInst[instId] = (
+                    s.pid,
+                    s.vid,
+                    chan,
+                    midi,
+                    s.midprg[2],
+                    s.midprg[3],
+                )  # for instrument list in mkScorePart
+        addElemT(nt, "voice", "1", lev + 1)  # default voice, for merging later
+        if noMsrRest:
+            addElemT(
+                nt, "type", xmltype, lev + 1
+            )  # add note type if not a measure rest
+        for i in range(ndot):  # add dots
+            dot = E.Element("dot")
+            addElem(nt, dot, lev + 1)
+        decos = s.getNoteDecos(n)  # get decorations for this note
+        if acc and not tstop:  # only add accidental if note not tied
+            e = E.Element("accidental")
+            if "courtesy" in decos:
+                e.set("parentheses", "yes")
+                decos.remove("courtesy")
+            e.text = s.accTab[acc]
+            addElem(nt, e, lev + 1)
+        tupnotation = ""  # start/stop notation element for tuplets
+        if s.ntup >= 0:  # add time modification element for tuplet notes
+            tmod = mkTmod(s.tmnum, s.tmden, lev + 1)
+            addElem(nt, tmod, lev + 1)
+            if s.ntup > 0 and not s.tupnts:
+                tupnotation = "start"
+            s.tupnts.append(
+                (rdvs, tmod)
+            )  # remember all tuplet modifiers with corresp. durations
+            if s.ntup == 0:  # last tuplet note (and possible chord notes there after)
+                if rdvs:
+                    tupnotation = (
+                        "stop"  # only insert notation in the real note (rdvs > 0)
+                    )
+                s.cmpNormType(
+                    rdvs, lev + 1
+                )  # compute and/or add normal-type elements (-> s.ntype)
         hasStem = 1
-        if not ischord: s.chordDecos = {}       # clear on non chord note
-        if 'stemless' in decos or (s.nostems and n.name != 'rest') or 'stemless' in s.chordDecos:
+        if not ischord:
+            s.chordDecos = {}  # clear on non chord note
+        if (
+            "stemless" in decos
+            or (s.nostems and n.name != "rest")
+            or "stemless" in s.chordDecos
+        ):
             hasStem = 0
-            addElemT (nt, 'stem', 'none', lev + 1)
-            if 'stemless' in decos: decos.remove ('stemless')   # do not handle in doNotations
-            if hasattr (n, 'pitches'): s.chordDecos ['stemless'] = 1    # set on first chord note
+            addElemT(nt, "stem", "none", lev + 1)
+            if "stemless" in decos:
+                decos.remove("stemless")  # do not handle in doNotations
+            if hasattr(n, "pitches"):
+                s.chordDecos["stemless"] = 1  # set on first chord note
         if notehead:
-            nh = addElemT (nt, 'notehead', re.sub (r'[+-]$', '', notehead), lev + 1)
-            if notehead[-1] in '+-': nh.set ('filled', 'yes' if notehead[-1] == '+' else 'no')
-        gstaff = s.gStaffNums.get (s.vid, 0)    # staff number of the current voice
-        if gstaff: addElemT (nt, 'staff', str (gstaff), lev + 1)
-        if hasStem: s.doBeams (n, nt, den, lev + 1)   # no stems -> no beams in a tab staff
-        s.doNotations (n, decos, ptup, alter, tupnotation, tstop, nt, lev + 1)
-        if n.objs: s.doLyr (n, nt, lev + 1)
-        else: s.prevLyric = {}   # clear on note without lyrics
+            nh = addElemT(nt, "notehead", re.sub(r"[+-]$", "", notehead), lev + 1)
+            if notehead[-1] in "+-":
+                nh.set("filled", "yes" if notehead[-1] == "+" else "no")
+        gstaff = s.gStaffNums.get(s.vid, 0)  # staff number of the current voice
+        if gstaff:
+            addElemT(nt, "staff", str(gstaff), lev + 1)
+        if hasStem:
+            s.doBeams(n, nt, den, lev + 1)  # no stems -> no beams in a tab staff
+        s.doNotations(n, decos, ptup, alter, tupnotation, tstop, nt, lev + 1)
+        if n.objs:
+            s.doLyr(n, nt, lev + 1)
+        else:
+            s.prevLyric = {}  # clear on note without lyrics
         return nt
 
-    def cmpNormType (s, rdvs, lev): # compute the normal-type of a tuplet (only needed for Finale)
-        if rdvs:    # the last real tuplet note (chord notes can still follow afterwards with rdvs == 0)
+    def cmpNormType(
+        s, rdvs, lev
+    ):  # compute the normal-type of a tuplet (only needed for Finale)
+        if (
+            rdvs
+        ):  # the last real tuplet note (chord notes can still follow afterwards with rdvs == 0)
             durs = [dur for dur, tmod in s.tupnts if dur > 0]
-            ndur = sum (durs) // s.tmnum    # duration of the normal type
-            s.irrtup = any ((dur != ndur) for dur in durs)  # irregular tuplet
+            ndur = sum(durs) // s.tmnum  # duration of the normal type
+            s.irrtup = any((dur != ndur) for dur in durs)  # irregular tuplet
             tix = 16 * s.divisions // ndur  # index in typeMap of normal-type duration
             if tix in s.typeMap:
-                s.ntype = str (s.typeMap [tix]) # the normal-type
-            else: s.irrtup = 0          # give up, no normal type possible
-        if s.irrtup:                    # only add normal-type for irregular tuplets
+                s.ntype = str(s.typeMap[tix])  # the normal-type
+            else:
+                s.irrtup = 0  # give up, no normal type possible
+        if s.irrtup:  # only add normal-type for irregular tuplets
             for dur, tmod in s.tupnts:  # add normal-type to all modifiers
-                addElemT (tmod, 'normal-type', s.ntype, lev + 1)
-        s.tupnts = []                   # reset the tuplet buffer
+                addElemT(tmod, "normal-type", s.ntype, lev + 1)
+        s.tupnts = []  # reset the tuplet buffer
 
-    def doNotations (s, n, decos, ptup, alter, tupnotation, tstop, nt, lev):
-        slurs = getattr (n, 'slurs', 0) # slur ends
-        pts = getattr (n, 'pitches', [])            # all chord notes available in the first note
-        ov = s.overlayVnum                          # current overlay voice number (0 for the main voice)
-        if pts:                                     # make list of pitches in chord: [(pitch, octave), ..]
-            if type (pts.pitch) == pObj: pts = [pts.pitch]      # chord with one note
-            else: pts = [tuple (p.t[-2:]) for p in pts.pitch]   # normal chord
-        for pt, (tie_alter, nts, vnum, ntelm) in sorted (list (s.ties.items ())):  # scan all open ties and delete illegal ones
-            if vnum != s.overlayVnum: continue      # tie belongs to different overlay
-            if pts and pt in pts: continue          # pitch tuple of tie exists in chord
-            if getattr (n, 'chord', 0): continue    # skip chord notes
-            if pt == ptup: continue                 # skip correct single note tie
-            if getattr (n, 'grace', 0): continue    # skip grace notes
-            info ('tie between different pitches: %s%s converted to slur' % pt)
-            del s.ties [pt]                         # remove the note from pending ties
-            e = [t for t in ntelm.findall ('tie') if t.get ('type') == 'start'][0]  # get the tie start element
-            ntelm.remove (e)                        # delete start tie element
-            e = [t for t in nts.findall ('tied') if t.get ('type') == 'start'][0]   # get the tied start element
-            e.tag = 'slur'                          # convert tie into slur
-            slurnum = pushSlur (s.slurstack, ov)
-            e.set ('number', str (slurnum))
-            if slurs: slurs.t.append (')')          # close slur on this note
-            else: slurs = pObj ('slurs', [')'])
-        tstart = getattr (n, 'tie', 0)  # start a new tie
-        if not (tstop or tstart or decos or slurs or s.slurbeg or tupnotation or s.trem): return nt
-        nots = E.Element ('notations')  # notation element needed
+    def doNotations(s, n, decos, ptup, alter, tupnotation, tstop, nt, lev):
+        slurs = getattr(n, "slurs", 0)  # slur ends
+        pts = getattr(n, "pitches", [])  # all chord notes available in the first note
+        ov = s.overlayVnum  # current overlay voice number (0 for the main voice)
+        if pts:  # make list of pitches in chord: [(pitch, octave), ..]
+            if type(pts.pitch) == pObj:
+                pts = [pts.pitch]  # chord with one note
+            else:
+                pts = [tuple(p.t[-2:]) for p in pts.pitch]  # normal chord
+        for pt, (tie_alter, nts, vnum, ntelm) in sorted(
+            list(s.ties.items())
+        ):  # scan all open ties and delete illegal ones
+            if vnum != s.overlayVnum:
+                continue  # tie belongs to different overlay
+            if pts and pt in pts:
+                continue  # pitch tuple of tie exists in chord
+            if getattr(n, "chord", 0):
+                continue  # skip chord notes
+            if pt == ptup:
+                continue  # skip correct single note tie
+            if getattr(n, "grace", 0):
+                continue  # skip grace notes
+            info("tie between different pitches: %s%s converted to slur" % pt)
+            del s.ties[pt]  # remove the note from pending ties
+            e = [t for t in ntelm.findall("tie") if t.get("type") == "start"][
+                0
+            ]  # get the tie start element
+            ntelm.remove(e)  # delete start tie element
+            e = [t for t in nts.findall("tied") if t.get("type") == "start"][
+                0
+            ]  # get the tied start element
+            e.tag = "slur"  # convert tie into slur
+            slurnum = pushSlur(s.slurstack, ov)
+            e.set("number", str(slurnum))
+            if slurs:
+                slurs.t.append(")")  # close slur on this note
+            else:
+                slurs = pObj("slurs", [")"])
+        tstart = getattr(n, "tie", 0)  # start a new tie
+        if not (
+            tstop or tstart or decos or slurs or s.slurbeg or tupnotation or s.trem
+        ):
+            return nt
+        nots = E.Element("notations")  # notation element needed
         if s.trem:  # +/- => tuple tremolo sequence / single note tremolo
-            if s.trem < 0: tupnotation = 'single'; s.trem = -s.trem
-            if not tupnotation: return  # only add notation at first or last note of a tremolo sequence
-            orn = E.Element ('ornaments')
-            trm = E.Element ('tremolo', type=tupnotation)   # type = start, stop or single
-            trm.text = str (s.trem)     # the number of bars in a tremolo note
-            addElem (nots, orn, lev + 1)
-            addElem (orn, trm, lev + 2)
-            if tupnotation == 'stop' or tupnotation == 'single': s.trem = 0
-        elif tupnotation:       # add tuplet type
-            tup = E.Element ('tuplet', type=tupnotation)
-            if tupnotation == 'start': tup.set ('bracket', 'yes')
-            addElem (nots, tup, lev + 1)
-        if tstop:               # stop tie
-            del s.ties[ptup]    # remove flag
-            tie = E.Element ('tied', type='stop')
-            addElem (nots, tie, lev + 1)
-        if tstart:              # start a tie
-            s.ties[ptup] = (alter, nots, s.overlayVnum, nt) # remember pitch tuple to stop tie and apply same alteration
-            tie = E.Element ('tied', type='start')
-            if tstart.t[0] == '.-': tie.set ('line-type', 'dotted')
-            addElem (nots, tie, lev + 1)
-        if decos:               # look for slurs and decorations
-            slurMap = { '(':1, '.(':1, '(,':1, "('":1, '.(,':1, ".('":1 }
-            arts = []           # collect articulations
-            for d in decos:     # do all slurs and decos
-                if d in slurMap: s.slurbeg.append (d); continue # slurs made in while loop at the end
-                elif d == 'fermata' or d == 'H':
-                    ntn = E.Element ('fermata', type='upright')
-                elif d == 'arpeggio':
-                    ntn = E.Element ('arpeggiate', number='1')
-                elif d in ['~(', '~)']:
-                    if d[1] == '(': tp = 'start'; s.glisnum += 1; gn = s.glisnum
-                    else:           tp = 'stop'; gn = s.glisnum; s.glisnum -= 1
-                    if s.glisnum < 0: s.glisnum = 0; continue   # stop without previous start
-                    ntn = E.Element ('glissando', {'line-type':'wavy', 'number':'%d' % gn, 'type':tp})
-                elif d in ['-(', '-)']:
-                    if d[1] == '(': tp = 'start'; s.slidenum += 1; gn = s.slidenum
-                    else:           tp = 'stop'; gn = s.slidenum; s.slidenum -= 1
-                    if s.slidenum < 0: s.slidenum = 0; continue   # stop without previous start
-                    ntn = E.Element ('slide', {'line-type':'solid', 'number':'%d' % gn, 'type':tp})
-                else: arts.append (d); continue
-                addElem (nots, ntn, lev + 1)
-            if arts:        # do only note articulations and collect staff annotations in xmldecos
-                rest = s.doArticulations (nt, nots, arts, lev + 1)
-                if rest: info ('unhandled note decorations: %s' % rest)
-        if slurs:           # these are only slur endings
-            for d in slurs.t:           # slurs to be closed on this note
-                if not s.slurstack.get (ov, 0): break    # no more open old slurs for this (overlay) voice
-                slurnum = s.slurstack [ov].pop ()
-                slur = E.Element ('slur', number='%d' % slurnum, type='stop')
-                addElem (nots, slur, lev + 1)
-        while s.slurbeg:    # create slurs beginning on this note
-            stp = s.slurbeg.pop (0)
-            slurnum = pushSlur (s.slurstack, ov)
-            ntn = E.Element ('slur', number='%d' % slurnum, type='start')
-            if '.' in stp: ntn.set ('line-type', 'dotted')
-            if ',' in stp: ntn.set ('placement', 'below')
-            if "'" in stp: ntn.set ('placement', 'above')
-            addElem (nots, ntn, lev + 1)            
-        if list (nots) != []:    # only add notations if not empty
-            addElem (nt, nots, lev)
+            if s.trem < 0:
+                tupnotation = "single"
+                s.trem = -s.trem
+            if not tupnotation:
+                return  # only add notation at first or last note of a tremolo sequence
+            orn = E.Element("ornaments")
+            trm = E.Element("tremolo", type=tupnotation)  # type = start, stop or single
+            trm.text = str(s.trem)  # the number of bars in a tremolo note
+            addElem(nots, orn, lev + 1)
+            addElem(orn, trm, lev + 2)
+            if tupnotation == "stop" or tupnotation == "single":
+                s.trem = 0
+        elif tupnotation:  # add tuplet type
+            tup = E.Element("tuplet", type=tupnotation)
+            if tupnotation == "start":
+                tup.set("bracket", "yes")
+            addElem(nots, tup, lev + 1)
+        if tstop:  # stop tie
+            del s.ties[ptup]  # remove flag
+            tie = E.Element("tied", type="stop")
+            addElem(nots, tie, lev + 1)
+        if tstart:  # start a tie
+            s.ties[ptup] = (
+                alter,
+                nots,
+                s.overlayVnum,
+                nt,
+            )  # remember pitch tuple to stop tie and apply same alteration
+            tie = E.Element("tied", type="start")
+            if tstart.t[0] == ".-":
+                tie.set("line-type", "dotted")
+            addElem(nots, tie, lev + 1)
+        if decos:  # look for slurs and decorations
+            slurMap = {"(": 1, ".(": 1, "(,": 1, "('": 1, ".(,": 1, ".('": 1}
+            arts = []  # collect articulations
+            for d in decos:  # do all slurs and decos
+                if d in slurMap:
+                    s.slurbeg.append(d)
+                    continue  # slurs made in while loop at the end
+                elif d == "fermata" or d == "H":
+                    ntn = E.Element("fermata", type="upright")
+                elif d == "arpeggio":
+                    ntn = E.Element("arpeggiate", number="1")
+                elif d in ["~(", "~)"]:
+                    if d[1] == "(":
+                        tp = "start"
+                        s.glisnum += 1
+                        gn = s.glisnum
+                    else:
+                        tp = "stop"
+                        gn = s.glisnum
+                        s.glisnum -= 1
+                    if s.glisnum < 0:
+                        s.glisnum = 0
+                        continue  # stop without previous start
+                    ntn = E.Element(
+                        "glissando",
+                        {"line-type": "wavy", "number": "%d" % gn, "type": tp},
+                    )
+                elif d in ["-(", "-)"]:
+                    if d[1] == "(":
+                        tp = "start"
+                        s.slidenum += 1
+                        gn = s.slidenum
+                    else:
+                        tp = "stop"
+                        gn = s.slidenum
+                        s.slidenum -= 1
+                    if s.slidenum < 0:
+                        s.slidenum = 0
+                        continue  # stop without previous start
+                    ntn = E.Element(
+                        "slide", {"line-type": "solid", "number": "%d" % gn, "type": tp}
+                    )
+                else:
+                    arts.append(d)
+                    continue
+                addElem(nots, ntn, lev + 1)
+            if (
+                arts
+            ):  # do only note articulations and collect staff annotations in xmldecos
+                rest = s.doArticulations(nt, nots, arts, lev + 1)
+                if rest:
+                    info("unhandled note decorations: %s" % rest)
+        if slurs:  # these are only slur endings
+            for d in slurs.t:  # slurs to be closed on this note
+                if not s.slurstack.get(ov, 0):
+                    break  # no more open old slurs for this (overlay) voice
+                slurnum = s.slurstack[ov].pop()
+                slur = E.Element("slur", number="%d" % slurnum, type="stop")
+                addElem(nots, slur, lev + 1)
+        while s.slurbeg:  # create slurs beginning on this note
+            stp = s.slurbeg.pop(0)
+            slurnum = pushSlur(s.slurstack, ov)
+            ntn = E.Element("slur", number="%d" % slurnum, type="start")
+            if "." in stp:
+                ntn.set("line-type", "dotted")
+            if "," in stp:
+                ntn.set("placement", "below")
+            if "'" in stp:
+                ntn.set("placement", "above")
+            addElem(nots, ntn, lev + 1)
+        if list(nots) != []:  # only add notations if not empty
+            addElem(nt, nots, lev)
 
-    def doArticulations (s, nt, nots, arts, lev):
+    def doArticulations(s, nt, nots, arts, lev):
         decos = []
         for a in arts:
             if a in s.artMap:
-                art = E.Element ('articulations')
-                addElem (nots, art, lev)
-                addElem (art, E.Element (s.artMap[a]), lev + 1)
+                art = E.Element("articulations")
+                addElem(nots, art, lev)
+                addElem(art, E.Element(s.artMap[a]), lev + 1)
             elif a in s.ornMap:
-                orn = E.Element ('ornaments')
-                addElem (nots, orn, lev)
-                addElem (orn, E.Element (s.ornMap[a]), lev + 1)
-            elif a in ['trill(','trill)']:
-                orn = E.Element ('ornaments')
-                addElem (nots, orn, lev)
-                type = 'start' if a.endswith ('(') else 'stop'
-                if type == 'start': addElem (orn, E.Element ('trill-mark'), lev + 1)                
-                addElem (orn, E.Element ('wavy-line', type=type), lev + 1)                
+                orn = E.Element("ornaments")
+                addElem(nots, orn, lev)
+                addElem(orn, E.Element(s.ornMap[a]), lev + 1)
+            elif a in ["trill(", "trill)"]:
+                orn = E.Element("ornaments")
+                addElem(nots, orn, lev)
+                type = "start" if a.endswith("(") else "stop"
+                if type == "start":
+                    addElem(orn, E.Element("trill-mark"), lev + 1)
+                addElem(orn, E.Element("wavy-line", type=type), lev + 1)
             elif a in s.tecMap:
-                tec = E.Element ('technical')
-                addElem (nots, tec, lev)
-                addElem (tec, E.Element (s.tecMap[a]), lev + 1)
-            elif a in '0123456':
-                tec = E.Element ('technical')
-                addElem (nots, tec, lev)
-                if s.tabStaff == s.pid:             # current voice belongs to a tabStaff
-                    alt = int (nt.findtext ('pitch/alter') or 0)    # find midi number of current note
-                    step = nt.findtext ('pitch/step')
-                    oct = int (nt.findtext ('pitch/octave'))
-                    midi = oct * 12 + [0,2,4,5,7,9,11]['CDEFGAB'.index (step)] + alt + 12
-                    if a == '0':                    # no string annotation: find one
-                        firstFit = ''
-                        for smid, istr in s.tunTup: # midi numbers of open strings from high to low
-                            if midi >= smid:        # highest open string where this note can be played
-                                isvrij = s.strAlloc.isVrij (istr - 1, s.gTime [0], s.gTime [1])
-                                a = str (istr)      # string number
-                                if not firstFit: firstFit = a
-                                if isvrij: break
-                        if not isvrij:              # no free string, take the first fit (lowest fret)
+                tec = E.Element("technical")
+                addElem(nots, tec, lev)
+                addElem(tec, E.Element(s.tecMap[a]), lev + 1)
+            elif a in "0123456":
+                tec = E.Element("technical")
+                addElem(nots, tec, lev)
+                if s.tabStaff == s.pid:  # current voice belongs to a tabStaff
+                    alt = int(
+                        nt.findtext("pitch/alter") or 0
+                    )  # find midi number of current note
+                    step = nt.findtext("pitch/step")
+                    oct = int(nt.findtext("pitch/octave"))
+                    midi = (
+                        oct * 12
+                        + [0, 2, 4, 5, 7, 9, 11]["CDEFGAB".index(step)]
+                        + alt
+                        + 12
+                    )
+                    if a == "0":  # no string annotation: find one
+                        firstFit = ""
+                        for (
+                            smid,
+                            istr,
+                        ) in s.tunTup:  # midi numbers of open strings from high to low
+                            if (
+                                midi >= smid
+                            ):  # highest open string where this note can be played
+                                isvrij = s.strAlloc.isVrij(
+                                    istr - 1, s.gTime[0], s.gTime[1]
+                                )
+                                a = str(istr)  # string number
+                                if not firstFit:
+                                    firstFit = a
+                                if isvrij:
+                                    break
+                        if (
+                            not isvrij
+                        ):  # no free string, take the first fit (lowest fret)
                             a = firstFit
-                            s.strAlloc.bezet (int (a) - 1, s.gTime [0], s.gTime [1])
-                    else:                           # force annotated string number 
-                        s.strAlloc.bezet (int (a) - 1, s.gTime [0], s.gTime [1])
-                    bmidi = s.tunmid [int (a) - 1]  # midi number of allocated string (with capodastro)
-                    fret =  midi - bmidi            # fret position (respecting capodastro)
+                            s.strAlloc.bezet(int(a) - 1, s.gTime[0], s.gTime[1])
+                    else:  # force annotated string number
+                        s.strAlloc.bezet(int(a) - 1, s.gTime[0], s.gTime[1])
+                    bmidi = s.tunmid[
+                        int(a) - 1
+                    ]  # midi number of allocated string (with capodastro)
+                    fret = midi - bmidi  # fret position (respecting capodastro)
                     if fret < 25 and fret >= 0:
-                        addElemT (tec, 'fret', str (fret), lev + 1)
+                        addElemT(tec, "fret", str(fret), lev + 1)
                     else:
-                        altp = 'b' if alt == -1 else '#' if alt == 1 else ''
-                        info ('fret %d out of range, note %s%d on string %s' % (fret, step+altp, oct, a))
-                    addElemT (tec, 'string', a, lev + 1)
+                        altp = "b" if alt == -1 else "#" if alt == 1 else ""
+                        info(
+                            "fret %d out of range, note %s%d on string %s"
+                            % (fret, step + altp, oct, a)
+                        )
+                    addElemT(tec, "string", a, lev + 1)
                 else:
-                    addElemT (tec, 'fingering', a, lev + 1)
-            else: decos.append (a)  # return staff annotations
+                    addElemT(tec, "fingering", a, lev + 1)
+            else:
+                decos.append(a)  # return staff annotations
         return decos
 
-    def doLyr (s, n, nt, lev):
-        for i, lyrobj in enumerate (n.objs):
-            lyrel = E.Element ('lyric', number = str (i + 1))
-            if lyrobj.name == 'syl':
-                dash = len (lyrobj.t) == 2
+    def doLyr(s, n, nt, lev):
+        for i, lyrobj in enumerate(n.objs):
+            lyrel = E.Element("lyric", number=str(i + 1))
+            if lyrobj.name == "syl":
+                dash = len(lyrobj.t) == 2
                 if dash:
-                    if i in s.lyrdash:  type = 'middle'
-                    else:               type = 'begin'; s.lyrdash [i] = 1
+                    if i in s.lyrdash:
+                        type = "middle"
+                    else:
+                        type = "begin"
+                        s.lyrdash[i] = 1
                 else:
-                    if i in s.lyrdash:  type = 'end';   del s.lyrdash [i]
-                    else:               type = 'single'
-                addElemT (lyrel, 'syllabic', type, lev + 1)
-                txt = lyrobj.t[0]                       # the syllabe
-                txt = re.sub (r'(?<!\\)~', ' ', txt)    # replace ~ by space when not escaped (preceded by \)
-                txt = re.sub (r'\\(.)', r'\1', txt)     # replace all escaped characters by themselves (for the time being)
-                addElemT (lyrel, 'text', txt, lev + 1)
-            elif lyrobj.name == 'ext' and i in s.prevLyric:
-                pext = s.prevLyric [i].find ('extend')  # identify previous extend
+                    if i in s.lyrdash:
+                        type = "end"
+                        del s.lyrdash[i]
+                    else:
+                        type = "single"
+                addElemT(lyrel, "syllabic", type, lev + 1)
+                txt = lyrobj.t[0]  # the syllabe
+                txt = re.sub(
+                    r"(?<!\\)~", " ", txt
+                )  # replace ~ by space when not escaped (preceded by \)
+                txt = re.sub(
+                    r"\\(.)", r"\1", txt
+                )  # replace all escaped characters by themselves (for the time being)
+                addElemT(lyrel, "text", txt, lev + 1)
+            elif lyrobj.name == "ext" and i in s.prevLyric:
+                pext = s.prevLyric[i].find("extend")  # identify previous extend
                 if pext == None:
-                    ext = E.Element ('extend', type = 'start')
-                    addElem (s.prevLyric [i], ext, lev + 1)
-                elif pext.get('type') == 'stop':        # subsequent extend: stop -> continue
-                    pext.set ('type', 'continue')
-                ext = E.Element ('extend', type = 'stop')   # always stop on current extend
-                addElem (lyrel, ext, lev + 1)
-            elif lyrobj.name == 'ext': info ('lyric extend error'); continue
-            else: continue          # skip other lyric elements or errors
-            addElem (nt, lyrel, lev)
-            s.prevLyric [i] = lyrel # for extension (melisma) on the next note
+                    ext = E.Element("extend", type="start")
+                    addElem(s.prevLyric[i], ext, lev + 1)
+                elif pext.get("type") == "stop":  # subsequent extend: stop -> continue
+                    pext.set("type", "continue")
+                ext = E.Element("extend", type="stop")  # always stop on current extend
+                addElem(lyrel, ext, lev + 1)
+            elif lyrobj.name == "ext":
+                info("lyric extend error")
+                continue
+            else:
+                continue  # skip other lyric elements or errors
+            addElem(nt, lyrel, lev)
+            s.prevLyric[i] = lyrel  # for extension (melisma) on the next note
 
-    def doBeams (s, n, nt, den, lev):
-        if hasattr (n, 'chord') or hasattr (n, 'grace'):
-            s.grcbbrk = s.grcbbrk or n.bbrk.t[0]    # remember if there was any bbrk in or before a grace sequence
+    def doBeams(s, n, nt, den, lev):
+        if hasattr(n, "chord") or hasattr(n, "grace"):
+            s.grcbbrk = (
+                s.grcbbrk or n.bbrk.t[0]
+            )  # remember if there was any bbrk in or before a grace sequence
             return
         bbrk = s.grcbbrk or n.bbrk.t[0] or den < 32
         s.grcbbrk = False
-        if not s.prevNote:  pbm = None
-        else:               pbm = s.prevNote.find ('beam')
-        bm = E.Element ('beam', number='1')
-        bm.text = 'begin'
+        if not s.prevNote:
+            pbm = None
+        else:
+            pbm = s.prevNote.find("beam")
+        bm = E.Element("beam", number="1")
+        bm.text = "begin"
         if pbm != None:
             if bbrk:
-                if pbm.text == 'begin':
-                    s.prevNote.remove (pbm)
-                elif pbm.text == 'continue':
-                    pbm.text = 'end'
+                if pbm.text == "begin":
+                    s.prevNote.remove(pbm)
+                elif pbm.text == "continue":
+                    pbm.text = "end"
                 s.prevNote = None
-            else: bm.text = 'continue'
-        if den >= 32 and n.name != 'rest':
-            addElem (nt, bm, lev)
+            else:
+                bm.text = "continue"
+        if den >= 32 and n.name != "rest":
+            addElem(nt, bm, lev)
             s.prevNote = nt
 
-    def stopBeams (s):
-        if not s.prevNote: return
-        pbm = s.prevNote.find ('beam')
+    def stopBeams(s):
+        if not s.prevNote:
+            return
+        pbm = s.prevNote.find("beam")
         if pbm != None:
-            if pbm.text == 'begin':
-                s.prevNote.remove (pbm)
-            elif pbm.text == 'continue':
-                pbm.text = 'end'
+            if pbm.text == "begin":
+                s.prevNote.remove(pbm)
+            elif pbm.text == "continue":
+                pbm.text = "end"
         s.prevNote = None
 
-    def staffDecos (s, decos, maat, lev):
-        gstaff = s.gStaffNums.get (s.vid, 0)        # staff number of the current voice        
+    def staffDecos(s, decos, maat, lev):
+        gstaff = s.gStaffNums.get(s.vid, 0)  # staff number of the current voice
         for d in decos:
-            d = s.usrSyms.get (d, d).strip ('!+')   # try to replace user defined symbol
+            d = s.usrSyms.get(d, d).strip("!+")  # try to replace user defined symbol
             if d in s.dynaMap:
-                dynel = E.Element ('dynamics')
-                addDirection (maat, dynel, lev, gstaff, [E.Element (d)], 'below', s.gcue_on)
+                dynel = E.Element("dynamics")
+                addDirection(
+                    maat, dynel, lev, gstaff, [E.Element(d)], "below", s.gcue_on
+                )
             elif d in s.wedgeMap:  # wedge
-                if ')' in d: type = 'stop'
-                else: type = 'crescendo' if '<' in d or 'crescendo' in d else 'diminuendo'
-                addDirection (maat, E.Element ('wedge', type=type), lev, gstaff)
-            elif d.startswith ('8v'):
-                if 'a' in d: type, plce = 'down', 'above'
-                else:        type, plce = 'up', 'below'
-                if ')' in d: type = 'stop'
-                addDirection (maat, E.Element ('octave-shift', type=type, size='8'), lev, gstaff, placement=plce)
-            elif d in (['ped','ped-up']):
-                type = 'stop' if d.endswith ('up') else 'start'
-                addDirection (maat, E.Element ('pedal', type=type), lev, gstaff)
-            elif d in ['coda', 'segno']:
-                text, attr, val = s.capoMap [d]
-                dir = addDirection (maat, E.Element (text), lev, gstaff, placement='above')
-                sound = E.Element ('sound'); sound.set (attr, val)
-                addElem (dir, sound, lev + 1)
+                if ")" in d:
+                    type = "stop"
+                else:
+                    type = "crescendo" if "<" in d or "crescendo" in d else "diminuendo"
+                addDirection(maat, E.Element("wedge", type=type), lev, gstaff)
+            elif d.startswith("8v"):
+                if "a" in d:
+                    type, plce = "down", "above"
+                else:
+                    type, plce = "up", "below"
+                if ")" in d:
+                    type = "stop"
+                addDirection(
+                    maat,
+                    E.Element("octave-shift", type=type, size="8"),
+                    lev,
+                    gstaff,
+                    placement=plce,
+                )
+            elif d in (["ped", "ped-up"]):
+                type = "stop" if d.endswith("up") else "start"
+                addDirection(maat, E.Element("pedal", type=type), lev, gstaff)
+            elif d in ["coda", "segno"]:
+                text, attr, val = s.capoMap[d]
+                dir = addDirection(
+                    maat, E.Element(text), lev, gstaff, placement="above"
+                )
+                sound = E.Element("sound")
+                sound.set(attr, val)
+                addElem(dir, sound, lev + 1)
             elif d in s.capoMap:
-                text, attr, val = s.capoMap [d]
-                words = E.Element ('words'); words.text = text
-                dir = addDirection (maat, words, lev, gstaff, placement='above')
-                sound = E.Element ('sound'); sound.set (attr, val)
-                addElem (dir, sound, lev + 1)
-            elif d == '(' or d == '.(': s.slurbeg.append (d)   # start slur on next note
-            elif d in ['/-','//-','///-','////-']:  # duplet tremolo sequence
-                s.tmnum, s.tmden, s.ntup, s.trem, s.intrem = 2, 1, 2, len (d) - 1, 1
-            elif d in ['/','//','///']: s.trem = - len (d)  # single note tremolo
-            elif d == 'rbstop': s.rbStop = 1;   # sluit een open volta aan het eind van de maat
-            else: s.nextdecos.append (d)    # keep annotation for the next note
-
-    def doFields (s, maat, fieldmap, lev):
-        def instDir (midelm, midnum, dirtxt):
-            instId = 'I%s-%s' % (s.pid, s.vid)
-            words = E.Element ('words'); words.text = dirtxt % midnum
-            snd = E.Element ('sound')
-            mi = E.Element ('midi-instrument', id=instId)
-            dir = addDirection (maat, words, lev, gstaff, placement='above')
-            addElem (dir, snd, lev + 1)
-            addElem (snd, mi, lev + 2)
-            addElemT (mi, midelm, midnum, lev + 3)
-        def addTrans (n):
-            e = E.Element ('transpose')
-            addElemT (e, 'chromatic', n, lev + 2)  # n == signed number string given after transpose
-            atts.append ((9, e))
-        def doClef (field):
-            if re.search (r'perc|map', field):  # percussion clef or new style perc=on or map=perc
-                r = re.search (r'(perc|map)\s*=\s*(\S*)', field)
-                s.percVoice = 0 if r and r.group (2) not in ['on','true','perc'] else 1
-                field = re.sub (r'(perc|map)\s*=\s*(\S*)', '', field)   # erase the perc= for proper clef matching
-            clef, gtrans = 0, 0
-            clefn = re.search (r'alto1|alto2|alto4|alto|tenor|bass3|bass|treble|perc|none|tab', field)
-            clefm = re.search (r"(?:^m=| m=|middle=)([A-Ga-g])([,']*)", field)
-            trans_oct2 = re.search (r'octave=([-+]?\d)', field)
-            trans = re.search (r'(?:^t=| t=|transpose=)(-?[\d]+)', field)
-            trans_oct = re.search (r'([+-^_])(8|15)', field)
-            cue_onoff = re.search (r'cue=(on|off)', field)
-            strings = re.search (r"strings=(\S+)", field)
-            stafflines = re.search (r'stafflines=\s*(\d)', field)
-            capo = re.search (r'capo=(\d+)', field)
-            if clefn:
-                clef = clefn.group ()
-            if clefm:
-                note, octstr = clefm.groups ()
-                nUp = note.upper ()
-                octnum = (4 if nUp == note else 5) + (len (octstr) if "'" in octstr else -len (octstr))
-                gtrans = (3 if nUp in 'AFD' else 4) - octnum 
-                if clef not in ['perc', 'none']: clef = s.clefLineMap [nUp]
-            if clef:
-                s.gtrans = gtrans   # only change global tranposition when a clef is really defined
-                if clef != 'none': s.curClef = clef       # keep track of current abc clef (for percmap)
-                sign, line = s.clefMap [clef]
-                if not sign: return
-                c = E.Element ('clef')
-                if gstaff: c.set ('number', str (gstaff))   # only add staff number when defined
-                addElemT (c, 'sign', sign, lev + 2)
-                if line: addElemT (c, 'line', line, lev + 2)
-                if trans_oct:
-                    n = trans_oct.group (1) in '-_' and -1 or 1
-                    if trans_oct.group (2) == '15': n *= 2  # 8 => 1 octave, 15 => 2 octaves
-                    addElemT (c, 'clef-octave-change', str (n), lev + 2) # transpose print out
-                    if trans_oct.group (1) in '+-': s.gtrans += n   # also transpose all pitches with one octave
-                atts.append ((7, c))
-            if trans_oct2:  # octave= can also be in a K: field
-                n = int (trans_oct2.group (1))
-                s.gtrans = gtrans + n
-            if trans != None:   # add transposition in semitones
-                e = E.Element ('transpose')
-                addElemT (e, 'chromatic', str (trans.group (1)), lev + 3)
-                atts.append ((9, e))
-            if cue_onoff: s.gcue_on = cue_onoff.group (1) == 'on'
-            nlines = 0
-            if clef == 'tab':
-                s.tabStaff = s.pid
-                if capo: s.capo = int (capo.group (1))
-                if strings: s.tuning = strings.group (1).split (',')
-                s.tunmid = [int (boct) * 12 + [0,2,4,5,7,9,11]['CDEFGAB'.index (bstep)] + 12 + s.capo for bstep, boct in s.tuning]
-                s.tunTup = sorted (zip (s.tunmid, range (len (s.tunmid), 0, -1)), reverse=1)
-                s.tunmid.reverse ()
-                nlines = str (len (s.tuning))
-                s.strAlloc.setlines (len (s.tuning), s.pid)
-                s.nostems = 'nostems' in field  # tab clef without stems
-                s.diafret = 'diafret' in field  # tab with diatonic fretting
-            if stafflines or nlines:
-                e = E.Element ('staff-details')
-                if gstaff: e.set ('number', str (gstaff))   # only add staff number when defined
-                if not nlines: nlines = stafflines.group (1)
-                addElemT (e, 'staff-lines', nlines, lev + 2)
-                if clef == 'tab':
-                    for line, t in enumerate (s.tuning):
-                        st = E.Element ('staff-tuning', line=str(line+1))
-                        addElemT (st, 'tuning-step', t[0], lev + 3)
-                        addElemT (st, 'tuning-octave', t[1], lev + 3)
-                        addElem (e, st, lev + 2)
-                if s.capo: addElemT (e, 'capo', str (s.capo), lev + 2)
-                atts.append ((8, e))
-        s.diafret = 0           # chromatic fretting is default
-        atts = []               # collect xml attribute elements [(order-number, xml-element), ..]
-        gstaff = s.gStaffNums.get (s.vid, 0)    # staff number of the current voice
-        for ftype, field in fieldmap.items ():
-            if not field:       # skip empty fields
-                continue
-            if ftype == 'Div':  # not an abc field, but handled as if
-                d = E.Element ('divisions')
-                d.text = field
-                atts.append ((1, d))
-            elif ftype == 'gstaff':  # make grand staff
-                e = E.Element ('staves')
-                e.text = str (field)
-                atts.append ((4, e))
-            elif ftype == 'M':
-                if field == 'none': continue
-                if field == 'C': field = '4/4'
-                elif field == 'C|': field = '2/2'
-                t = E.Element ('time')
-                if '/' not in field:
-                    info ('M:%s not recognized, 4/4 assumed' % field)
-                    field = '4/4'
-                beats, btype = field.split ('/')[:2]
-                try: s.mdur = simplify (eval (beats), int (btype))  # measure duration for Z and X rests (eval allows M:2+3/4)
-                except:
-                    info ('error in M:%s, 4/4 assumed' % field)
-                    s.mdur = (4,4)
-                    beats, btype = '4','4'
-                addElemT (t, 'beats', beats, lev + 2)
-                addElemT (t, 'beat-type', btype, lev + 2)
-                atts.append ((3, t))
-            elif ftype == 'K':
-                accs = ['F','C','G','D','A','E','B']    # == s.sharpness [7:14]
-                mode = ''
-                key = re.match (r'\s*([A-G][#b]?)\s*([a-zA-Z]*)', field)
-                alts = re.search (r'\s((\s?[=^_][A-Ga-g])+)', ' ' + field)  # avoid matching middle=G and m=G
-                if key:
-                    key, mode = key.groups ()
-                    mode = mode.lower ()[:3] # only first three chars, no case
-                    if mode not in s.offTab: mode = 'maj'
-                    fifths = s.sharpness.index (key) - s.offTab [mode]
-                    if fifths >= 0: s.keyAlts = dict (zip (accs[:fifths], fifths * ['1']))
-                    else:           s.keyAlts = dict (zip (accs[fifths:], -fifths * ['-1']))
-                elif field.startswith ('none') or field == '':  # the default key
-                    fifths = 0
-                    mode = 'maj'
-                if alts:
-                    alts = re.findall (r'[=^_][A-Ga-g]', alts.group(1)) # list of explicit alterations
-                    alts = [(x[1], s.alterTab [x[0]]) for x in alts]    # [step, alter]
-                    for step, alter in alts:                # correct permanent alterations for this key
-                        s.keyAlts [step.upper ()] = alter
-                    k = E.Element ('key')
-                    koctave = []
-                    lowerCaseSteps = [step.upper () for step, alter in alts if step.islower ()]
-                    for step, alter in sorted (list (s.keyAlts.items ())):
-                        if alter == '0':                    # skip neutrals
-                            del s.keyAlts [step.upper ()]   # otherwise you get neutral signs on normal notes
-                            continue
-                        addElemT (k, 'key-step', step.upper (), lev + 2)
-                        addElemT (k, 'key-alter', alter, lev + 2)
-                        koctave.append ('5' if step in lowerCaseSteps else '4')
-                    if koctave:                     # only key signature if not empty
-                        for oct in koctave:
-                            e = E.Element ('key-octave', number=oct)
-                            addElem (k, e, lev + 2)
-                        atts.append ((2, k))
-                elif mode:
-                    k = E.Element ('key')
-                    addElemT (k, 'fifths', str (fifths), lev + 2)
-                    addElemT (k, 'mode', s.modTab [mode], lev + 2)
-                    atts.append ((2, k))
-                doClef (field)
-            elif ftype == 'L':
-                try: s.unitLcur = lmap (int, field.split ('/'))
-                except: s.unitLcur = (1,8)
-                if len (s.unitLcur) == 1 or s.unitLcur[1] not in s.typeMap:
-                    info ('L:%s is not allowed, 1/8 assumed' % field)
-                    s.unitLcur = 1,8
-            elif ftype == 'V':
-                doClef (field)
-            elif ftype == 'I':
-                s.doField_I (ftype, field, instDir, addTrans)
-            elif ftype == 'Q':
-                s.doTempo (maat, field, lev)
-            elif ftype == 'P':  # ad hoc translation of P: into a staff text direction
-                words = E.Element ('rehearsal')
-                words.set ('font-weight', 'bold')
-                words.text = field
-                addDirection (maat, words, lev, gstaff, placement='above')
-            elif ftype in 'TCOAZNGHRBDFSU':
-                info ('**illegal header field in body: %s, content: %s' % (ftype, field))
+                text, attr, val = s.capoMap[d]
+                words = E.Element("words")
+                words.text = text
+                dir = addDirection(maat, words, lev, gstaff, placement="above")
+                sound = E.Element("sound")
+                sound.set(attr, val)
+                addElem(dir, sound, lev + 1)
+            elif d == "(" or d == ".(":
+                s.slurbeg.append(d)  # start slur on next note
+            elif d in ["/-", "//-", "///-", "////-"]:  # duplet tremolo sequence
+                s.tmnum, s.tmden, s.ntup, s.trem, s.intrem = 2, 1, 2, len(d) - 1, 1
+            elif d in ["/", "//", "///"]:
+                s.trem = -len(d)  # single note tremolo
+            elif d == "rbstop":
+                s.rbStop = 1  # sluit een open volta aan het eind van de maat
             else:
-                info ('unhandled field: %s, content: %s' % (ftype, field))
+                s.nextdecos.append(d)  # keep annotation for the next note
+
+    def doFields(s, maat, fieldmap, lev):
+        def instDir(midelm, midnum, dirtxt):
+            instId = "I%s-%s" % (s.pid, s.vid)
+            words = E.Element("words")
+            words.text = dirtxt % midnum
+            snd = E.Element("sound")
+            mi = E.Element("midi-instrument", id=instId)
+            dir = addDirection(maat, words, lev, gstaff, placement="above")
+            addElem(dir, snd, lev + 1)
+            addElem(snd, mi, lev + 2)
+            addElemT(mi, midelm, midnum, lev + 3)
+
+        def addTrans(n):
+            e = E.Element("transpose")
+            addElemT(
+                e, "chromatic", n, lev + 2
+            )  # n == signed number string given after transpose
+            atts.append((9, e))
+
+        def doClef(field):
+            if re.search(
+                r"perc|map", field
+            ):  # percussion clef or new style perc=on or map=perc
+                r = re.search(r"(perc|map)\s*=\s*(\S*)", field)
+                s.percVoice = 0 if r and r.group(2) not in ["on", "true", "perc"] else 1
+                field = re.sub(
+                    r"(perc|map)\s*=\s*(\S*)", "", field
+                )  # erase the perc= for proper clef matching
+            clef, gtrans = 0, 0
+            clefn = re.search(
+                r"alto1|alto2|alto4|alto|tenor|bass3|bass|treble|perc|none|tab", field
+            )
+            clefm = re.search(r"(?:^m=| m=|middle=)([A-Ga-g])([,']*)", field)
+            trans_oct2 = re.search(r"octave=([-+]?\d)", field)
+            trans = re.search(r"(?:^t=| t=|transpose=)(-?[\d]+)", field)
+            trans_oct = re.search(r"([+-^_])(8|15)", field)
+            cue_onoff = re.search(r"cue=(on|off)", field)
+            strings = re.search(r"strings=(\S+)", field)
+            stafflines = re.search(r"stafflines=\s*(\d)", field)
+            capo = re.search(r"capo=(\d+)", field)
+            if clefn:
+                clef = clefn.group()
+            if clefm:
+                note, octstr = clefm.groups()
+                nUp = note.upper()
+                octnum = (4 if nUp == note else 5) + (
+                    len(octstr) if "'" in octstr else -len(octstr)
+                )
+                gtrans = (3 if nUp in "AFD" else 4) - octnum
+                if clef not in ["perc", "none"]:
+                    clef = s.clefLineMap[nUp]
+            if clef:
+                s.gtrans = gtrans  # only change global tranposition when a clef is really defined
+                if clef != "none":
+                    s.curClef = clef  # keep track of current abc clef (for percmap)
+                sign, line = s.clefMap[clef]
+                if not sign:
+                    return
+                c = E.Element("clef")
+                if gstaff:
+                    c.set("number", str(gstaff))  # only add staff number when defined
+                addElemT(c, "sign", sign, lev + 2)
+                if line:
+                    addElemT(c, "line", line, lev + 2)
+                if trans_oct:
+                    n = trans_oct.group(1) in "-_" and -1 or 1
+                    if trans_oct.group(2) == "15":
+                        n *= 2  # 8 => 1 octave, 15 => 2 octaves
+                    addElemT(
+                        c, "clef-octave-change", str(n), lev + 2
+                    )  # transpose print out
+                    if trans_oct.group(1) in "+-":
+                        s.gtrans += n  # also transpose all pitches with one octave
+                atts.append((7, c))
+            if trans_oct2:  # octave= can also be in a K: field
+                n = int(trans_oct2.group(1))
+                s.gtrans = gtrans + n
+            if trans != None:  # add transposition in semitones
+                e = E.Element("transpose")
+                addElemT(e, "chromatic", str(trans.group(1)), lev + 3)
+                atts.append((9, e))
+            if cue_onoff:
+                s.gcue_on = cue_onoff.group(1) == "on"
+            nlines = 0
+            if clef == "tab":
+                s.tabStaff = s.pid
+                if capo:
+                    s.capo = int(capo.group(1))
+                if strings:
+                    s.tuning = strings.group(1).split(",")
+                s.tunmid = [
+                    int(boct) * 12
+                    + [0, 2, 4, 5, 7, 9, 11]["CDEFGAB".index(bstep)]
+                    + 12
+                    + s.capo
+                    for bstep, boct in s.tuning
+                ]
+                s.tunTup = sorted(zip(s.tunmid, range(len(s.tunmid), 0, -1)), reverse=1)
+                s.tunmid.reverse()
+                nlines = str(len(s.tuning))
+                s.strAlloc.setlines(len(s.tuning), s.pid)
+                s.nostems = "nostems" in field  # tab clef without stems
+                s.diafret = "diafret" in field  # tab with diatonic fretting
+            if stafflines or nlines:
+                e = E.Element("staff-details")
+                if gstaff:
+                    e.set("number", str(gstaff))  # only add staff number when defined
+                if not nlines:
+                    nlines = stafflines.group(1)
+                addElemT(e, "staff-lines", nlines, lev + 2)
+                if clef == "tab":
+                    for line, t in enumerate(s.tuning):
+                        st = E.Element("staff-tuning", line=str(line + 1))
+                        addElemT(st, "tuning-step", t[0], lev + 3)
+                        addElemT(st, "tuning-octave", t[1], lev + 3)
+                        addElem(e, st, lev + 2)
+                if s.capo:
+                    addElemT(e, "capo", str(s.capo), lev + 2)
+                atts.append((8, e))
+
+        s.diafret = 0  # chromatic fretting is default
+        atts = []  # collect xml attribute elements [(order-number, xml-element), ..]
+        gstaff = s.gStaffNums.get(s.vid, 0)  # staff number of the current voice
+        for ftype, field in fieldmap.items():
+            if not field:  # skip empty fields
+                continue
+            if ftype == "Div":  # not an abc field, but handled as if
+                d = E.Element("divisions")
+                d.text = field
+                atts.append((1, d))
+            elif ftype == "gstaff":  # make grand staff
+                e = E.Element("staves")
+                e.text = str(field)
+                atts.append((4, e))
+            elif ftype == "M":
+                if field == "none":
+                    continue
+                if field == "C":
+                    field = "4/4"
+                elif field == "C|":
+                    field = "2/2"
+                t = E.Element("time")
+                if "/" not in field:
+                    info("M:%s not recognized, 4/4 assumed" % field)
+                    field = "4/4"
+                beats, btype = field.split("/")[:2]
+                try:
+                    s.mdur = simplify(
+                        eval(beats), int(btype)
+                    )  # measure duration for Z and X rests (eval allows M:2+3/4)
+                except:
+                    info("error in M:%s, 4/4 assumed" % field)
+                    s.mdur = (4, 4)
+                    beats, btype = "4", "4"
+                addElemT(t, "beats", beats, lev + 2)
+                addElemT(t, "beat-type", btype, lev + 2)
+                atts.append((3, t))
+            elif ftype == "K":
+                accs = ["F", "C", "G", "D", "A", "E", "B"]  # == s.sharpness [7:14]
+                mode = ""
+                key = re.match(r"\s*([A-G][#b]?)\s*([a-zA-Z]*)", field)
+                alts = re.search(
+                    r"\s((\s?[=^_][A-Ga-g])+)", " " + field
+                )  # avoid matching middle=G and m=G
+                if key:
+                    key, mode = key.groups()
+                    mode = mode.lower()[:3]  # only first three chars, no case
+                    if mode not in s.offTab:
+                        mode = "maj"
+                    fifths = s.sharpness.index(key) - s.offTab[mode]
+                    if fifths >= 0:
+                        s.keyAlts = dict(zip(accs[:fifths], fifths * ["1"]))
+                    else:
+                        s.keyAlts = dict(zip(accs[fifths:], -fifths * ["-1"]))
+                elif field.startswith("none") or field == "":  # the default key
+                    fifths = 0
+                    mode = "maj"
+                if alts:
+                    alts = re.findall(
+                        r"[=^_][A-Ga-g]", alts.group(1)
+                    )  # list of explicit alterations
+                    alts = [(x[1], s.alterTab[x[0]]) for x in alts]  # [step, alter]
+                    for (
+                        step,
+                        alter,
+                    ) in alts:  # correct permanent alterations for this key
+                        s.keyAlts[step.upper()] = alter
+                    k = E.Element("key")
+                    koctave = []
+                    lowerCaseSteps = [
+                        step.upper() for step, alter in alts if step.islower()
+                    ]
+                    for step, alter in sorted(list(s.keyAlts.items())):
+                        if alter == "0":  # skip neutrals
+                            del s.keyAlts[
+                                step.upper()
+                            ]  # otherwise you get neutral signs on normal notes
+                            continue
+                        addElemT(k, "key-step", step.upper(), lev + 2)
+                        addElemT(k, "key-alter", alter, lev + 2)
+                        koctave.append("5" if step in lowerCaseSteps else "4")
+                    if koctave:  # only key signature if not empty
+                        for oct in koctave:
+                            e = E.Element("key-octave", number=oct)
+                            addElem(k, e, lev + 2)
+                        atts.append((2, k))
+                elif mode:
+                    k = E.Element("key")
+                    addElemT(k, "fifths", str(fifths), lev + 2)
+                    addElemT(k, "mode", s.modTab[mode], lev + 2)
+                    atts.append((2, k))
+                doClef(field)
+            elif ftype == "L":
+                try:
+                    s.unitLcur = lmap(int, field.split("/"))
+                except:
+                    s.unitLcur = (1, 8)
+                if len(s.unitLcur) == 1 or s.unitLcur[1] not in s.typeMap:
+                    info("L:%s is not allowed, 1/8 assumed" % field)
+                    s.unitLcur = 1, 8
+            elif ftype == "V":
+                doClef(field)
+            elif ftype == "I":
+                s.doField_I(ftype, field, instDir, addTrans)
+            elif ftype == "Q":
+                s.doTempo(maat, field, lev)
+            elif ftype == "P":  # ad hoc translation of P: into a staff text direction
+                words = E.Element("rehearsal")
+                words.set("font-weight", "bold")
+                words.text = field
+                addDirection(maat, words, lev, gstaff, placement="above")
+            elif ftype in "TCOAZNGHRBDFSU":
+                info("**illegal header field in body: %s, content: %s" % (ftype, field))
+            else:
+                info("unhandled field: %s, content: %s" % (ftype, field))
 
         if atts:
-            att = E.Element ('attributes')      # insert sub elements in the order required by musicXML
-            addElem (maat, att, lev)
-            for _, att_elem in sorted (atts, key=lambda x: x[0]):   # ordering !
-                addElem (att, att_elem, lev + 1)
+            att = E.Element(
+                "attributes"
+            )  # insert sub elements in the order required by musicXML
+            addElem(maat, att, lev)
+            for _, att_elem in sorted(atts, key=lambda x: x[0]):  # ordering !
+                addElem(att, att_elem, lev + 1)
         if s.diafret:
-            other = E.Element ('other-direction'); other.text = 'diatonic fretting'
-            addDirection (maat, other, lev, 0)
+            other = E.Element("other-direction")
+            other.text = "diatonic fretting"
+            addDirection(maat, other, lev, 0)
 
-    def doTempo (s, maat, field, lev):
-        gstaff = s.gStaffNums.get (s.vid, 0)    # staff number of the current voice
-        t = re.search (r'(\d)/(\d\d?)\s*=\s*(\d[.\d]*)|(\d[.\d]*)', field)
-        rtxt = re.search (r'"([^"]*)"', field) # look for text in Q: field
-        if not t and not rtxt: return
+    def doTempo(s, maat, field, lev):
+        gstaff = s.gStaffNums.get(s.vid, 0)  # staff number of the current voice
+        t = re.search(r"(\d)/(\d\d?)\s*=\s*(\d[.\d]*)|(\d[.\d]*)", field)
+        rtxt = re.search(r'"([^"]*)"', field)  # look for text in Q: field
+        if not t and not rtxt:
+            return
         elems = []  # [(element, sub-elements)] will be added as direction-types
         if rtxt:
-            num, den, upm = 1, 4, s.tempoMap.get (rtxt.group (1).lower ().strip (), 120)
-            words = E.Element ('words'); words.text = rtxt.group (1)
-            elems.append ((words, []))
+            num, den, upm = 1, 4, s.tempoMap.get(rtxt.group(1).lower().strip(), 120)
+            words = E.Element("words")
+            words.text = rtxt.group(1)
+            elems.append((words, []))
         if t:
             try:
-                if t.group (4): num, den, upm = 1, s.unitLcur[1] , float (t.group (4))  # old syntax Q:120
-                else:           num, den, upm = int (t.group (1)), int (t.group (2)), float (t.group (3))
-            except: info ('conversion error: %s' % field); return
-            num, den = simplify (num, den);
+                if t.group(4):
+                    num, den, upm = (
+                        1,
+                        s.unitLcur[1],
+                        float(t.group(4)),
+                    )  # old syntax Q:120
+                else:
+                    num, den, upm = int(t.group(1)), int(t.group(2)), float(t.group(3))
+            except:
+                info("conversion error: %s" % field)
+                return
+            num, den = simplify(num, den)
             dotted, den_not = (1, den // 2) if num == 3 else (0, den)
-            metro = E.Element ('metronome')
-            u = E.Element ('beat-unit'); u.text = s.typeMap.get (4 * den_not, 'quarter')
-            pm = E.Element ('per-minute'); pm.text = ('%.2f' % upm).rstrip ('0').rstrip ('.')
-            subelms = [u, E.Element ('beat-unit-dot'), pm] if dotted else [u, pm]
-            elems.append ((metro, subelms))
-        dir = addDirection (maat, elems, lev, gstaff, [], placement='above')
-        if num != 1 and num != 3: info ('in Q: numerator in %d/%d not supported' % (num, den))
-        qpm = 4. * num * upm / den
-        sound = E.Element ('sound'); sound.set ('tempo', '%.2f' % qpm)
-        addElem (dir, sound, lev + 1)
+            metro = E.Element("metronome")
+            u = E.Element("beat-unit")
+            u.text = s.typeMap.get(4 * den_not, "quarter")
+            pm = E.Element("per-minute")
+            pm.text = ("%.2f" % upm).rstrip("0").rstrip(".")
+            subelms = [u, E.Element("beat-unit-dot"), pm] if dotted else [u, pm]
+            elems.append((metro, subelms))
+        dir = addDirection(maat, elems, lev, gstaff, [], placement="above")
+        if num != 1 and num != 3:
+            info("in Q: numerator in %d/%d not supported" % (num, den))
+        qpm = 4.0 * num * upm / den
+        sound = E.Element("sound")
+        sound.set("tempo", "%.2f" % qpm)
+        addElem(dir, sound, lev + 1)
 
-    def mkBarline (s, maat, loc, lev, style='', dir='', ending=''):
-        b = E.Element ('barline', location=loc)
+    def mkBarline(s, maat, loc, lev, style="", dir="", ending=""):
+        b = E.Element("barline", location=loc)
         if style:
-            addElemT (b, 'bar-style', style, lev + 1)
-        if s.curVolta:    # first stop a current volta
-            end = E.Element ('ending', number=s.curVolta, type='stop')
-            s.curVolta = ''
-            if loc == 'left':   # stop should always go to a right barline
-                bp = E.Element ('barline', location='right')
-                addElem (bp, end, lev + 1)
-                addElem (s.prevmsre, bp, lev)   # prevmsre has no right barline! (ending would have stopped there)
+            addElemT(b, "bar-style", style, lev + 1)
+        if s.curVolta:  # first stop a current volta
+            end = E.Element("ending", number=s.curVolta, type="stop")
+            s.curVolta = ""
+            if loc == "left":  # stop should always go to a right barline
+                bp = E.Element("barline", location="right")
+                addElem(bp, end, lev + 1)
+                addElem(
+                    s.prevmsre, bp, lev
+                )  # prevmsre has no right barline! (ending would have stopped there)
             else:
-                addElem (b, end, lev + 1)
+                addElem(b, end, lev + 1)
         if ending:
-            ending = ending.replace ('-',',')   # MusicXML only accepts comma's
-            endtxt = ''
-            if ending.startswith ('"'):     # ending is a quoted string
-                endtxt = ending.strip ('"')
-                ending = '33'               # any number that is not likely to occur elsewhere
-            end = E.Element ('ending', number=ending, type='start')
-            if endtxt: end.text = endtxt    # text appears in score in stead of number attribute
-            addElem (b, end, lev + 1)
+            ending = ending.replace("-", ",")  # MusicXML only accepts comma's
+            endtxt = ""
+            if ending.startswith('"'):  # ending is a quoted string
+                endtxt = ending.strip('"')
+                ending = "33"  # any number that is not likely to occur elsewhere
+            end = E.Element("ending", number=ending, type="start")
+            if endtxt:
+                end.text = endtxt  # text appears in score in stead of number attribute
+            addElem(b, end, lev + 1)
             s.curVolta = ending
         if dir:
-            r = E.Element ('repeat', direction=dir)
-            addElem (b, r, lev + 1)
-        addElem (maat, b, lev)
+            r = E.Element("repeat", direction=dir)
+            addElem(b, r, lev + 1)
+        addElem(maat, b, lev)
 
-    def doChordSym (s, maat, sym, lev):
-        alterMap = {'#':'1','=':'0','b':'-1'}
+    def doChordSym(s, maat, sym, lev):
+        alterMap = {"#": "1", "=": "0", "b": "-1"}
         rnt = sym.root.t
-        chord = E.Element ('harmony')
-        addElem (maat, chord, lev)
-        root = E.Element ('root')
-        addElem (chord, root, lev + 1)
-        addElemT (root, 'root-step', rnt[0], lev + 2)
-        if len (rnt) == 2: addElemT (root, 'root-alter', alterMap [rnt[1]], lev + 2)
-        kind = s.chordTab.get (sym.kind.t[0], 'major') if sym.kind.t else 'major'
-        addElemT (chord, 'kind', kind, lev + 1)
-        if hasattr (sym, 'bass'):
+        chord = E.Element("harmony")
+        addElem(maat, chord, lev)
+        root = E.Element("root")
+        addElem(chord, root, lev + 1)
+        addElemT(root, "root-step", rnt[0], lev + 2)
+        if len(rnt) == 2:
+            addElemT(root, "root-alter", alterMap[rnt[1]], lev + 2)
+        kind = s.chordTab.get(sym.kind.t[0], "major") if sym.kind.t else "major"
+        addElemT(chord, "kind", kind, lev + 1)
+        if hasattr(sym, "bass"):
             bnt = sym.bass.t
-            bass = E.Element ('bass')
-            addElem (chord, bass, lev + 1)
-            addElemT (bass, 'bass-step', bnt[0], lev + 2)
-            if len (bnt) == 2: addElemT (bass, 'bass-alter', alterMap [bnt[1]], lev + 2)
-        degs = getattr (sym, 'degree', '')
+            bass = E.Element("bass")
+            addElem(chord, bass, lev + 1)
+            addElemT(bass, "bass-step", bnt[0], lev + 2)
+            if len(bnt) == 2:
+                addElemT(bass, "bass-alter", alterMap[bnt[1]], lev + 2)
+        degs = getattr(sym, "degree", "")
         if degs:
-            if type (degs) != list_type: degs = [degs]
+            if type(degs) != list_type:
+                degs = [degs]
             for deg in degs:
                 deg = deg.t[0]
-                if deg[0] == '#':   alter = '1';  deg = deg[1:]
-                elif deg[0] == 'b': alter = '-1'; deg = deg[1:]
-                else:               alter = '0';  deg = deg
-                degree = E.Element ('degree')
-                addElem (chord, degree, lev + 1)
-                addElemT (degree, 'degree-value', deg, lev + 2)
-                addElemT (degree, 'degree-alter', alter, lev + 2)
-                addElemT (degree, 'degree-type', 'add', lev + 2)
+                if deg[0] == "#":
+                    alter = "1"
+                    deg = deg[1:]
+                elif deg[0] == "b":
+                    alter = "-1"
+                    deg = deg[1:]
+                else:
+                    alter = "0"
+                    deg = deg
+                degree = E.Element("degree")
+                addElem(chord, degree, lev + 1)
+                addElemT(degree, "degree-value", deg, lev + 2)
+                addElemT(degree, "degree-alter", alter, lev + 2)
+                addElemT(degree, "degree-type", "add", lev + 2)
 
-    def mkMeasure (s, i, t, lev, fieldmap={}):
+    def mkMeasure(s, i, t, lev, fieldmap={}):
         s.msreAlts = {}
         s.ntup, s.trem, s.intrem = -1, 0, 0
-        s.acciatura = 0 # next grace element gets acciatura attribute
-        s.rbStop = 0    # sluit een open volta aan het eind van de maat
+        s.acciatura = 0  # next grace element gets acciatura attribute
+        s.rbStop = 0  # sluit een open volta aan het eind van de maat
         overlay = 0
-        maat = E.Element ('measure', number = str(i))
-        if fieldmap: s.doFields (maat, fieldmap, lev + 1)
-        if s.linebrk:   # there was a line break in the previous measure
-            e = E.Element ('print')
-            e.set ('new-system', 'yes')
-            addElem (maat, e, lev + 1)
+        maat = E.Element("measure", number=str(i))
+        if fieldmap:
+            s.doFields(maat, fieldmap, lev + 1)
+        if s.linebrk:  # there was a line break in the previous measure
+            e = E.Element("print")
+            e.set("new-system", "yes")
+            addElem(maat, e, lev + 1)
             s.linebrk = 0
-        for it, x in enumerate (t):
-            if x.name == 'note' or x.name == 'rest':
-                if x.dur.t[0] == 0:  # a leading zero was used for stemmless in abcm2ps, we only support !stemless!
-                    x.dur.t = tuple ([1, x.dur.t[1]])
-                note = s.mkNote (x, lev + 1)
-                addElem (maat, note, lev + 1)
-            elif x.name == 'lbar':
+        for it, x in enumerate(t):
+            if x.name == "note" or x.name == "rest":
+                if (
+                    x.dur.t[0] == 0
+                ):  # a leading zero was used for stemmless in abcm2ps, we only support !stemless!
+                    x.dur.t = tuple([1, x.dur.t[1]])
+                note = s.mkNote(x, lev + 1)
+                addElem(maat, note, lev + 1)
+            elif x.name == "lbar":
                 bar = x.t[0]
-                if bar == '|' or bar == '[|': pass # skip redundant bar
-                elif ':' in bar:    # forward repeat
-                    volta = x.t[1] if len (x.t) == 2  else ''
-                    s.mkBarline (maat, 'left', lev + 1, style='heavy-light', dir='forward', ending=volta)
-                else:               # bar must be a volta number
-                    s.mkBarline (maat, 'left', lev + 1, ending=bar)
-            elif x.name == 'rbar':
+                if bar == "|" or bar == "[|":
+                    pass  # skip redundant bar
+                elif ":" in bar:  # forward repeat
+                    volta = x.t[1] if len(x.t) == 2 else ""
+                    s.mkBarline(
+                        maat,
+                        "left",
+                        lev + 1,
+                        style="heavy-light",
+                        dir="forward",
+                        ending=volta,
+                    )
+                else:  # bar must be a volta number
+                    s.mkBarline(maat, "left", lev + 1, ending=bar)
+            elif x.name == "rbar":
                 bar = x.t[0]
-                if bar == '.|':
-                    s.mkBarline (maat, 'right', lev + 1, style='dotted')
-                elif ':' in bar:  # backward repeat
-                    s.mkBarline (maat, 'right', lev + 1, style='light-heavy', dir='backward')
-                elif bar == '||':
-                    s.mkBarline (maat, 'right', lev + 1, style='light-light')
-                elif bar == '[|]' or bar == '[]':
-                    s.mkBarline (maat, 'right', lev + 1, style='none')
-                elif '[' in bar or ']' in bar:
-                    s.mkBarline (maat, 'right', lev + 1, style='light-heavy')
-                elif bar == '|' and s.rbStop:   # normale barline hoeft niet, behalve om een volta te stoppen
-                    s.mkBarline (maat, 'right', lev + 1, style='regular')
-                elif bar[0] == '&': overlay = 1
-            elif x.name == 'tup':
-                if   len (x.t) == 3: n, into, nts = x.t
-                elif len (x.t) == 2: n, into, nts = x.t + [0]
-                else:                n, into, nts = x.t[0], 0, 0
-                if into == 0: into = 3 if n in [2,4,8] else 2
-                if nts == 0: nts = n
-                s.tmnum, s.tmden, s.ntup = n, into, nts
-            elif x.name == 'deco':
-                s.staffDecos (x.t, maat, lev + 1)   # output staff decos, postpone note decos to next note
-            elif x.name == 'text':
-                pos, text = x.t[:2]
-                place = 'above' if pos == '^' else 'below'
-                words = E.Element ('words')
-                words.text = text
-                gstaff = s.gStaffNums.get (s.vid, 0)    # staff number of the current voice
-                addDirection (maat, words, lev + 1, gstaff, placement=place)
-            elif x.name == 'inline':
-                fieldtype, fieldval = x.t[0], ' '.join (x.t[1:])
-                s.doFields (maat, {fieldtype:fieldval}, lev + 1)
-            elif x.name == 'accia': s.acciatura = 1
-            elif x.name == 'linebrk':
-                s.supports_tag = 1
-                if it > 0 and t[it -1].name == 'lbar':  # we are at start of measure
-                    e = E.Element ('print')             # output linebreak now
-                    e.set ('new-system', 'yes')
-                    addElem (maat, e, lev + 1)
+                if bar == ".|":
+                    s.mkBarline(maat, "right", lev + 1, style="dotted")
+                elif ":" in bar:  # backward repeat
+                    s.mkBarline(
+                        maat, "right", lev + 1, style="light-heavy", dir="backward"
+                    )
+                elif bar == "||":
+                    s.mkBarline(maat, "right", lev + 1, style="light-light")
+                elif bar == "[|]" or bar == "[]":
+                    s.mkBarline(maat, "right", lev + 1, style="none")
+                elif "[" in bar or "]" in bar:
+                    s.mkBarline(maat, "right", lev + 1, style="light-heavy")
+                elif (
+                    bar == "|" and s.rbStop
+                ):  # normale barline hoeft niet, behalve om een volta te stoppen
+                    s.mkBarline(maat, "right", lev + 1, style="regular")
+                elif bar[0] == "&":
+                    overlay = 1
+            elif x.name == "tup":
+                if len(x.t) == 3:
+                    n, into, nts = x.t
+                elif len(x.t) == 2:
+                    n, into, nts = x.t + [0]
                 else:
-                    s.linebrk = 1   # output linebreak at start of next measure
-            elif x.name == 'chordsym':
-                s.doChordSym (maat, x, lev + 1)
-        s.stopBeams ()
+                    n, into, nts = x.t[0], 0, 0
+                if into == 0:
+                    into = 3 if n in [2, 4, 8] else 2
+                if nts == 0:
+                    nts = n
+                s.tmnum, s.tmden, s.ntup = n, into, nts
+            elif x.name == "deco":
+                s.staffDecos(
+                    x.t, maat, lev + 1
+                )  # output staff decos, postpone note decos to next note
+            elif x.name == "text":
+                pos, text = x.t[:2]
+                place = "above" if pos == "^" else "below"
+                words = E.Element("words")
+                words.text = text
+                gstaff = s.gStaffNums.get(s.vid, 0)  # staff number of the current voice
+                addDirection(maat, words, lev + 1, gstaff, placement=place)
+            elif x.name == "inline":
+                fieldtype, fieldval = x.t[0], " ".join(x.t[1:])
+                s.doFields(maat, {fieldtype: fieldval}, lev + 1)
+            elif x.name == "accia":
+                s.acciatura = 1
+            elif x.name == "linebrk":
+                s.supports_tag = 1
+                if it > 0 and t[it - 1].name == "lbar":  # we are at start of measure
+                    e = E.Element("print")  # output linebreak now
+                    e.set("new-system", "yes")
+                    addElem(maat, e, lev + 1)
+                else:
+                    s.linebrk = 1  # output linebreak at start of next measure
+            elif x.name == "chordsym":
+                s.doChordSym(maat, x, lev + 1)
+        s.stopBeams()
         s.prevmsre = maat
         return maat, overlay
 
-    def mkPart (s, maten, id, lev, attrs, nstaves, rOpt):
+    def mkPart(s, maten, id, lev, attrs, nstaves, rOpt):
         s.slurstack = {}
-        s.glisnum = 0;          # xml number attribute for glissandos
-        s.slidenum = 0;         # xml number attribute for slides
-        s.unitLcur = s.unitL    # set the default unit length at begin of each voice
-        s.curVolta = ''
+        s.glisnum = 0  # xml number attribute for glissandos
+        s.slidenum = 0  # xml number attribute for slides
+        s.unitLcur = s.unitL  # set the default unit length at begin of each voice
+        s.curVolta = ""
         s.lyrdash = {}
         s.linebrk = 0
-        s.midprg = ['', '', '', ''] # MIDI channel nr, program nr, volume, panning for the current part
-        s.gcue_on = 0           # reset cue note marker for each new voice
-        s.gtrans = 0            # reset octave transposition (by clef)
-        s.percVoice = 0         # 1 if percussion clef encountered
-        s.curClef = ''          # current abc clef (for percmap)
-        s.nostems = 0           # for the tab clef
+        s.midprg = [
+            "",
+            "",
+            "",
+            "",
+        ]  # MIDI channel nr, program nr, volume, panning for the current part
+        s.gcue_on = 0  # reset cue note marker for each new voice
+        s.gtrans = 0  # reset octave transposition (by clef)
+        s.percVoice = 0  # 1 if percussion clef encountered
+        s.curClef = ""  # current abc clef (for percmap)
+        s.nostems = 0  # for the tab clef
         s.tuning = s.tuningDef  # reset string tuning to default
-        part = E.Element ('part', id=id)
-        s.overlayVnum = 0       # overlay voice number to relate ties that extend from one overlayed measure to the next
-        gstaff = s.gStaffNums.get (s.vid, 0)    # staff number of the current voice
-        attrs_cpy = attrs.copy ()   # don't change attrs itself in next line
-        if gstaff == 1: attrs_cpy ['gstaff'] = nstaves  # make a grand staff
-        if 'perc' in attrs_cpy.get ('V', ''): del attrs_cpy ['K'] # remove key from percussion voice
-        msre, overlay = s.mkMeasure (1, maten[0], lev + 1, attrs_cpy)
-        addElem (part, msre, lev + 1)
-        for i, maat in enumerate (maten[1:]):
+        part = E.Element("part", id=id)
+        s.overlayVnum = 0  # overlay voice number to relate ties that extend from one overlayed measure to the next
+        gstaff = s.gStaffNums.get(s.vid, 0)  # staff number of the current voice
+        attrs_cpy = attrs.copy()  # don't change attrs itself in next line
+        if gstaff == 1:
+            attrs_cpy["gstaff"] = nstaves  # make a grand staff
+        if "perc" in attrs_cpy.get("V", ""):
+            del attrs_cpy["K"]  # remove key from percussion voice
+        msre, overlay = s.mkMeasure(1, maten[0], lev + 1, attrs_cpy)
+        addElem(part, msre, lev + 1)
+        for i, maat in enumerate(maten[1:]):
             s.overlayVnum = s.overlayVnum + 1 if overlay else 0
-            msre, next_overlay = s.mkMeasure (i+2, maat, lev + 1)
-            if overlay: mergePartMeasure (part, msre, s.overlayVnum, rOpt)
-            else:       addElem (part, msre, lev + 1)
+            msre, next_overlay = s.mkMeasure(i + 2, maat, lev + 1)
+            if overlay:
+                mergePartMeasure(part, msre, s.overlayVnum, rOpt)
+            else:
+                addElem(part, msre, lev + 1)
             overlay = next_overlay
         return part
 
-    def mkScorePart (s, id, vids_p, partAttr, lev):
-        def mkInst (instId, vid, midchan, midprog, midnot, vol, pan, lev):
-            si = E.Element ('score-instrument', id=instId)
-            pnm = partAttr.get (vid, [''])[0]   # part name if present
-            addElemT (si, 'instrument-name', pnm or 'dummy', lev + 2)   # MuseScore needs a name
-            mi = E.Element ('midi-instrument', id=instId)
-            if midchan: addElemT (mi, 'midi-channel', midchan, lev + 2)
-            if midprog: addElemT (mi, 'midi-program', str (int (midprog) + 1), lev + 2) # compatible with abc2midi
-            if midnot:  addElemT (mi, 'midi-unpitched', str (int (midnot) + 1), lev + 2)
-            if vol: addElemT (mi, 'volume', '%.2f' % (int (vol) / 1.27), lev + 2)
-            if pan: addElemT (mi, 'pan', '%.2f' % (int (pan) / 127. * 180 - 90), lev + 2)
+    def mkScorePart(s, id, vids_p, partAttr, lev):
+        def mkInst(instId, vid, midchan, midprog, midnot, vol, pan, lev):
+            si = E.Element("score-instrument", id=instId)
+            pnm = partAttr.get(vid, [""])[0]  # part name if present
+            addElemT(
+                si, "instrument-name", pnm or "dummy", lev + 2
+            )  # MuseScore needs a name
+            mi = E.Element("midi-instrument", id=instId)
+            if midchan:
+                addElemT(mi, "midi-channel", midchan, lev + 2)
+            if midprog:
+                addElemT(
+                    mi, "midi-program", str(int(midprog) + 1), lev + 2
+                )  # compatible with abc2midi
+            if midnot:
+                addElemT(mi, "midi-unpitched", str(int(midnot) + 1), lev + 2)
+            if vol:
+                addElemT(mi, "volume", "%.2f" % (int(vol) / 1.27), lev + 2)
+            if pan:
+                addElemT(mi, "pan", "%.2f" % (int(pan) / 127.0 * 180 - 90), lev + 2)
             return (si, mi)
-        naam, subnm, midprg = partAttr [id]
-        sp = E.Element ('score-part', id='P'+id)
-        nm = E.Element ('part-name')
+
+        naam, subnm, midprg = partAttr[id]
+        sp = E.Element("score-part", id="P" + id)
+        nm = E.Element("part-name")
         nm.text = naam
-        addElem (sp, nm, lev + 1)
-        snm = E.Element ('part-abbreviation')
+        addElem(sp, nm, lev + 1)
+        snm = E.Element("part-abbreviation")
         snm.text = subnm
-        if subnm: addElem (sp, snm, lev + 1)    # only add if subname was given
+        if subnm:
+            addElem(sp, snm, lev + 1)  # only add if subname was given
         inst = []
-        for instId, (pid, vid, chan, midprg, vol, pan) in sorted (s.midiInst.items ()):
-            midprg, midnot = ('0', midprg) if chan == '10' else (midprg, '')
-            if pid == id: inst.append (mkInst (instId, vid, chan, midprg, midnot, vol, pan, lev))
-        for si, mi in inst: addElem (sp, si, lev + 1)
-        for si, mi in inst: addElem (sp, mi, lev + 1)
+        for instId, (pid, vid, chan, midprg, vol, pan) in sorted(s.midiInst.items()):
+            midprg, midnot = ("0", midprg) if chan == "10" else (midprg, "")
+            if pid == id:
+                inst.append(mkInst(instId, vid, chan, midprg, midnot, vol, pan, lev))
+        for si, mi in inst:
+            addElem(sp, si, lev + 1)
+        for si, mi in inst:
+            addElem(sp, mi, lev + 1)
         return sp
 
-    def mkPartlist (s, vids, partAttr, lev):
-        def addPartGroup (sym, num):
-            pg = E.Element ('part-group', number=str (num), type='start')
-            addElem (partlist, pg, lev + 1)
-            addElemT (pg, 'group-symbol', sym, lev + 2)
-            addElemT (pg, 'group-barline', 'yes', lev + 2)
-        partlist = E.Element ('part-list')
-        g_num = 0       # xml group number
-        for g in (s.groups or vids):    # brace/bracket or abc_voice_id
-            if   g == '[': g_num += 1; addPartGroup ('bracket', g_num)
-            elif g == '{': g_num += 1; addPartGroup ('brace', g_num)
-            elif g in '}]':
-                pg = E.Element ('part-group', number=str (g_num), type='stop')
-                addElem (partlist, pg, lev + 1)
+    def mkPartlist(s, vids, partAttr, lev):
+        def addPartGroup(sym, num):
+            pg = E.Element("part-group", number=str(num), type="start")
+            addElem(partlist, pg, lev + 1)
+            addElemT(pg, "group-symbol", sym, lev + 2)
+            addElemT(pg, "group-barline", "yes", lev + 2)
+
+        partlist = E.Element("part-list")
+        g_num = 0  # xml group number
+        for g in s.groups or vids:  # brace/bracket or abc_voice_id
+            if g == "[":
+                g_num += 1
+                addPartGroup("bracket", g_num)
+            elif g == "{":
+                g_num += 1
+                addPartGroup("brace", g_num)
+            elif g in "}]":
+                pg = E.Element("part-group", number=str(g_num), type="stop")
+                addElem(partlist, pg, lev + 1)
                 g_num -= 1
-            else:   # g = abc_voice_id
-                if g not in vids: continue  # error in %%score
-                sp = s.mkScorePart (g, vids, partAttr, lev + 1)
-                addElem (partlist, sp, lev + 1)
+            else:  # g = abc_voice_id
+                if g not in vids:
+                    continue  # error in %%score
+                sp = s.mkScorePart(g, vids, partAttr, lev + 1)
+                addElem(partlist, sp, lev + 1)
         return partlist
 
-    def doField_I (s, type, x, instDir, addTrans):
-        def instChange (midchan, midprog):  # instDir -> doFields
-            if midchan and midchan != s.midprg [0]: instDir ('midi-channel', midchan, 'chan: %s')
-            if midprog and midprog != s.midprg [1]: instDir ('midi-program', str (int (midprog) + 1), 'prog: %s')
-        def readPfmt (x, n): # read ABC page formatting constant
-            if not s.pageFmtAbc: s.pageFmtAbc = s.pageFmtDef    # set the default values on first change
-            ro = re.search (r'[^.\d]*([\d.]+)\s*(cm|in|pt)?', x)    # float followed by unit
+    def doField_I(s, type, x, instDir, addTrans):
+        def instChange(midchan, midprog):  # instDir -> doFields
+            if midchan and midchan != s.midprg[0]:
+                instDir("midi-channel", midchan, "chan: %s")
+            if midprog and midprog != s.midprg[1]:
+                instDir("midi-program", str(int(midprog) + 1), "prog: %s")
+
+        def readPfmt(x, n):  # read ABC page formatting constant
+            if not s.pageFmtAbc:
+                s.pageFmtAbc = s.pageFmtDef  # set the default values on first change
+            ro = re.search(
+                r"[^.\d]*([\d.]+)\s*(cm|in|pt)?", x
+            )  # float followed by unit
             if ro:
-                x, unit = ro.groups ()  # unit == None when not present
-                u = {'cm':10., 'in':25.4, 'pt':25.4/72} [unit] if unit else 1.
-                s.pageFmtAbc [n] = float (x) * u   # convert ABC values to millimeters
-            else: info ('error in page format: %s' % x)
-        def readPercMap (x):    # parse I:percmap <abc_note> <step> <MIDI> <notehead>
-            def getMidNum (sndnm):          # find midi number of GM drum sound name
-                pnms = sndnm.split ('-')    # sound name parts (from I:percmap)
-                ps = s.percsnd [:]          # copy of the instruments
-                _f = lambda ip, xs, pnm: ip < len (xs) and xs[ip].find (pnm) > -1   # part xs[ip] and pnm match
-                for ip, pnm in enumerate (pnms):    # match all percmap sound name parts
-                    ps = [(nm, mnum) for nm, mnum in ps if _f (ip, nm.split ('-'), pnm) ]   # filter instruments
-                    if len (ps) <= 1: break # no match or one instrument left
-                if len (ps) == 0: info ('drum sound: %s not found' % sndnm); return '38'
-                return ps [0][1]            # midi number of (first) instrument found
-            def midiVal (acc, step, oct):   # abc note -> midi note number
-                oct = (4 if step.upper() == step else 5) + int (oct)
-                return oct * 12 + [0,2,4,5,7,9,11]['CDEFGAB'.index (step.upper())] + {'^':1,'_':-1,'=':0}.get (acc, 0) + 12
-            p0, p1, p2, p3, p4 = abc_percmap.parseString (x).asList ()  # percmap, abc-note, display-step, midi, note-head
-            acc, astep, aoct = p1
-            nstep, noct = (astep, aoct) if p2 == '*' else p2
-            if p3 == '*':                           midi = str (midiVal (acc, astep, aoct))
-            elif isinstance (p3, list_type):        midi = str (midiVal (p3[0], p3[1], p3[2]))
-            elif isinstance (p3, int_type):         midi = str (p3)
-            else:                                   midi = getMidNum (p3.lower ())
-            head = re.sub (r'(.)-([^x])', r'\1 \2', p4) # convert abc note head names to xml
-            s.percMap [(s.pid, acc + astep, aoct)] = (nstep, noct, midi, head)
-        if x.startswith ('score') or x.startswith ('staves'):
-            s.staveDefs += [x]          # collect all voice mappings
-        elif x.startswith ('staffwidth'): info ('skipped I-field: %s' % x)
-        elif x.startswith ('staff'):    # set new staff number of the current voice
-            r1 = re.search (r'staff *([+-]?)(\d)', x)
-            if r1:
-                sign = r1.group (1)
-                num = int (r1.group (2))
-                gstaff = s.gStaffNums.get (s.vid, 0)    # staff number of the current voice
-                if sign:                                # relative staff number
-                    num = (sign == '-') and gstaff - num or gstaff + num
-                else:                                   # absolute abc staff number
-                    try: vabc = s.staves [num - 1][0]   # vid of (first voice of) abc-staff num
-                    except: vabc = 0; info ('abc staff %s does not exist' % num)
-                    num = s.gStaffNumsOrg.get (vabc, 0) # xml staff number of abc-staff num
-                if gstaff and num > 0 and num <= s.gNstaves [s.vid]:
-                    s.gStaffNums [s.vid] = num
-                else: info ('could not relocate to staff: %s' % r1.group ())
-            else: info ('not a valid staff redirection: %s' % x)
-        elif x.startswith ('scale'): readPfmt (x, 0)
-        elif x.startswith ('pageheight'): readPfmt (x, 1)
-        elif x.startswith ('pagewidth'): readPfmt (x, 2)
-        elif x.startswith ('leftmargin'): readPfmt (x, 3)
-        elif x.startswith ('rightmargin'): readPfmt (x, 4)
-        elif x.startswith ('topmargin'): readPfmt (x, 5)
-        elif x.startswith ('botmargin'): readPfmt (x, 6)
-        elif x.startswith ('MIDI') or x.startswith ('midi'):
-            r1 = re.search (r'program *(\d*) +(\d+)', x)
-            r2 = re.search (r'channel *(\d+)', x)
-            r3 = re.search (r"drummap\s+([_=^]*)([A-Ga-g])([,']*)\s+(\d+)", x)
-            r4 = re.search (r'control *(\d+) +(\d+)', x)
-            ch_nw, prg_nw, vol_nw, pan_nw = '', '', '', ''
-            if r1: ch_nw, prg_nw = r1.groups () # channel nr or '', program nr
-            if r2: ch_nw = r2.group (1)         # channel nr only
-            if r4:
-                cnum, cval = r4.groups ()       # controller number, controller value
-                if cnum == '7': vol_nw = cval
-                if cnum == '10': pan_nw = cval
-            if r1 or r2 or r4:
-                ch  = ch_nw  or s.midprg [0]
-                prg = prg_nw or s.midprg [1]
-                vol = vol_nw or s.midprg [2]
-                pan = pan_nw or s.midprg [3]
-                instId = 'I%s-%s' % (s.pid, s.vid)              # only look for real instruments, no percussion
-                if instId in s.midiInst: instChange (ch, prg)   # instChance -> doFields
-                s.midprg = [ch, prg, vol, pan]  # mknote: new instrument -> s.midiInst
-            if r3:      # translate drummap to percmap
-                acc, step, oct, midi = r3.groups ()
-                oct = -len (oct) if ',' in x else len (oct)
-                notehead = 'x' if acc == '^' else 'circle-x' if acc == '_' else 'normal'
-                s.percMap [(s.pid, acc + step, oct)] = (step, oct, midi, notehead)
-            r = re.search (r'transpose[^-\d]*(-?\d+)', x)
-            if r: addTrans (r.group (1))        # addTrans -> doFields
-        elif x.startswith ('percmap'): readPercMap (x); s.pMapFound = 1
-        else: info ('skipped I-field: %s' % x)
-
-    def parseStaveDef (s, vdefs):
-        for vid in vdefs: s.vcepid [vid] = vid              # default: each voice becomes an xml part
-        if not s.staveDefs: return vdefs
-        for x in s.staveDefs [1:]: info ('%%%%%s dropped, multiple stave mappings not supported' % x)
-        x = s.staveDefs [0]                                 # only the first %%score is honoured
-        score = abc_scoredef.parseString (x) [0]
-        f = lambda x: type (x) == uni_type and [x] or x
-        s.staves = lmap (f, mkStaves (score, vdefs))        # [[vid] for each staff]
-        s.grands = lmap (f, mkGrand (score, vdefs))         # [staff-id], staff-id == [vid][0]
-        s.groups = mkGroups (score)
-        vce_groups = [vids for vids in s.staves if len (vids) > 1]  # all voice groups
-        d = {}                                              # for each voice group: map first voice id -> all merged voice ids
-        for vgr in vce_groups: d [vgr[0]] = vgr
-        for gstaff in s.grands:                             # for all grand staves
-            if len (gstaff) == 1: continue                  # skip single parts
-            for v, stf_num in zip (gstaff, range (1, len (gstaff) + 1)):
-                for vx in d.get (v, [v]):                   # allocate staff numbers
-                    s.gStaffNums [vx] = stf_num             # to all constituant voices
-                    s.gNstaves [vx] = len (gstaff)          # also remember total number of staves
-        s.gStaffNumsOrg = s.gStaffNums.copy ()              # keep original allocation for abc -> xml staff map
-        for xmlpart in s.grands:
-            pid = xmlpart [0]                               # part id == first staff id == first voice id
-            vces = [v for stf in xmlpart for v in d.get (stf, [stf])]
-            for v in vces: s.vcepid [v] = pid
-        return vdefs
-
-    def voiceNamesAndMaps (s, ps):  # get voice names and mappings
-        vdefs = {}
-        for vid, vcedef, vce in ps: # vcedef == emtpy or first pObj == voice definition
-            pname, psubnm = '', ''  # part name and abbreviation
-            if not vcedef:          # simple abc without voice definitions
-                vdefs [vid] =  pname, psubnm, ''
-            else:                   # abc with voice definitions
-                if vid != vcedef.t[1]: info ('voice ids unequal: %s (reg-ex) != %s (grammar)' % (vid, vcedef.t[1]))
-                rn = re.search (r'(?:name|nm)="([^"]*)"', vcedef.t[2])
-                if rn: pname = rn.group (1)
-                rn = re.search (r'(?:subname|snm|sname)="([^"]*)"', vcedef.t[2])
-                if rn: psubnm = rn.group (1)
-                vcedef.t[2] = vcedef.t[2].replace ('"%s"' % pname, '""').replace ('"%s"' % psubnm, '""')   # clear voice name to avoid false clef matches later on
-                vdefs [vid] =  pname, psubnm, vcedef.t[2]
-            xs = [pObj.t[1] for maat in vce for pObj in maat if pObj.name == 'inline']  # all inline statements in vce
-            s.staveDefs += [x.replace ('%5d',']') for x in xs if x.startswith ('score') or x.startswith ('staves')] # filter %%score and %%staves
-        return vdefs
-
-    def doHeaderField (s, fld, attrmap):
-        type, value = fld.t[0], fld.t[1].replace ('%5d',']')    # restore closing brackets (see splitHeaderVoices)
-        if not value:    # skip empty field
-            return
-        if type == 'M':
-            attrmap [type] = value
-        elif type == 'L':
-            try: s.unitL = lmap (int, fld.t[1].split ('/'))
-            except:
-                info ('illegal unit length:%s, 1/8 assumed' % fld.t[1])
-                s.unitL = 1,8
-            if len (s.unitL) == 1 or s.unitL[1] not in s.typeMap:
-                info ('L:%s is not allowed, 1/8 assumed' % fld.t[1])
-                s.unitL = 1,8
-        elif type == 'K':
-            attrmap[type] = value
-        elif type == 'T':
-            s.title = s.title + '\n' + value if s.title else value
-        elif type == 'U':
-            sym = fld.t[2].strip ('!+')
-            s.usrSyms [value] = sym
-        elif type == 'I':
-            s.doField_I (type, value, lambda x,y,z:0, lambda x:0)
-        elif type == 'Q':
-            attrmap[type] = value
-        elif type in 'CRZNOAGHBDFSP':           # part maps are treated as meta data
-            type = s.metaMap.get (type, type)   # respect the (user defined --meta) mapping of various ABC fields to XML meta data types
-            c = s.metadata.get (type, '')
-            s.metadata [type] = c + '\n' + value if c else value    # concatenate multiple info fields with new line as separator
-        else:
-            info ('skipped header: %s' % fld)
-
-    def mkIdentification (s, score, lev):
-        if s.title:
-            xs = s.title.split ('\n')   # the first T: line goes to work-title
-            ys = '\n'.join (xs [1:])    # place subsequent T: lines into work-number
-            w = E.Element ('work')
-            addElem (score, w, lev + 1)
-            if ys: addElemT (w, 'work-number', ys, lev + 2)
-            addElemT (w, 'work-title', xs[0], lev + 2)
-        ident = E.Element ('identification')
-        addElem (score, ident, lev + 1)
-        for mtype, mval in s.metadata.items ():
-            if mtype in s.metaTypes and mtype != 'rights':    # all metaTypes are MusicXML creator types
-                c = E.Element ('creator', type=mtype)
-                c.text = mval
-                addElem (ident, c, lev + 2)
-        if 'rights' in s.metadata:
-            c = addElemT (ident, 'rights', s.metadata ['rights'], lev + 2)
-        encoding = E.Element ('encoding')
-        addElem (ident, encoding, lev + 2)
-        encoder = E.Element ('encoder')
-        encoder.text = 'abc2xml version %d' % VERSION
-        addElem (encoding, encoder, lev + 3)
-        if s.supports_tag:  # avoids interference of auto-flowing and explicit linebreaks
-            suports = E.Element ('supports', attribute="new-system", element="print", type="yes", value="yes")
-            addElem (encoding, suports, lev + 3)
-        encodingDate = E.Element ('encoding-date')
-        encodingDate.text = str (datetime.date.today ())
-        addElem (encoding, encodingDate, lev + 3)
-        s.addMeta (ident, lev + 2)
-
-    def mkDefaults (s, score, lev):
-        if s.pageFmtCmd: s.pageFmtAbc = s.pageFmtCmd
-        if not s.pageFmtAbc: return # do not output the defaults if none is desired
-        abcScale, h, w, l, r, t, b = s.pageFmtAbc
-        space = abcScale * 2.117    # 2.117 = 6pt = space between staff lines for scale = 1.0 in abcm2ps
-        mils = 4 * space    # staff height in millimeters
-        scale = 40. / mils  # tenth's per millimeter
-        dflts = E.Element ('defaults')
-        addElem (score, dflts, lev)
-        scaling = E.Element ('scaling')
-        addElem (dflts, scaling, lev + 1)
-        addElemT (scaling, 'millimeters', '%g' % mils, lev + 2)
-        addElemT (scaling, 'tenths', '40', lev + 2)
-        layout = E.Element ('page-layout')
-        addElem (dflts, layout, lev + 1)
-        addElemT (layout, 'page-height', '%g' % (h * scale), lev + 2)
-        addElemT (layout, 'page-width', '%g' % (w * scale), lev + 2)
-        margins = E.Element ('page-margins', type='both')
-        addElem (layout, margins, lev + 2)
-        addElemT (margins, 'left-margin', '%g' % (l * scale), lev + 3)
-        addElemT (margins, 'right-margin', '%g' % (r * scale), lev + 3)
-        addElemT (margins, 'top-margin', '%g' % (t * scale), lev + 3)
-        addElemT (margins, 'bottom-margin', '%g' % (b * scale), lev + 3)
-
-    def addMeta (s, parent, lev):
-        misc = E.Element ('miscellaneous')
-        mf = 0
-        for mtype, mval in sorted (s.metadata.items ()):
-            if mtype == 'S':
-                addElemT (parent, 'source', mval, lev)
-            elif mtype in s.metaTypes: continue  # mapped meta data has already been output (in creator elements)
+                x, unit = ro.groups()  # unit == None when not present
+                u = {"cm": 10.0, "in": 25.4, "pt": 25.4 / 72}[unit] if unit else 1.0
+                s.pageFmtAbc[n] = float(x) * u  # convert ABC values to millimeters
             else:
-                mf = E.Element ('miscellaneous-field', name=s.metaTab [mtype])
-                mf.text = mval
-                addElem (misc, mf, lev + 1)
-        if mf != 0: addElem (parent, misc, lev)
+                info("error in page format: %s" % x)
 
-    def parse (s, abc_string, rOpt=False, bOpt=False, fOpt=False):
-        abctext = abc_string.replace ('[I:staff ','[I:staff')  # avoid false beam breaks
-        s.reset (fOpt)
-        header, voices = splitHeaderVoices (abctext)
+        def readPercMap(x):  # parse I:percmap <abc_note> <step> <MIDI> <notehead>
+            def getMidNum(sndnm):  # find midi number of GM drum sound name
+                pnms = sndnm.split("-")  # sound name parts (from I:percmap)
+                ps = s.percsnd[:]  # copy of the instruments
+                _f = (
+                    lambda ip, xs, pnm: ip < len(xs) and xs[ip].find(pnm) > -1
+                )  # part xs[ip] and pnm match
+                for ip, pnm in enumerate(pnms):  # match all percmap sound name parts
+                    ps = [
+                        (nm, mnum) for nm, mnum in ps if _f(ip, nm.split("-"), pnm)
+                    ]  # filter instruments
+                    if len(ps) <= 1:
+                        break  # no match or one instrument left
+                if len(ps) == 0:
+                    info("drum sound: %s not found" % sndnm)
+                    return "38"
+                return ps[0][1]  # midi number of (first) instrument found
+
+            def midiVal(acc, step, oct):  # abc note -> midi note number
+                oct = (4 if step.upper() == step else 5) + int(oct)
+                return (
+                    oct * 12
+                    + [0, 2, 4, 5, 7, 9, 11]["CDEFGAB".index(step.upper())]
+                    + {"^": 1, "_": -1, "=": 0}.get(acc, 0)
+                    + 12
+                )
+
+            p0, p1, p2, p3, p4 = abc_percmap.parseString(
+                x
+            ).asList()  # percmap, abc-note, display-step, midi, note-head
+            acc, astep, aoct = p1
+            nstep, noct = (astep, aoct) if p2 == "*" else p2
+            if p3 == "*":
+                midi = str(midiVal(acc, astep, aoct))
+            elif isinstance(p3, list_type):
+                midi = str(midiVal(p3[0], p3[1], p3[2]))
+            elif isinstance(p3, int_type):
+                midi = str(p3)
+            else:
+                midi = getMidNum(p3.lower())
+            head = re.sub(
+                r"(.)-([^x])", r"\1 \2", p4
+            )  # convert abc note head names to xml
+            s.percMap[(s.pid, acc + astep, aoct)] = (nstep, noct, midi, head)
+
+        if x.startswith("score") or x.startswith("staves"):
+            s.staveDefs += [x]  # collect all voice mappings
+        elif x.startswith("staffwidth"):
+            info("skipped I-field: %s" % x)
+        elif x.startswith("staff"):  # set new staff number of the current voice
+            r1 = re.search(r"staff *([+-]?)(\d)", x)
+            if r1:
+                sign = r1.group(1)
+                num = int(r1.group(2))
+                gstaff = s.gStaffNums.get(s.vid, 0)  # staff number of the current voice
+                if sign:  # relative staff number
+                    num = (sign == "-") and gstaff - num or gstaff + num
+                else:  # absolute abc staff number
+                    try:
+                        vabc = s.staves[num - 1][
+                            0
+                        ]  # vid of (first voice of) abc-staff num
+                    except:
+                        vabc = 0
+                        info("abc staff %s does not exist" % num)
+                    num = s.gStaffNumsOrg.get(
+                        vabc, 0
+                    )  # xml staff number of abc-staff num
+                if gstaff and num > 0 and num <= s.gNstaves[s.vid]:
+                    s.gStaffNums[s.vid] = num
+                else:
+                    info("could not relocate to staff: %s" % r1.group())
+            else:
+                info("not a valid staff redirection: %s" % x)
+        elif x.startswith("scale"):
+            readPfmt(x, 0)
+        elif x.startswith("pageheight"):
+            readPfmt(x, 1)
+        elif x.startswith("pagewidth"):
+            readPfmt(x, 2)
+        elif x.startswith("leftmargin"):
+            readPfmt(x, 3)
+        elif x.startswith("rightmargin"):
+            readPfmt(x, 4)
+        elif x.startswith("topmargin"):
+            readPfmt(x, 5)
+        elif x.startswith("botmargin"):
+            readPfmt(x, 6)
+        elif x.startswith("MIDI") or x.startswith("midi"):
+            r1 = re.search(r"program *(\d*) +(\d+)", x)
+            r2 = re.search(r"channel *(\d+)", x)
+            r3 = re.search(r"drummap\s+([_=^]*)([A-Ga-g])([,']*)\s+(\d+)", x)
+            r4 = re.search(r"control *(\d+) +(\d+)", x)
+            ch_nw, prg_nw, vol_nw, pan_nw = "", "", "", ""
+            if r1:
+                ch_nw, prg_nw = r1.groups()  # channel nr or '', program nr
+            if r2:
+                ch_nw = r2.group(1)  # channel nr only
+            if r4:
+                cnum, cval = r4.groups()  # controller number, controller value
+                if cnum == "7":
+                    vol_nw = cval
+                if cnum == "10":
+                    pan_nw = cval
+            if r1 or r2 or r4:
+                ch = ch_nw or s.midprg[0]
+                prg = prg_nw or s.midprg[1]
+                vol = vol_nw or s.midprg[2]
+                pan = pan_nw or s.midprg[3]
+                instId = "I%s-%s" % (
+                    s.pid,
+                    s.vid,
+                )  # only look for real instruments, no percussion
+                if instId in s.midiInst:
+                    instChange(ch, prg)  # instChance -> doFields
+                s.midprg = [ch, prg, vol, pan]  # mknote: new instrument -> s.midiInst
+            if r3:  # translate drummap to percmap
+                acc, step, oct, midi = r3.groups()
+                oct = -len(oct) if "," in x else len(oct)
+                notehead = "x" if acc == "^" else "circle-x" if acc == "_" else "normal"
+                s.percMap[(s.pid, acc + step, oct)] = (step, oct, midi, notehead)
+            r = re.search(r"transpose[^-\d]*(-?\d+)", x)
+            if r:
+                addTrans(r.group(1))  # addTrans -> doFields
+        elif x.startswith("percmap"):
+            readPercMap(x)
+            s.pMapFound = 1
+        else:
+            info("skipped I-field: %s" % x)
+
+    def parseStaveDef(s, vdefs):
+        for vid in vdefs:
+            s.vcepid[vid] = vid  # default: each voice becomes an xml part
+        if not s.staveDefs:
+            return vdefs
+        for x in s.staveDefs[1:]:
+            info("%%%%%s dropped, multiple stave mappings not supported" % x)
+        x = s.staveDefs[0]  # only the first %%score is honoured
+        score = abc_scoredef.parseString(x)[0]
+        f = lambda x: type(x) == uni_type and [x] or x
+        s.staves = lmap(f, mkStaves(score, vdefs))  # [[vid] for each staff]
+        s.grands = lmap(f, mkGrand(score, vdefs))  # [staff-id], staff-id == [vid][0]
+        s.groups = mkGroups(score)
+        vce_groups = [vids for vids in s.staves if len(vids) > 1]  # all voice groups
+        d = {}  # for each voice group: map first voice id -> all merged voice ids
+        for vgr in vce_groups:
+            d[vgr[0]] = vgr
+        for gstaff in s.grands:  # for all grand staves
+            if len(gstaff) == 1:
+                continue  # skip single parts
+            for v, stf_num in zip(gstaff, range(1, len(gstaff) + 1)):
+                for vx in d.get(v, [v]):  # allocate staff numbers
+                    s.gStaffNums[vx] = stf_num  # to all constituant voices
+                    s.gNstaves[vx] = len(gstaff)  # also remember total number of staves
+        s.gStaffNumsOrg = (
+            s.gStaffNums.copy()
+        )  # keep original allocation for abc -> xml staff map
+        for xmlpart in s.grands:
+            pid = xmlpart[0]  # part id == first staff id == first voice id
+            vces = [v for stf in xmlpart for v in d.get(stf, [stf])]
+            for v in vces:
+                s.vcepid[v] = pid
+        return vdefs
+
+    def voiceNamesAndMaps(s, ps):  # get voice names and mappings
+        vdefs = {}
+        for vid, vcedef, vce in ps:  # vcedef == emtpy or first pObj == voice definition
+            pname, psubnm = "", ""  # part name and abbreviation
+            if not vcedef:  # simple abc without voice definitions
+                vdefs[vid] = pname, psubnm, ""
+            else:  # abc with voice definitions
+                if vid != vcedef.t[1]:
+                    info(
+                        "voice ids unequal: %s (reg-ex) != %s (grammar)"
+                        % (vid, vcedef.t[1])
+                    )
+                rn = re.search(r'(?:name|nm)="([^"]*)"', vcedef.t[2])
+                if rn:
+                    pname = rn.group(1)
+                rn = re.search(r'(?:subname|snm|sname)="([^"]*)"', vcedef.t[2])
+                if rn:
+                    psubnm = rn.group(1)
+                vcedef.t[2] = (
+                    vcedef.t[2]
+                    .replace('"%s"' % pname, '""')
+                    .replace('"%s"' % psubnm, '""')
+                )  # clear voice name to avoid false clef matches later on
+                vdefs[vid] = pname, psubnm, vcedef.t[2]
+            xs = [
+                pObj.t[1] for maat in vce for pObj in maat if pObj.name == "inline"
+            ]  # all inline statements in vce
+            s.staveDefs += [
+                x.replace("%5d", "]")
+                for x in xs
+                if x.startswith("score") or x.startswith("staves")
+            ]  # filter %%score and %%staves
+        return vdefs
+
+    def doHeaderField(s, fld, attrmap):
+        type, value = fld.t[0], fld.t[1].replace(
+            "%5d", "]"
+        )  # restore closing brackets (see splitHeaderVoices)
+        if not value:  # skip empty field
+            return
+        if type == "M":
+            attrmap[type] = value
+        elif type == "L":
+            try:
+                s.unitL = lmap(int, fld.t[1].split("/"))
+            except:
+                info("illegal unit length:%s, 1/8 assumed" % fld.t[1])
+                s.unitL = 1, 8
+            if len(s.unitL) == 1 or s.unitL[1] not in s.typeMap:
+                info("L:%s is not allowed, 1/8 assumed" % fld.t[1])
+                s.unitL = 1, 8
+        elif type == "K":
+            attrmap[type] = value
+        elif type == "T":
+            s.title = s.title + "\n" + value if s.title else value
+        elif type == "U":
+            sym = fld.t[2].strip("!+")
+            s.usrSyms[value] = sym
+        elif type == "I":
+            s.doField_I(type, value, lambda x, y, z: 0, lambda x: 0)
+        elif type == "Q":
+            attrmap[type] = value
+        elif type in "CRZNOAGHBDFSP":  # part maps are treated as meta data
+            type = s.metaMap.get(
+                type, type
+            )  # respect the (user defined --meta) mapping of various ABC fields to XML meta data types
+            c = s.metadata.get(type, "")
+            s.metadata[type] = (
+                c + "\n" + value if c else value
+            )  # concatenate multiple info fields with new line as separator
+        else:
+            info("skipped header: %s" % fld)
+
+    def mkIdentification(s, score, lev):
+        if s.title:
+            xs = s.title.split("\n")  # the first T: line goes to work-title
+            ys = "\n".join(xs[1:])  # place subsequent T: lines into work-number
+            w = E.Element("work")
+            addElem(score, w, lev + 1)
+            if ys:
+                addElemT(w, "work-number", ys, lev + 2)
+            addElemT(w, "work-title", xs[0], lev + 2)
+        ident = E.Element("identification")
+        addElem(score, ident, lev + 1)
+        for mtype, mval in s.metadata.items():
+            if (
+                mtype in s.metaTypes and mtype != "rights"
+            ):  # all metaTypes are MusicXML creator types
+                c = E.Element("creator", type=mtype)
+                c.text = mval
+                addElem(ident, c, lev + 2)
+        if "rights" in s.metadata:
+            c = addElemT(ident, "rights", s.metadata["rights"], lev + 2)
+        encoding = E.Element("encoding")
+        addElem(ident, encoding, lev + 2)
+        encoder = E.Element("encoder")
+        encoder.text = "abc2xml version %d" % VERSION
+        addElem(encoding, encoder, lev + 3)
+        if (
+            s.supports_tag
+        ):  # avoids interference of auto-flowing and explicit linebreaks
+            suports = E.Element(
+                "supports",
+                attribute="new-system",
+                element="print",
+                type="yes",
+                value="yes",
+            )
+            addElem(encoding, suports, lev + 3)
+        encodingDate = E.Element("encoding-date")
+        encodingDate.text = str(datetime.date.today())
+        addElem(encoding, encodingDate, lev + 3)
+        s.addMeta(ident, lev + 2)
+
+    def mkDefaults(s, score, lev):
+        if s.pageFmtCmd:
+            s.pageFmtAbc = s.pageFmtCmd
+        if not s.pageFmtAbc:
+            return  # do not output the defaults if none is desired
+        abcScale, h, w, l, r, t, b = s.pageFmtAbc
+        space = (
+            abcScale * 2.117
+        )  # 2.117 = 6pt = space between staff lines for scale = 1.0 in abcm2ps
+        mils = 4 * space  # staff height in millimeters
+        scale = 40.0 / mils  # tenth's per millimeter
+        dflts = E.Element("defaults")
+        addElem(score, dflts, lev)
+        scaling = E.Element("scaling")
+        addElem(dflts, scaling, lev + 1)
+        addElemT(scaling, "millimeters", "%g" % mils, lev + 2)
+        addElemT(scaling, "tenths", "40", lev + 2)
+        layout = E.Element("page-layout")
+        addElem(dflts, layout, lev + 1)
+        addElemT(layout, "page-height", "%g" % (h * scale), lev + 2)
+        addElemT(layout, "page-width", "%g" % (w * scale), lev + 2)
+        margins = E.Element("page-margins", type="both")
+        addElem(layout, margins, lev + 2)
+        addElemT(margins, "left-margin", "%g" % (l * scale), lev + 3)
+        addElemT(margins, "right-margin", "%g" % (r * scale), lev + 3)
+        addElemT(margins, "top-margin", "%g" % (t * scale), lev + 3)
+        addElemT(margins, "bottom-margin", "%g" % (b * scale), lev + 3)
+
+    def addMeta(s, parent, lev):
+        misc = E.Element("miscellaneous")
+        mf = 0
+        for mtype, mval in sorted(s.metadata.items()):
+            if mtype == "S":
+                addElemT(parent, "source", mval, lev)
+            elif mtype in s.metaTypes:
+                continue  # mapped meta data has already been output (in creator elements)
+            else:
+                mf = E.Element("miscellaneous-field", name=s.metaTab[mtype])
+                mf.text = mval
+                addElem(misc, mf, lev + 1)
+        if mf != 0:
+            addElem(parent, misc, lev)
+
+    def parse(s, abc_string, rOpt=False, bOpt=False, fOpt=False):
+        abctext = abc_string.replace("[I:staff ", "[I:staff")  # avoid false beam breaks
+        s.reset(fOpt)
+        header, voices = splitHeaderVoices(abctext)
         ps = []
         try:
-            lbrk_insert = 0 if re.search (r'I:linebreak\s*([!$]|none)|I:continueall\s*(1|true)', header) else bOpt
-            hs = abc_header.parseString (header) if header else ''
+            lbrk_insert = (
+                0
+                if re.search(
+                    r"I:linebreak\s*([!$]|none)|I:continueall\s*(1|true)", header
+                )
+                else bOpt
+            )
+            hs = abc_header.parseString(header) if header else ""
             for id, voice in voices:
-                if lbrk_insert:                                 # insert linebreak at EOL
-                    r1 = re.compile (r'\[[wA-Z]:[^]]*\]')       # inline field
-                    has_abc = lambda x: r1.sub ('', x).strip () # empty if line only contains inline fields
-                    voice = '\n'.join ([balk.rstrip ('$!') + '$' if has_abc (balk) else balk for balk in voice.splitlines ()])
-                prevLeftBar = None      # previous voice ended with a left-bar symbol (double repeat)
-                s.orderChords = s.fOpt and ('tab' in voice [:200] or [x for x in hs if x.t[0] == 'K' and 'tab' in x.t[1]])
-                vce = abc_voice.parseString (voice).asList ()
-                lyr_notes = []          # remember notes between lyric blocks
-                for m in vce:           # all measures
-                    for e in m:         # all abc-elements
-                        if e.name == 'lyr_blk':         # -> e.objs is list of lyric lines
-                            lyr = [line.objs for line in e.objs]    # line.objs is listof syllables
-                            alignLyr (lyr_notes, lyr)   # put all syllables into corresponding notes
+                if lbrk_insert:  # insert linebreak at EOL
+                    r1 = re.compile(r"\[[wA-Z]:[^]]*\]")  # inline field
+                    has_abc = lambda x: r1.sub(
+                        "", x
+                    ).strip()  # empty if line only contains inline fields
+                    voice = "\n".join(
+                        [
+                            balk.rstrip("$!") + "$" if has_abc(balk) else balk
+                            for balk in voice.splitlines()
+                        ]
+                    )
+                prevLeftBar = (
+                    None  # previous voice ended with a left-bar symbol (double repeat)
+                )
+                s.orderChords = s.fOpt and (
+                    "tab" in voice[:200]
+                    or [x for x in hs if x.t[0] == "K" and "tab" in x.t[1]]
+                )
+                vce = abc_voice.parseString(voice).asList()
+                lyr_notes = []  # remember notes between lyric blocks
+                for m in vce:  # all measures
+                    for e in m:  # all abc-elements
+                        if e.name == "lyr_blk":  # -> e.objs is list of lyric lines
+                            lyr = [
+                                line.objs for line in e.objs
+                            ]  # line.objs is listof syllables
+                            alignLyr(
+                                lyr_notes, lyr
+                            )  # put all syllables into corresponding notes
                             lyr_notes = []
                         else:
-                            lyr_notes.append (e)
-                if not vce:             # empty voice, insert an inline field that will be rejected
-                    vce = [[pObj ('inline', ['I', 'empty voice'])]]
+                            lyr_notes.append(e)
+                if not vce:  # empty voice, insert an inline field that will be rejected
+                    vce = [[pObj("inline", ["I", "empty voice"])]]
                 if prevLeftBar:
-                    vce[0].insert (0, prevLeftBar)  # insert at begin of first measure
+                    vce[0].insert(0, prevLeftBar)  # insert at begin of first measure
                     prevLeftBar = None
-                if vce[-1] and vce[-1][-1].name == 'lbar':  # last measure ends with an lbar
+                if (
+                    vce[-1] and vce[-1][-1].name == "lbar"
+                ):  # last measure ends with an lbar
                     prevLeftBar = vce[-1][-1]
-                    if len (vce) > 1:   # vce should not become empty (-> exception when taking vcelyr [0][0])
-                        del vce[-1]     # lbar was the only element in measure vce[-1]
+                    if (
+                        len(vce) > 1
+                    ):  # vce should not become empty (-> exception when taking vcelyr [0][0])
+                        del vce[-1]  # lbar was the only element in measure vce[-1]
                 vcelyr = vce
-                elem1 = vcelyr [0][0]   # the first element of the first measure
-                if  elem1.name == 'inline'and elem1.t[0] == 'V':    # is a voice definition
-                    voicedef = elem1 
-                    del vcelyr [0][0]   # do not read voicedef twice
+                elem1 = vcelyr[0][0]  # the first element of the first measure
+                if (
+                    elem1.name == "inline" and elem1.t[0] == "V"
+                ):  # is a voice definition
+                    voicedef = elem1
+                    del vcelyr[0][0]  # do not read voicedef twice
                 else:
-                    voicedef = ''
-                ps.append ((id, voicedef, vcelyr))
+                    voicedef = ""
+                ps.append((id, voicedef, vcelyr))
         except ParseException as err:
-            if err.loc > 40:    # limit length of error message, compatible with markInputline
-                err.pstr = err.pstr [err.loc - 40: err.loc + 40]
+            if (
+                err.loc > 40
+            ):  # limit length of error message, compatible with markInputline
+                err.pstr = err.pstr[err.loc - 40 : err.loc + 40]
                 err.loc = 40
-            xs = err.line[err.col-1:]
-            info (err.line, warn=0)
-            info ((err.col-1) * '-' + '^', warn=0)
-            if   re.search (r'\[U:', xs):
-                info ('Error: illegal user defined symbol: %s' % xs[1:], warn=0)
-            elif re.search (r'\[[OAPZNGHRBDFSXTCIU]:', xs):
-                info ('Error: header-only field %s appears after K:' % xs[1:], warn=0)
+            xs = err.line[err.col - 1 :]
+            info(err.line, warn=0)
+            info((err.col - 1) * "-" + "^", warn=0)
+            if re.search(r"\[U:", xs):
+                info("Error: illegal user defined symbol: %s" % xs[1:], warn=0)
+            elif re.search(r"\[[OAPZNGHRBDFSXTCIU]:", xs):
+                info("Error: header-only field %s appears after K:" % xs[1:], warn=0)
             else:
-                info ('Syntax error at column %d' % err.col, warn=0)
+                info("Syntax error at column %d" % err.col, warn=0)
             raise
 
-        score = E.Element ('score-partwise')
-        attrmap = {'Div': str (s.divisions), 'K':'C treble', 'M':'4/4'}
+        score = E.Element("score-partwise")
+        attrmap = {"Div": str(s.divisions), "K": "C treble", "M": "4/4"}
         for res in hs:
-            if res.name == 'field':
-                s.doHeaderField (res, attrmap)
+            if res.name == "field":
+                s.doHeaderField(res, attrmap)
             else:
-                info ('unexpected header item: %s' % res)
+                info("unexpected header item: %s" % res)
 
-        vdefs = s.voiceNamesAndMaps (ps)
-        vdefs = s.parseStaveDef (vdefs)
+        vdefs = s.voiceNamesAndMaps(ps)
+        vdefs = s.parseStaveDef(vdefs)
 
         lev = 0
         vids, parts, partAttr = [], [], {}
-        s.strAlloc = stringAlloc ()
-        for vid, _, vce in ps:          # voice id, voice parse tree
-            pname, psubnm, voicedef = vdefs [vid]   # part name
-            attrmap ['V'] = voicedef    # abc text of first voice definition (after V:vid) or empty
-            pid = 'P%s' % vid           # let part id start with an alpha
-            s.vid = vid                 # avoid parameter passing, needed in mkNote for instrument id
-            s.pid = s.vcepid [s.vid]    # xml part-id for the current voice
-            s.gTime = (0, 0)            # reset time
-            s.strAlloc.beginZoek ()     # reset search index
-            part = s.mkPart (vce, pid, lev + 1, attrmap, s.gNstaves.get (vid, 0), rOpt)
-            if 'Q' in attrmap: del attrmap ['Q']    # header tempo only in first part
-            parts.append (part)
-            vids.append (vid)
-            partAttr [vid] = (pname, psubnm, s.midprg)
-            if s.midprg != ['', '', '', ''] and not s.percVoice:    # when a part has only rests
-                instId = 'I%s-%s' % (s.pid, s.vid)
-                if instId not in s.midiInst: s.midiInst [instId] = (s.pid, s.vid, s.midprg [0], s.midprg [1], s.midprg [2], s.midprg [3])
-        parts, vidsnew = mergeParts (parts, vids, s.staves, rOpt) # merge parts into staves as indicated by %%score
-        parts, vidsnew = mergeParts (parts, vidsnew, s.grands, rOpt, 1) # merge grand staves
-        reduceMids (parts, vidsnew, s.midiInst)
+        s.strAlloc = stringAlloc()
+        for vid, _, vce in ps:  # voice id, voice parse tree
+            pname, psubnm, voicedef = vdefs[vid]  # part name
+            attrmap["V"] = (
+                voicedef  # abc text of first voice definition (after V:vid) or empty
+            )
+            pid = "P%s" % vid  # let part id start with an alpha
+            s.vid = vid  # avoid parameter passing, needed in mkNote for instrument id
+            s.pid = s.vcepid[s.vid]  # xml part-id for the current voice
+            s.gTime = (0, 0)  # reset time
+            s.strAlloc.beginZoek()  # reset search index
+            part = s.mkPart(vce, pid, lev + 1, attrmap, s.gNstaves.get(vid, 0), rOpt)
+            if "Q" in attrmap:
+                del attrmap["Q"]  # header tempo only in first part
+            parts.append(part)
+            vids.append(vid)
+            partAttr[vid] = (pname, psubnm, s.midprg)
+            if (
+                s.midprg != ["", "", "", ""] and not s.percVoice
+            ):  # when a part has only rests
+                instId = "I%s-%s" % (s.pid, s.vid)
+                if instId not in s.midiInst:
+                    s.midiInst[instId] = (
+                        s.pid,
+                        s.vid,
+                        s.midprg[0],
+                        s.midprg[1],
+                        s.midprg[2],
+                        s.midprg[3],
+                    )
+        parts, vidsnew = mergeParts(
+            parts, vids, s.staves, rOpt
+        )  # merge parts into staves as indicated by %%score
+        parts, vidsnew = mergeParts(
+            parts, vidsnew, s.grands, rOpt, 1
+        )  # merge grand staves
+        reduceMids(parts, vidsnew, s.midiInst)
 
-        s.mkIdentification (score, lev)
-        s.mkDefaults (score, lev + 1)
+        s.mkIdentification(score, lev)
+        s.mkDefaults(score, lev + 1)
 
-        partlist = s.mkPartlist (vids, partAttr, lev + 1)
-        addElem (score, partlist, lev + 1)
-        for ip, part in enumerate (parts): addElem (score, part, lev + 1)
+        partlist = s.mkPartlist(vids, partAttr, lev + 1)
+        addElem(score, partlist, lev + 1)
+        for ip, part in enumerate(parts):
+            addElem(score, part, lev + 1)
 
         return score
 
 
-def decodeInput (data_string):
-    try:        enc = 'utf-8';   unicode_string = data_string.decode (enc)
+def decodeInput(data_string):
+    try:
+        enc = "utf-8"
+        unicode_string = data_string.decode(enc)
     except:
-        try:    enc = 'latin-1'; unicode_string = data_string.decode (enc)
-        except: raise ValueError ('data not encoded in utf-8 nor in latin-1')
-    info ('decoded from %s' % enc)
+        try:
+            enc = "latin-1"
+            unicode_string = data_string.decode(enc)
+        except:
+            raise ValueError("data not encoded in utf-8 nor in latin-1")
+    info("decoded from %s" % enc)
     return unicode_string
 
-def ggd (a, b): # greatest common divisor
-    return a if b == 0 else ggd (b, a % b)
 
-xmlVersion = "<?xml version='1.0' encoding='utf-8'?>"    
-def fixDoctype (elem):
-    if python3: xs = E.tostring (elem, encoding='unicode')  # writing to file will auto-encode to utf-8
-    else:       xs = E.tostring (elem, encoding='utf-8')    # keep the string utf-8 encoded for writing to file
-    ys = xs.split ('\n')
-    ys.insert (0, xmlVersion)  # crooked logic of ElementTree lib
-    ys.insert (1, '<!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 3.0 Partwise//EN" "http://www.musicxml.org/dtds/partwise.dtd">')
-    return '\n'.join (ys)
+def ggd(a, b):  # greatest common divisor
+    return a if b == 0 else ggd(b, a % b)
 
-def xml2mxl (pad, fnm, data):   # write xml data to compressed .mxl file
+
+xmlVersion = "<?xml version='1.0' encoding='utf-8'?>"
+
+
+def fixDoctype(elem):
+    if python3:
+        xs = E.tostring(
+            elem, encoding="unicode"
+        )  # writing to file will auto-encode to utf-8
+    else:
+        xs = E.tostring(
+            elem, encoding="utf-8"
+        )  # keep the string utf-8 encoded for writing to file
+    ys = xs.split("\n")
+    ys.insert(0, xmlVersion)  # crooked logic of ElementTree lib
+    ys.insert(
+        1,
+        '<!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 3.0 Partwise//EN" "http://www.musicxml.org/dtds/partwise.dtd">',
+    )
+    return "\n".join(ys)
+
+
+def xml2mxl(pad, fnm, data):  # write xml data to compressed .mxl file
     from zipfile import ZipFile, ZIP_DEFLATED
-    fnmext = fnm + '.xml'       # file name with extension, relative to the root within the archive
-    outfile = os.path.join (pad, fnm + '.mxl')
-    meta  = '%s\n<container><rootfiles>\n' % xmlVersion
-    meta += '<rootfile full-path="%s" media-type="application/vnd.recordare.musicxml+xml"/>\n' % fnmext
-    meta += '</rootfiles></container>'
-    f = ZipFile (outfile, 'w', ZIP_DEFLATED)
-    f.writestr ('META-INF/container.xml', meta)
-    f.writestr (fnmext, data)
-    f.close ()
-    info ('%s written' % outfile, warn=0)
 
-def convert (pad, fnm, abc_string, mxl, rOpt=False, tOpt=False, bOpt=False, fOpt=False):  # not used, backwards compatibility
-    score = mxm.parse (abc_string, rOpt, bOpt, fOpt)
-    writefile (pad, fnm, '', score, mxl, tOpt)
+    fnmext = (
+        fnm + ".xml"
+    )  # file name with extension, relative to the root within the archive
+    outfile = os.path.join(pad, fnm + ".mxl")
+    meta = "%s\n<container><rootfiles>\n" % xmlVersion
+    meta += (
+        '<rootfile full-path="%s" media-type="application/vnd.recordare.musicxml+xml"/>\n'
+        % fnmext
+    )
+    meta += "</rootfiles></container>"
+    f = ZipFile(outfile, "w", ZIP_DEFLATED)
+    f.writestr("META-INF/container.xml", meta)
+    f.writestr(fnmext, data)
+    f.close()
+    info("%s written" % outfile, warn=0)
 
-def writefile (pad, fnm, fnmNum, xmldoc, mxlOpt, tOpt=False):
-    ipad, ifnm = os.path.split (fnm)                    # base name of input path is
+
+def convert(
+    pad, fnm, abc_string, mxl, rOpt=False, tOpt=False, bOpt=False, fOpt=False
+):  # not used, backwards compatibility
+    score = mxm.parse(abc_string, rOpt, bOpt, fOpt)
+    writefile(pad, fnm, "", score, mxl, tOpt)
+
+
+def writefile(pad, fnm, fnmNum, xmldoc, mxlOpt, tOpt=False):
+    ipad, ifnm = os.path.split(fnm)  # base name of input path is
     if tOpt:
-        x = xmldoc.findtext ('work/work-title', 'no_title')
-        ifnm = x.replace (',','_').replace ("'",'_').replace ('?','_')
+        x = xmldoc.findtext("work/work-title", "no_title")
+        ifnm = x.replace(",", "_").replace("'", "_").replace("?", "_")
     else:
         ifnm += fnmNum
-    xmlstr = fixDoctype (xmldoc)
+    xmlstr = fixDoctype(xmldoc)
     if pad:
-        if not mxlOpt or mxlOpt in ['a', 'add']:
-            outfnm = os.path.join (pad, ifnm + '.xml')  # joined with path from -o option
-            outfile = open (outfnm, 'w')
-            outfile.write (xmlstr)
-            outfile.close ()
-            info ('%s written' % outfnm, warn=0)
-        if mxlOpt: xml2mxl (pad, ifnm, xmlstr)          # also write a compressed version
+        if not mxlOpt or mxlOpt in ["a", "add"]:
+            outfnm = os.path.join(pad, ifnm + ".xml")  # joined with path from -o option
+            outfile = open(outfnm, "w")
+            outfile.write(xmlstr)
+            outfile.close()
+            info("%s written" % outfnm, warn=0)
+        if mxlOpt:
+            xml2mxl(pad, ifnm, xmlstr)  # also write a compressed version
     else:
         outfile = sys.stdout
-        outfile.write (xmlstr)
-        outfile.write ('\n')
+        outfile.write(xmlstr)
+        outfile.write("\n")
 
-def readfile (fnmext, errmsg='read error: '):
+
+def readfile(fnmext, errmsg="read error: "):
     try:
-        if fnmext == '-.abc': fobj = stdin  # see python2/3 differences
-        else: fobj = open (fnmext, 'rb')
-        encoded_data = fobj.read ()
-        fobj.close ()
-        return encoded_data if type (encoded_data) == uni_type else decodeInput (encoded_data)
+        if fnmext == "-.abc":
+            fobj = stdin  # see python2/3 differences
+        else:
+            fobj = open(fnmext, "rb")
+        encoded_data = fobj.read()
+        fobj.close()
+        return (
+            encoded_data
+            if type(encoded_data) == uni_type
+            else decodeInput(encoded_data)
+        )
     except Exception as e:
-        info (errmsg + repr (e) + ' ' + fnmext)
+        info(errmsg + repr(e) + " " + fnmext)
         return None
 
-def expand_abc_include (abctxt):
+
+def expand_abc_include(abctxt):
     ys = []
-    for x in abctxt.splitlines ():
-        if x.startswith ('%%abc-include') or x.startswith ('I:abc-include'):
-            x = readfile (x[13:].strip (), 'include error: ')
-        if x != None: ys.append (x)
-    return '\n'.join (ys)
+    for x in abctxt.splitlines():
+        if x.startswith("%%abc-include") or x.startswith("I:abc-include"):
+            x = readfile(x[13:].strip(), "include error: ")
+        if x != None:
+            ys.append(x)
+    return "\n".join(ys)
 
-abc_header, abc_voice, abc_scoredef, abc_percmap = abc_grammar () # compute grammars only once
-mxm = MusicXml ()               # same for instance of MusicXml
 
-def getXmlScores (abc_string, skip=0, num=1, rOpt=False, bOpt=False, fOpt=False): # not used, backwards compatibility
-    return [fixDoctype (xml_doc) for xml_doc in
-        getXmlDocs (abc_string, skip=0, num=1, rOpt=False, bOpt=False, fOpt=False)]
+abc_header, abc_voice, abc_scoredef, abc_percmap = (
+    abc_grammar()
+)  # compute grammars only once
+mxm = MusicXml()  # same for instance of MusicXml
 
-def getXmlDocs (abc_string, skip=0, num=1, rOpt=False, bOpt=False, fOpt=False): # added by David Randolph
+
+def getXmlScores(
+    abc_string, skip=0, num=1, rOpt=False, bOpt=False, fOpt=False
+):  # not used, backwards compatibility
+    return [
+        fixDoctype(xml_doc)
+        for xml_doc in getXmlDocs(
+            abc_string, skip=0, num=1, rOpt=False, bOpt=False, fOpt=False
+        )
+    ]
+
+
+def getXmlDocs(
+    abc_string, skip=0, num=1, rOpt=False, bOpt=False, fOpt=False
+):  # added by David Randolph
     xml_docs = []
-    abctext = expand_abc_include (abc_string)
-    fragments = re.split (r'^\s*X:', abctext, flags=re.M)
-    preamble = fragments [0]    # tunes can be preceeded by formatting instructions
+    abctext = expand_abc_include(abc_string)
+    fragments = re.split(r"^\s*X:", abctext, flags=re.M)
+    preamble = fragments[0]  # tunes can be preceeded by formatting instructions
     tunes = fragments[1:]
-    if not tunes and preamble: tunes, preamble = ['1\n' + preamble], ''  # tune without X:
-    for itune, tune in enumerate (tunes):
-        if itune < skip: continue           # skip tunes, then read at most num tunes
-        if itune >= skip + num: break
-        tune = preamble + 'X:' + tune       # restore preamble before each tune
-        try:                                # convert string abctext -> file pad/fnmNum.xml
-            score = mxm.parse (tune, rOpt, bOpt, fOpt)
-            ds = list (score.iter ('duration')) # need to iterate twice
-            ss = [int (d.text) for d in ds]
-            deler = reduce (ggd, ss + [21]) # greatest common divisor of all durations
-            for i, d in enumerate (ds): d.text = str (ss [i] // deler)
-            for d in score.iter ('divisions'): d.text = str (int (d.text) // deler)
-            xml_docs.append (score)
+    if not tunes and preamble:
+        tunes, preamble = ["1\n" + preamble], ""  # tune without X:
+    for itune, tune in enumerate(tunes):
+        if itune < skip:
+            continue  # skip tunes, then read at most num tunes
+        if itune >= skip + num:
+            break
+        tune = preamble + "X:" + tune  # restore preamble before each tune
+        try:  # convert string abctext -> file pad/fnmNum.xml
+            score = mxm.parse(tune, rOpt, bOpt, fOpt)
+            ds = list(score.iter("duration"))  # need to iterate twice
+            ss = [int(d.text) for d in ds]
+            deler = reduce(ggd, ss + [21])  # greatest common divisor of all durations
+            for i, d in enumerate(ds):
+                d.text = str(ss[i] // deler)
+            for d in score.iter("divisions"):
+                d.text = str(int(d.text) // deler)
+            xml_docs.append(score)
         except ParseException:
-            pass         # output already printed
+            pass  # output already printed
         except Exception as err:
-            info ('an exception occurred.\n%s' % err)
+            info("an exception occurred.\n%s" % err)
     return xml_docs
 
-#----------------
+
+# ----------------
 # Main Program
-#----------------
-if __name__ == '__main__':
+# ----------------
+if __name__ == "__main__":
     from optparse import OptionParser
     from glob import glob
     import time
 
-    parser = OptionParser (usage='%prog [-h] [-r] [-t] [-b] [-m SKIP NUM] [-o DIR] [-p PFMT] [-z MODE] [--meta MAP] <file1> [<file2> ...]', version='version %d' % VERSION)
-    parser.add_option ("-o", action="store", help="store xml files in DIR", default='', metavar='DIR')
-    parser.add_option ("-m", action="store", help="skip SKIP (0) tunes, then read at most NUM (1) tunes", nargs=2, type='int', default=(0,1), metavar='SKIP NUM')
-    parser.add_option ("-p", action="store", help="pageformat PFMT (mm) = scale (0.75), pageheight (297), pagewidth (210), leftmargin (18), rightmargin (18), topmargin (10), botmargin (10)", default='', metavar='PFMT')
-    parser.add_option ("-z", "--mxl", dest="mxl", help="store as compressed mxl, MODE = a(dd) or r(eplace)", default='', metavar='MODE')
-    parser.add_option ("-r", action="store_true", help="show whole measure rests in merged staffs", default=False)
-    parser.add_option ("-t", action="store_true", help="use tune title as file name", default=False)
-    parser.add_option ("-b", action="store_true", help="line break at EOL", default=False)
-    parser.add_option ("--meta", action="store", help="map infofields to XML metadata, MAP = R:poet,Z:lyricist,N:...", default='', metavar='MAP')
-    parser.add_option ("-f", action="store_true", help="force string/fret allocations for tab staves", default=False)
-    options, args = parser.parse_args ()
-    if len (args) == 0: parser.error ('no input file given')
+    parser = OptionParser(
+        usage="%prog [-h] [-r] [-t] [-b] [-m SKIP NUM] [-o DIR] [-p PFMT] [-z MODE] [--meta MAP] <file1> [<file2> ...]",
+        version="version %d" % VERSION,
+    )
+    parser.add_option(
+        "-o", action="store", help="store xml files in DIR", default="", metavar="DIR"
+    )
+    parser.add_option(
+        "-m",
+        action="store",
+        help="skip SKIP (0) tunes, then read at most NUM (1) tunes",
+        nargs=2,
+        type="int",
+        default=(0, 1),
+        metavar="SKIP NUM",
+    )
+    parser.add_option(
+        "-p",
+        action="store",
+        help="pageformat PFMT (mm) = scale (0.75), pageheight (297), pagewidth (210), leftmargin (18), rightmargin (18), topmargin (10), botmargin (10)",
+        default="",
+        metavar="PFMT",
+    )
+    parser.add_option(
+        "-z",
+        "--mxl",
+        dest="mxl",
+        help="store as compressed mxl, MODE = a(dd) or r(eplace)",
+        default="",
+        metavar="MODE",
+    )
+    parser.add_option(
+        "-r",
+        action="store_true",
+        help="show whole measure rests in merged staffs",
+        default=False,
+    )
+    parser.add_option(
+        "-t", action="store_true", help="use tune title as file name", default=False
+    )
+    parser.add_option(
+        "-b", action="store_true", help="line break at EOL", default=False
+    )
+    parser.add_option(
+        "--meta",
+        action="store",
+        help="map infofields to XML metadata, MAP = R:poet,Z:lyricist,N:...",
+        default="",
+        metavar="MAP",
+    )
+    parser.add_option(
+        "-f",
+        action="store_true",
+        help="force string/fret allocations for tab staves",
+        default=False,
+    )
+    options, args = parser.parse_args()
+    if len(args) == 0:
+        parser.error("no input file given")
     pad = options.o
-    if options.mxl and options.mxl not in ['a','add', 'r', 'replace']:
-        parser.error ('MODE should be a(dd) or r(eplace), not: %s' % options.mxl)
+    if options.mxl and options.mxl not in ["a", "add", "r", "replace"]:
+        parser.error("MODE should be a(dd) or r(eplace), not: %s" % options.mxl)
     if pad:
-        if not os.path.exists (pad): os.mkdir (pad)
-        if not os.path.isdir (pad): parser.error ('%s is not a directory' % pad)
-    if options.p:   # set page formatting values
-        try:        # space, page-height, -width, margin-left, -right, -top, -bottom
-            mxm.pageFmtCmd = lmap (float, options.p.split (','))
-            if len (mxm.pageFmtCmd) != 7: raise ValueError ('-p needs 7 values')
-        except Exception as err: parser.error (err)
-    for x in options.meta.split (','):
-        if not x: continue
-        try: field, tag = x.split (':')
-        except: parser.error ('--meta: %s cannot be split on colon' % x)
-        if field not in 'OAZNGHRBDFSPW': parser.error ('--meta: field %s is no valid ABC field' % field)
-        if tag not in mxm.metaTypes: parser.error ('--meta: tag %s is no valid XML creator type' % tag)
-        mxm.metaMap [field] = tag
+        if not os.path.exists(pad):
+            os.mkdir(pad)
+        if not os.path.isdir(pad):
+            parser.error("%s is not a directory" % pad)
+    if options.p:  # set page formatting values
+        try:  # space, page-height, -width, margin-left, -right, -top, -bottom
+            mxm.pageFmtCmd = lmap(float, options.p.split(","))
+            if len(mxm.pageFmtCmd) != 7:
+                raise ValueError("-p needs 7 values")
+        except Exception as err:
+            parser.error(err)
+    for x in options.meta.split(","):
+        if not x:
+            continue
+        try:
+            field, tag = x.split(":")
+        except:
+            parser.error("--meta: %s cannot be split on colon" % x)
+        if field not in "OAZNGHRBDFSPW":
+            parser.error("--meta: field %s is no valid ABC field" % field)
+        if tag not in mxm.metaTypes:
+            parser.error("--meta: tag %s is no valid XML creator type" % tag)
+        mxm.metaMap[field] = tag
     fnmext_list = []
     for i in args:
-        if i == '-': fnmext_list.append ('-.abc')   # represents standard input
-        else:        fnmext_list += glob (i)
-    if not fnmext_list: parser.error ('none of the input files exist')
-    t_start = time.time ()
+        if i == "-":
+            fnmext_list.append("-.abc")  # represents standard input
+        else:
+            fnmext_list += glob(i)
+    if not fnmext_list:
+        parser.error("none of the input files exist")
+    t_start = time.time()
     for fnmext in fnmext_list:
-        fnm, ext = os.path.splitext (fnmext)
-        if ext.lower () not in ('.abc'):
-            info ('skipped input file %s, it should have extension .abc' % fnmext)
+        fnm, ext = os.path.splitext(fnmext)
+        if ext.lower() not in (".abc"):
+            info("skipped input file %s, it should have extension .abc" % fnmext)
             continue
-        if os.path.isdir (fnmext):
-            info ('skipped directory %s. Only files are accepted' % fnmext)
+        if os.path.isdir(fnmext):
+            info("skipped directory %s. Only files are accepted" % fnmext)
             continue
-        abctext = readfile (fnmext)
+        abctext = readfile(fnmext)
         skip, num = options.m
-        xml_docs = getXmlDocs (abctext, skip, num, options.r, options.b, options.f)
-        for itune, xmldoc in enumerate (xml_docs):
-            fnmNum = '%02d' % (itune + 1) if len (xml_docs) > 1 else ''
-            writefile (pad, fnm, fnmNum, xmldoc, options.mxl, options.t)
-    info ('done in %.2f secs' % (time.time () - t_start))
+        xml_docs = getXmlDocs(abctext, skip, num, options.r, options.b, options.f)
+        for itune, xmldoc in enumerate(xml_docs):
+            fnmNum = "%02d" % (itune + 1) if len(xml_docs) > 1 else ""
+            writefile(pad, fnm, fnmNum, xmldoc, options.mxl, options.t)
+    info("done in %.2f secs" % (time.time() - t_start))

--- a/gradio/config.py
+++ b/gradio/config.py
@@ -1,15 +1,13 @@
-import os
-
 # Configurations for inference
-INFERENCE_WEIGHTS_PATH = 'weights_notagenx_p_size_16_p_length_1024_p_layers_20_h_size_1280.pth'               # Path to weights for inference# Folder to save output files
-TOP_K = 9                                                       # Top k for sampling
-TOP_P = 0.9                                                      # Top p for sampling
-TEMPERATURE = 1.2                                                 # Temperature for sampling
+INFERENCE_WEIGHTS_PATH = "weights_notagenx_p_size_16_p_length_1024_p_layers_20_h_size_1280.pth"  # Path to weights for inference# Folder to save output files
+TOP_K = 9  # Top k for sampling
+TOP_P = 0.9  # Top p for sampling
+TEMPERATURE = 1.2  # Temperature for sampling
 
 # Configurations for model
-PATCH_STREAM = True                                             # Stream training / inference
-PATCH_SIZE = 16                                                # Patch Size
-PATCH_LENGTH = 1024                                             # Patch Length
-CHAR_NUM_LAYERS = 6                                             # Number of layers in the decoder
-PATCH_NUM_LAYERS = 20                                           # Number of layers in the encoder
-HIDDEN_SIZE = 1280                                               # Hidden Size
+PATCH_STREAM = True  # Stream training / inference
+PATCH_SIZE = 16  # Patch Size
+PATCH_LENGTH = 1024  # Patch Length
+CHAR_NUM_LAYERS = 6  # Number of layers in the decoder
+PATCH_NUM_LAYERS = 20  # Number of layers in the encoder
+HIDDEN_SIZE = 1280  # Hidden Size

--- a/gradio/demo.py
+++ b/gradio/demo.py
@@ -6,15 +6,14 @@ from io import TextIOBase
 from inference import inference_patch
 import datetime
 import subprocess
-import os
 
 # Predefined valid combinations set
-with open('prompts.txt', 'r') as f:
+with open("prompts.txt", "r") as f:
     prompts = f.readlines()
 valid_combinations = set()
 for prompt in prompts:
     prompt = prompt.strip()
-    parts = prompt.split('_')
+    parts = prompt.split("_")
     valid_combinations.add((parts[0], parts[1], parts[2]))
 
 # Generate available options
@@ -22,35 +21,38 @@ periods = sorted({p for p, _, _ in valid_combinations})
 composers = sorted({c for _, c, _ in valid_combinations})
 instruments = sorted({i for _, _, i in valid_combinations})
 
+
 # Dynamic component updates
 def update_components(period, composer):
     if not period:
         return [
             gr.Dropdown(choices=[], value=None, interactive=False),
-            gr.Dropdown(choices=[], value=None, interactive=False)
+            gr.Dropdown(choices=[], value=None, interactive=False),
         ]
-    
+
     valid_composers = sorted({c for p, c, _ in valid_combinations if p == period})
-    valid_instruments = sorted({i for p, c, i in valid_combinations if p == period and c == composer}) if composer else []
-    
+    valid_instruments = (
+        sorted({i for p, c, i in valid_combinations if p == period and c == composer})
+        if composer
+        else []
+    )
+
     return [
         gr.Dropdown(
             choices=valid_composers,
             value=composer if composer in valid_composers else None,
-            interactive=True  
+            interactive=True,
         ),
         gr.Dropdown(
-            choices=valid_instruments,
-            value=None,
-            interactive=bool(valid_instruments)  
-        )
+            choices=valid_instruments, value=None, interactive=bool(valid_instruments)
+        ),
     ]
 
 
 class RealtimeStream(TextIOBase):
     def __init__(self, queue):
         self.queue = queue
-    
+
     def write(self, text):
         self.queue.put(text)
         return len(text)
@@ -59,11 +61,11 @@ class RealtimeStream(TextIOBase):
 def save_and_convert(abc_content, period, composer, instrumentation):
     if not all([period, composer, instrumentation]):
         raise gr.Error("Please complete a valid generation first before saving")
-    
+
     timestamp = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
     prompt_str = f"{period}_{composer}_{instrumentation}"
     filename_base = f"{timestamp}_{prompt_str}"
-    
+
     abc_filename = f"{filename_base}.abc"
     with open(abc_filename, "w", encoding="utf-8") as f:
         f.write(abc_content)
@@ -71,88 +73,90 @@ def save_and_convert(abc_content, period, composer, instrumentation):
     xml_filename = f"{filename_base}.xml"
     try:
         subprocess.run(
-            ["python", "abc2xml.py", '-o', '.', abc_filename, ],
+            [
+                "python",
+                "abc2xml.py",
+                "-o",
+                ".",
+                abc_filename,
+            ],
             check=True,
             capture_output=True,
-            text=True
+            text=True,
         )
     except subprocess.CalledProcessError as e:
         error_msg = f"Conversion failed: {e.stderr}" if e.stderr else "Unknown error"
-        raise gr.Error(f"ABC to XML conversion failed: {error_msg}. Please try to generate another composition.")
-    
-    return f"Saved successfully: {abc_filename} -> {xml_filename}"
+        raise gr.Error(
+            f"ABC to XML conversion failed: {error_msg}. Please try to generate another composition."
+        )
 
+    return f"Saved successfully: {abc_filename} -> {xml_filename}"
 
 
 def generate_music(period, composer, instrumentation):
     if (period, composer, instrumentation) not in valid_combinations:
-        raise gr.Error("Invalid prompt combination! Please re-select from the period options")
-    
+        raise gr.Error(
+            "Invalid prompt combination! Please re-select from the period options"
+        )
+
     output_queue = queue.Queue()
     original_stdout = sys.stdout
     sys.stdout = RealtimeStream(output_queue)
-    
+
     result_container = []
+
     def run_inference():
         try:
             result_container.append(inference_patch(period, composer, instrumentation))
         finally:
             sys.stdout = original_stdout
-    
+
     thread = threading.Thread(target=run_inference)
     thread.start()
-    
+
     process_output = ""
     while thread.is_alive():
         try:
             text = output_queue.get(timeout=0.1)
             process_output += text
-            yield process_output, None  
+            yield process_output, None
         except queue.Empty:
             continue
-    
+
     while not output_queue.empty():
         text = output_queue.get()
         process_output += text
         yield process_output, None
-    
+
     final_result = result_container[0] if result_container else ""
     yield process_output, final_result
 
+
 with gr.Blocks() as demo:
     gr.Markdown("## NotaGen")
-    
+
     with gr.Row():
         # 左侧栏
         with gr.Column():
             period_dd = gr.Dropdown(
-                choices=periods,
-                value=None, 
-                label="Period",
-                interactive=True
+                choices=periods, value=None, label="Period", interactive=True
             )
             composer_dd = gr.Dropdown(
-                choices=[],
-                value=None,
-                label="Composer",
-                interactive=False
+                choices=[], value=None, label="Composer", interactive=False
             )
             instrument_dd = gr.Dropdown(
-                choices=[],
-                value=None,
-                label="Instrumentation",
-                interactive=False
+                choices=[], value=None, label="Instrumentation", interactive=False
             )
-            
+
             generate_btn = gr.Button("Generate!", variant="primary")
-            
+
             process_output = gr.Textbox(
                 label="Generation process",
                 interactive=False,
                 lines=15,
                 max_lines=15,
                 placeholder="Generation progress will be shown here...",
-                elem_classes="process-output"
+                elem_classes="process-output",
             )
 
         # 右侧栏
@@ -162,40 +166,37 @@ with gr.Blocks() as demo:
                 interactive=True,
                 lines=23,
                 placeholder="Post-processed ABC scores will be shown here...",
-                elem_classes="final-output"
+                elem_classes="final-output",
             )
-            
+
             with gr.Row():
                 save_btn = gr.Button("💾 Save as ABC & XML files", variant="secondary")
-            
+
             save_status = gr.Textbox(
-                label="Save Status",
-                interactive=False,
-                visible=True,
-                max_lines=2
+                label="Save Status", interactive=False, visible=True, max_lines=2
             )
-    
+
     period_dd.change(
         update_components,
         inputs=[period_dd, composer_dd],
-        outputs=[composer_dd, instrument_dd]
+        outputs=[composer_dd, instrument_dd],
     )
     composer_dd.change(
         update_components,
         inputs=[period_dd, composer_dd],
-        outputs=[composer_dd, instrument_dd]
+        outputs=[composer_dd, instrument_dd],
     )
-    
+
     generate_btn.click(
         generate_music,
         inputs=[period_dd, composer_dd, instrument_dd],
-        outputs=[process_output, final_output]
+        outputs=[process_output, final_output],
     )
-    
+
     save_btn.click(
         save_and_convert,
         inputs=[final_output, period_dd, composer_dd, instrument_dd],
-        outputs=[save_status]
+        outputs=[save_status],
     )
 
 
@@ -230,7 +231,4 @@ demo.css = css
 
 if __name__ == "__main__":
 
-    demo.launch(
-        server_name="0.0.0.0",
-        server_port=7861
-    )
+    demo.launch(server_name="0.0.0.0", server_port=7861)

--- a/gradio/inference.py
+++ b/gradio/inference.py
@@ -1,15 +1,13 @@
-
-import os
 import time
 import torch
 from utils import *
 from config import *
 from transformers import GPT2Config
-from abctoolkit.utils import Exclaim_re, Quote_re, SquareBracket_re, Barline_regexPattern
-from abctoolkit.transpose import Note_list, Pitch_sign_list
+from abctoolkit.utils import Barline_regexPattern
+from abctoolkit.transpose import Note_list
 from abctoolkit.duration import calculate_bartext_duration
 
-Note_list = Note_list + ['z', 'x']
+Note_list = Note_list + ["z", "x"]
 
 if torch.cuda.is_available():
     device = torch.device("cuda")
@@ -20,20 +18,26 @@ else:
 
 patchilizer = Patchilizer()
 
-patch_config = GPT2Config(num_hidden_layers=PATCH_NUM_LAYERS,
-                          max_length=PATCH_LENGTH,
-                          max_position_embeddings=PATCH_LENGTH,
-                          n_embd=HIDDEN_SIZE,
-                          num_attention_heads=HIDDEN_SIZE // 64,
-                          vocab_size=1)
-byte_config = GPT2Config(num_hidden_layers=CHAR_NUM_LAYERS,
-                         max_length=PATCH_SIZE + 1,
-                         max_position_embeddings=PATCH_SIZE + 1,
-                         hidden_size=HIDDEN_SIZE,
-                         num_attention_heads=HIDDEN_SIZE // 64,
-                         vocab_size=128)
+patch_config = GPT2Config(
+    num_hidden_layers=PATCH_NUM_LAYERS,
+    max_length=PATCH_LENGTH,
+    max_position_embeddings=PATCH_LENGTH,
+    n_embd=HIDDEN_SIZE,
+    num_attention_heads=HIDDEN_SIZE // 64,
+    vocab_size=1,
+)
+byte_config = GPT2Config(
+    num_hidden_layers=CHAR_NUM_LAYERS,
+    max_length=PATCH_SIZE + 1,
+    max_position_embeddings=PATCH_SIZE + 1,
+    hidden_size=HIDDEN_SIZE,
+    num_attention_heads=HIDDEN_SIZE // 64,
+    vocab_size=128,
+)
 
-model = NotaGenLMHeadModel(encoder_config=patch_config, decoder_config=byte_config).to(device)
+model = NotaGenLMHeadModel(encoder_config=patch_config, decoder_config=byte_config).to(
+    device
+)
 
 
 def prepare_model_for_kbit_training(model, use_gradient_checkpointing=True):
@@ -59,23 +63,23 @@ def prepare_model_for_kbit_training(model, use_gradient_checkpointing=True):
     return model
 
 
-model = prepare_model_for_kbit_training(
-    model,
-    use_gradient_checkpointing=False  
+model = prepare_model_for_kbit_training(model, use_gradient_checkpointing=False)
+
+print(
+    "Parameter Number: "
+    + str(sum(p.numel() for p in model.parameters() if p.requires_grad))
 )
 
-print("Parameter Number: " + str(sum(p.numel() for p in model.parameters() if p.requires_grad)))
-
 checkpoint = torch.load(INFERENCE_WEIGHTS_PATH, map_location=torch.device(device))
-model.load_state_dict(checkpoint['model'])
+model.load_state_dict(checkpoint["model"])
 model = model.to(device)
 model.eval()
 
 
 def complete_brackets(s):
     stack = []
-    bracket_map = {'{': '}', '[': ']', '(': ')'}
-    
+    bracket_map = {"{": "}", "[": "]", "(": ")"}
+
     # Iterate through each character, handle bracket matching
     for char in s:
         if char in bracket_map:
@@ -87,9 +91,9 @@ def complete_brackets(s):
                     if stack and stack[-1] == key:
                         stack.pop()
                     break  # Found matching right bracket, process next character
-    
+
     # Complete missing right brackets (in reverse order of remaining left brackets in stack)
-    completion = ''.join(bracket_map[c] for c in reversed(stack))
+    completion = "".join(bracket_map[c] for c in reversed(stack))
     return s + completion
 
 
@@ -97,23 +101,23 @@ def rest_unreduce(abc_lines):
 
     tunebody_index = None
     for i in range(len(abc_lines)):
-        if abc_lines[i].startswith('%%score'):
+        if abc_lines[i].startswith("%%score"):
             abc_lines[i] = complete_brackets(abc_lines[i])
-        if '[V:' in abc_lines[i]:
+        if "[V:" in abc_lines[i]:
             tunebody_index = i
             break
 
-    metadata_lines = abc_lines[: tunebody_index]
+    metadata_lines = abc_lines[:tunebody_index]
     tunebody_lines = abc_lines[tunebody_index:]
 
     part_symbol_list = []
     voice_group_list = []
     for line in metadata_lines:
-        if line.startswith('%%score'):
-            for round_bracket_match in re.findall(r'\((.*?)\)', line):
+        if line.startswith("%%score"):
+            for round_bracket_match in re.findall(r"\((.*?)\)", line):
                 voice_group_list.append(round_bracket_match.split())
             existed_voices = [item for sublist in voice_group_list for item in sublist]
-        if line.startswith('V:'):
+        if line.startswith("V:"):
             symbol = line.split()[0]
             part_symbol_list.append(symbol)
             if symbol[2:] not in existed_voices:
@@ -121,33 +125,33 @@ def rest_unreduce(abc_lines):
     z_symbol_list = []  # voices that use z as rest
     x_symbol_list = []  # voices that use x as rest
     for voice_group in voice_group_list:
-        z_symbol_list.append('V:' + voice_group[0])
+        z_symbol_list.append("V:" + voice_group[0])
         for j in range(1, len(voice_group)):
-            x_symbol_list.append('V:' + voice_group[j])
+            x_symbol_list.append("V:" + voice_group[j])
 
     part_symbol_list.sort(key=lambda x: int(x[2:]))
 
     unreduced_tunebody_lines = []
 
     for i, line in enumerate(tunebody_lines):
-        unreduced_line = ''
+        unreduced_line = ""
 
-        line = re.sub(r'^\[r:[^\]]*\]', '', line)
+        line = re.sub(r"^\[r:[^\]]*\]", "", line)
 
-        pattern = r'\[V:(\d+)\](.*?)(?=\[V:|$)'
+        pattern = r"\[V:(\d+)\](.*?)(?=\[V:|$)"
         matches = re.findall(pattern, line)
 
         line_bar_dict = {}
         for match in matches:
-            key = f'V:{match[0]}'
+            key = f"V:{match[0]}"
             value = match[1]
             line_bar_dict[key] = value
 
         # calculate duration and collect barline
-        dur_dict = {}  
+        dur_dict = {}
         for symbol, bartext in line_bar_dict.items():
-            right_barline = ''.join(re.split(Barline_regexPattern, bartext)[-2:])
-            bartext = bartext[:-len(right_barline)]
+            right_barline = "".join(re.split(Barline_regexPattern, bartext)[-2:])
+            bartext = bartext[: -len(right_barline)]
             try:
                 bar_dur = calculate_bartext_duration(bartext)
             except:
@@ -161,24 +165,28 @@ def rest_unreduce(abc_lines):
         try:
             ref_dur = max(dur_dict, key=dur_dict.get)
         except:
-            pass    # use last ref_dur
+            pass  # use last ref_dur
 
         if i == 0:
-            prefix_left_barline = line.split('[V:')[0]
+            prefix_left_barline = line.split("[V:")[0]
         else:
-            prefix_left_barline = ''
+            prefix_left_barline = ""
 
         for symbol in part_symbol_list:
             if symbol in line_bar_dict.keys():
                 symbol_bartext = line_bar_dict[symbol]
             else:
                 if symbol in z_symbol_list:
-                    symbol_bartext = prefix_left_barline + 'z' + str(ref_dur) + right_barline
+                    symbol_bartext = (
+                        prefix_left_barline + "z" + str(ref_dur) + right_barline
+                    )
                 elif symbol in x_symbol_list:
-                    symbol_bartext = prefix_left_barline + 'x' + str(ref_dur) + right_barline
-            unreduced_line += '[' + symbol + ']' + symbol_bartext
+                    symbol_bartext = (
+                        prefix_left_barline + "x" + str(ref_dur) + right_barline
+                    )
+            unreduced_line += "[" + symbol + "]" + symbol_bartext
 
-        unreduced_tunebody_lines.append(unreduced_line + '\n')
+        unreduced_tunebody_lines.append(unreduced_line + "\n")
 
     unreduced_lines = metadata_lines + unreduced_tunebody_lines
 
@@ -187,28 +195,34 @@ def rest_unreduce(abc_lines):
 
 def inference_patch(period, composer, instrumentation):
 
-    prompt_lines=[
-    '%' + period + '\n',
-    '%' + composer + '\n',
-    '%' + instrumentation + '\n']
+    prompt_lines = [
+        "%" + period + "\n",
+        "%" + composer + "\n",
+        "%" + instrumentation + "\n",
+    ]
 
     while True:
 
         failure_flag = False
 
-        bos_patch = [patchilizer.bos_token_id] * (PATCH_SIZE - 1) + [patchilizer.eos_token_id]
+        bos_patch = [patchilizer.bos_token_id] * (PATCH_SIZE - 1) + [
+            patchilizer.eos_token_id
+        ]
 
         start_time = time.time()
 
         prompt_patches = patchilizer.patchilize_metadata(prompt_lines)
-        byte_list = list(''.join(prompt_lines))
+        byte_list = list("".join(prompt_lines))
         context_tunebody_byte_list = []
         metadata_byte_list = []
 
-        print(''.join(byte_list), end='')
+        print("".join(byte_list), end="")
 
-        prompt_patches = [[ord(c) for c in patch] + [patchilizer.special_token_id] * (PATCH_SIZE - len(patch)) for patch
-                          in prompt_patches]
+        prompt_patches = [
+            [ord(c) for c in patch]
+            + [patchilizer.special_token_id] * (PATCH_SIZE - len(patch))
+            for patch in prompt_patches
+        ]
         prompt_patches.insert(0, bos_patch)
 
         input_patches = torch.tensor(prompt_patches, device=device).reshape(1, -1)
@@ -219,23 +233,38 @@ def inference_patch(period, composer, instrumentation):
         tunebody_flag = False
 
         with torch.inference_mode():
-            
+
             while True:
-                with torch.autocast(device_type='cuda', dtype=torch.float16):
-                    predicted_patch = model.generate(input_patches.unsqueeze(0),
-                                                    top_k=TOP_K,
-                                                    top_p=TOP_P,
-                                                    temperature=TEMPERATURE)
-                if not tunebody_flag and patchilizer.decode([predicted_patch]).startswith('[r:'):  # 初次进入tunebody，必须以[r:0/开头
+                with torch.autocast(device_type="cuda", dtype=torch.float16):
+                    predicted_patch = model.generate(
+                        input_patches.unsqueeze(0),
+                        top_k=TOP_K,
+                        top_p=TOP_P,
+                        temperature=TEMPERATURE,
+                    )
+                if not tunebody_flag and patchilizer.decode(
+                    [predicted_patch]
+                ).startswith(
+                    "[r:"
+                ):  # 初次进入tunebody，必须以[r:0/开头
                     tunebody_flag = True
-                    r0_patch = torch.tensor([ord(c) for c in '[r:0/']).unsqueeze(0).to(device)
-                    temp_input_patches = torch.concat([input_patches, r0_patch], axis=-1)
-                    predicted_patch = model.generate(temp_input_patches.unsqueeze(0),
-                                                    top_k=TOP_K,
-                                                    top_p=TOP_P,
-                                                    temperature=TEMPERATURE)
-                    predicted_patch = [ord(c) for c in '[r:0/'] + predicted_patch
-                if predicted_patch[0] == patchilizer.bos_token_id and predicted_patch[1] == patchilizer.eos_token_id:
+                    r0_patch = (
+                        torch.tensor([ord(c) for c in "[r:0/"]).unsqueeze(0).to(device)
+                    )
+                    temp_input_patches = torch.concat(
+                        [input_patches, r0_patch], axis=-1
+                    )
+                    predicted_patch = model.generate(
+                        temp_input_patches.unsqueeze(0),
+                        top_k=TOP_K,
+                        top_p=TOP_P,
+                        temperature=TEMPERATURE,
+                    )
+                    predicted_patch = [ord(c) for c in "[r:0/"] + predicted_patch
+                if (
+                    predicted_patch[0] == patchilizer.bos_token_id
+                    and predicted_patch[1] == patchilizer.eos_token_id
+                ):
                     end_flag = True
                     break
                 next_patch = patchilizer.decode([predicted_patch])
@@ -246,7 +275,7 @@ def inference_patch(period, composer, instrumentation):
                         context_tunebody_byte_list.append(char)
                     else:
                         metadata_byte_list.append(char)
-                    print(char, end='')
+                    print(char, end="")
 
                 patch_end_flag = False
                 for j in range(len(predicted_patch)):
@@ -255,64 +284,80 @@ def inference_patch(period, composer, instrumentation):
                     if predicted_patch[j] == patchilizer.eos_token_id:
                         patch_end_flag = True
 
-                predicted_patch = torch.tensor([predicted_patch], device=device)  # (1, 16)
-                input_patches = torch.cat([input_patches, predicted_patch], dim=1)  # (1, 16 * patch_len)
+                predicted_patch = torch.tensor(
+                    [predicted_patch], device=device
+                )  # (1, 16)
+                input_patches = torch.cat(
+                    [input_patches, predicted_patch], dim=1
+                )  # (1, 16 * patch_len)
 
                 if len(byte_list) > 102400:
                     failure_flag = True
                     break
-                if time.time() - start_time > 10 * 60: 
+                if time.time() - start_time > 10 * 60:
                     failure_flag = True
                     break
 
                 if input_patches.shape[1] >= PATCH_LENGTH * PATCH_SIZE and not end_flag:
-                    print('Stream generating...')
+                    print("Stream generating...")
 
-                    metadata = ''.join(metadata_byte_list)
-                    context_tunebody = ''.join(context_tunebody_byte_list)
+                    metadata = "".join(metadata_byte_list)
+                    context_tunebody = "".join(context_tunebody_byte_list)
 
-                    if '\n' not in context_tunebody:
-                        break   # Generated content is all metadata, abandon
+                    if "\n" not in context_tunebody:
+                        break  # Generated content is all metadata, abandon
 
-                    context_tunebody_liness = context_tunebody.split('\n')
-                    if not context_tunebody.endswith('\n'):
-                        context_tunebody_liness = [context_tunebody_liness[i] + '\n' for i in range(len(context_tunebody_liness) - 1)] + [context_tunebody_liness[-1]]
+                    context_tunebody_liness = context_tunebody.split("\n")
+                    if not context_tunebody.endswith("\n"):
+                        context_tunebody_liness = [
+                            context_tunebody_liness[i] + "\n"
+                            for i in range(len(context_tunebody_liness) - 1)
+                        ] + [context_tunebody_liness[-1]]
                     else:
-                        context_tunebody_liness = [context_tunebody_liness[i] + '\n' for i in range(len(context_tunebody_liness))]
+                        context_tunebody_liness = [
+                            context_tunebody_liness[i] + "\n"
+                            for i in range(len(context_tunebody_liness))
+                        ]
 
                     cut_index = len(context_tunebody_liness) // 2
-                    abc_code_slice = metadata + ''.join(context_tunebody_liness[-cut_index:])
+                    abc_code_slice = metadata + "".join(
+                        context_tunebody_liness[-cut_index:]
+                    )
 
                     input_patches = patchilizer.encode_generate(abc_code_slice)
 
-                    input_patches = [item for sublist in input_patches for item in sublist]
+                    input_patches = [
+                        item for sublist in input_patches for item in sublist
+                    ]
                     input_patches = torch.tensor([input_patches], device=device)
                     input_patches = input_patches.reshape(1, -1)
 
-                    context_tunebody_byte_list = list(''.join(context_tunebody_lines[-cut_index:]))
+                    context_tunebody_byte_list = list(
+                        "".join(context_tunebody_lines[-cut_index:])
+                    )
 
             if not failure_flag:
-                abc_text = ''.join(byte_list)
+                abc_text = "".join(byte_list)
 
                 # unreduce
-                abc_lines = abc_text.split('\n')
+                abc_lines = abc_text.split("\n")
                 abc_lines = list(filter(None, abc_lines))
-                abc_lines = [line + '\n' for line in abc_lines]
+                abc_lines = [line + "\n" for line in abc_lines]
                 try:
                     unreduced_abc_lines = rest_unreduce(abc_lines)
                 except:
                     failure_flag = True
                     pass
                 else:
-                    unreduced_abc_lines = [line for line in unreduced_abc_lines if not(line.startswith('%') and not line.startswith('%%'))]
-                    unreduced_abc_lines = ['X:1\n'] + unreduced_abc_lines
-                    unreduced_abc_text = ''.join(unreduced_abc_lines)
+                    unreduced_abc_lines = [
+                        line
+                        for line in unreduced_abc_lines
+                        if not (line.startswith("%") and not line.startswith("%%"))
+                    ]
+                    unreduced_abc_lines = ["X:1\n"] + unreduced_abc_lines
+                    unreduced_abc_text = "".join(unreduced_abc_lines)
                     return unreduced_abc_text
 
 
-        
-
-
-
-if __name__ == '__main__':
-    inference_patch('Classical', 'Beethoven, Ludwig van', 'Keyboard')
+if __name__ == "__main__":
+    inference_patch("Classical", "Beethoven, Ludwig van", "Keyboard")

--- a/gradio/utils.py
+++ b/gradio/utils.py
@@ -1,20 +1,18 @@
 import torch
 import random
 import bisect
-import json
 import re
 import numpy as np
 from config import *
-from transformers import GPT2Model, GPT2LMHeadModel, LlamaModel, LlamaForCausalLM, PreTrainedModel
+from transformers import GPT2Model, GPT2LMHeadModel, PreTrainedModel
 from samplings import top_p_sampling, top_k_sampling, temperature_sampling
-from tokenizers import Tokenizer
 
 
 class Patchilizer:
     def __init__(self, stream=PATCH_STREAM):
         self.stream = stream
         self.delimiters = ["|:", "::", ":|", "[|", "||", "|]", "|"]
-        self.regexPattern = '(' + '|'.join(map(re.escape, self.delimiters)) + ')'
+        self.regexPattern = "(" + "|".join(map(re.escape, self.delimiters)) + ")"
         self.bos_token_id = 1
         self.eos_token_id = 2
         self.special_token_id = 0
@@ -34,11 +32,19 @@ class Patchilizer:
                     new_line_bars = line_bars
                 else:
                     if line_bars[0] in self.delimiters:
-                        new_line_bars = [line_bars[i] + line_bars[i + 1] for i in range(0, len(line_bars), 2)]
+                        new_line_bars = [
+                            line_bars[i] + line_bars[i + 1]
+                            for i in range(0, len(line_bars), 2)
+                        ]
                     else:
-                        new_line_bars = [line_bars[0]] + [line_bars[i] + line_bars[i + 1] for i in range(1, len(line_bars), 2)]
-                    if 'V' not in new_line_bars[-1]:
-                        new_line_bars[-2] += new_line_bars[-1]  # 吸收最后一个 小节线+\n 的组合
+                        new_line_bars = [line_bars[0]] + [
+                            line_bars[i] + line_bars[i + 1]
+                            for i in range(1, len(line_bars), 2)
+                        ]
+                    if "V" not in new_line_bars[-1]:
+                        new_line_bars[-2] += new_line_bars[
+                            -1
+                        ]  # 吸收最后一个 小节线+\n 的组合
                         new_line_bars = new_line_bars[:-1]
                 new_bars += new_line_bars
         except:
@@ -49,14 +55,16 @@ class Patchilizer:
     def split_patches(self, abc_text, patch_size=PATCH_SIZE, generate_last=False):
         if not generate_last and len(abc_text) % patch_size != 0:
             abc_text += chr(self.eos_token_id)
-        patches = [abc_text[i : i + patch_size] for i in range(0, len(abc_text), patch_size)]
+        patches = [
+            abc_text[i : i + patch_size] for i in range(0, len(abc_text), patch_size)
+        ]
         return patches
 
     def patch2chars(self, patch):
         """
         Convert a patch into a bar.
         """
-        bytes = ''
+        bytes = ""
         for idx in patch:
             if idx == self.eos_token_id:
                 break
@@ -64,7 +72,6 @@ class Patchilizer:
                 pass
             bytes += chr(idx)
         return bytes
-        
 
     def patchilize_metadata(self, metadata_lines):
 
@@ -73,77 +80,103 @@ class Patchilizer:
             metadata_patches += self.split_patches(line)
 
         return metadata_patches
-    
-    def patchilize_tunebody(self, tunebody_lines, encode_mode='train'):
+
+    def patchilize_tunebody(self, tunebody_lines, encode_mode="train"):
 
         tunebody_patches = []
         bars = self.split_bars(tunebody_lines)
-        if encode_mode == 'train':
+        if encode_mode == "train":
             for bar in bars:
                 tunebody_patches += self.split_patches(bar)
-        elif encode_mode == 'generate':
+        elif encode_mode == "generate":
             for bar in bars[:-1]:
                 tunebody_patches += self.split_patches(bar)
             tunebody_patches += self.split_patches(bars[-1], generate_last=True)
-       
+
         return tunebody_patches
 
-    def encode_train(self, abc_text, patch_length=PATCH_LENGTH, patch_size=PATCH_SIZE, add_special_patches=True, cut=True):
+    def encode_train(
+        self,
+        abc_text,
+        patch_length=PATCH_LENGTH,
+        patch_size=PATCH_SIZE,
+        add_special_patches=True,
+        cut=True,
+    ):
 
-        lines = abc_text.split('\n')
+        lines = abc_text.split("\n")
         lines = list(filter(None, lines))
-        lines = [line + '\n' for line in lines]
+        lines = [line + "\n" for line in lines]
 
         tunebody_index = -1
         for i, line in enumerate(lines):
-            if '[V:' in line:
+            if "[V:" in line:
                 tunebody_index = i
                 break
 
-        metadata_lines = lines[ : tunebody_index]
-        tunebody_lines = lines[tunebody_index : ]
+        metadata_lines = lines[:tunebody_index]
+        tunebody_lines = lines[tunebody_index:]
 
         if self.stream:
-            tunebody_lines = ['[r:' + str(line_index) + '/' + str(len(tunebody_lines) - line_index - 1) + ']' + line for line_index, line in
-                                enumerate(tunebody_lines)]    
+            tunebody_lines = [
+                "[r:"
+                + str(line_index)
+                + "/"
+                + str(len(tunebody_lines) - line_index - 1)
+                + "]"
+                + line
+                for line_index, line in enumerate(tunebody_lines)
+            ]
 
         metadata_patches = self.patchilize_metadata(metadata_lines)
-        tunebody_patches = self.patchilize_tunebody(tunebody_lines, encode_mode='train')
+        tunebody_patches = self.patchilize_tunebody(tunebody_lines, encode_mode="train")
 
         if add_special_patches:
-            bos_patch = chr(self.bos_token_id) * (patch_size - 1) + chr(self.eos_token_id)
-            eos_patch = chr(self.bos_token_id) + chr(self.eos_token_id) * (patch_size - 1)
+            bos_patch = chr(self.bos_token_id) * (patch_size - 1) + chr(
+                self.eos_token_id
+            )
+            eos_patch = chr(self.bos_token_id) + chr(self.eos_token_id) * (
+                patch_size - 1
+            )
 
             metadata_patches = [bos_patch] + metadata_patches
             tunebody_patches = tunebody_patches + [eos_patch]
 
         if self.stream:
             if len(metadata_patches) + len(tunebody_patches) > patch_length:
-                available_cut_indexes = [0] + [index + 1 for index, patch in enumerate(tunebody_patches) if '\n' in patch]
-                line_index_for_cut_index = list(range(len(available_cut_indexes)))  
+                available_cut_indexes = [0] + [
+                    index + 1
+                    for index, patch in enumerate(tunebody_patches)
+                    if "\n" in patch
+                ]
+                line_index_for_cut_index = list(range(len(available_cut_indexes)))
                 end_index = len(metadata_patches) + len(tunebody_patches) - patch_length
-                biggest_index = bisect.bisect_left(available_cut_indexes, end_index) 
-                available_cut_indexes = available_cut_indexes[:biggest_index + 1]
+                biggest_index = bisect.bisect_left(available_cut_indexes, end_index)
+                available_cut_indexes = available_cut_indexes[: biggest_index + 1]
 
                 if len(available_cut_indexes) == 1:
-                    choices = ['head']
+                    choices = ["head"]
                 elif len(available_cut_indexes) == 2:
-                    choices = ['head', 'tail']
+                    choices = ["head", "tail"]
                 else:
-                    choices = ['head', 'tail', 'middle']
+                    choices = ["head", "tail", "middle"]
                 choice = random.choice(choices)
-                if choice == 'head':
+                if choice == "head":
                     patches = metadata_patches + tunebody_patches[0:]
                 else:
-                    if choice == 'tail':
+                    if choice == "tail":
                         cut_index = len(available_cut_indexes) - 1
                     else:
-                        cut_index = random.choice(range(1, len(available_cut_indexes) - 1))
+                        cut_index = random.choice(
+                            range(1, len(available_cut_indexes) - 1)
+                        )
 
-                    line_index = line_index_for_cut_index[cut_index] 
-                    stream_tunebody_lines = tunebody_lines[line_index : ]
-                    
-                    stream_tunebody_patches = self.patchilize_tunebody(stream_tunebody_lines, encode_mode='train')
+                    line_index = line_index_for_cut_index[cut_index]
+                    stream_tunebody_lines = tunebody_lines[line_index:]
+
+                    stream_tunebody_patches = self.patchilize_tunebody(
+                        stream_tunebody_lines, encode_mode="train"
+                    )
                     if add_special_patches:
                         stream_tunebody_patches = stream_tunebody_patches + [eos_patch]
                     patches = metadata_patches + stream_tunebody_patches
@@ -152,52 +185,68 @@ class Patchilizer:
         else:
             patches = metadata_patches + tunebody_patches
 
-        if cut: 
-            patches = patches[ : patch_length]
-        else:   
+        if cut:
+            patches = patches[:patch_length]
+        else:
             pass
 
         # encode to ids
         id_patches = []
         for patch in patches:
-            id_patch = [ord(c) for c in patch] + [self.special_token_id] * (patch_size - len(patch))
+            id_patch = [ord(c) for c in patch] + [self.special_token_id] * (
+                patch_size - len(patch)
+            )
             id_patches.append(id_patch)
 
         return id_patches
 
-    def encode_generate(self, abc_code, patch_length=PATCH_LENGTH, patch_size=PATCH_SIZE, add_special_patches=True):
+    def encode_generate(
+        self,
+        abc_code,
+        patch_length=PATCH_LENGTH,
+        patch_size=PATCH_SIZE,
+        add_special_patches=True,
+    ):
 
-        lines = abc_code.split('\n')
+        lines = abc_code.split("\n")
         lines = list(filter(None, lines))
-    
+
         tunebody_index = None
         for i, line in enumerate(lines):
-            if line.startswith('[V:') or line.startswith('[r:'):
+            if line.startswith("[V:") or line.startswith("[r:"):
                 tunebody_index = i
                 break
-    
-        metadata_lines = lines[ : tunebody_index]
-        tunebody_lines = lines[tunebody_index : ]   
-    
-        metadata_lines = [line + '\n' for line in metadata_lines]
+
+        metadata_lines = lines[:tunebody_index]
+        tunebody_lines = lines[tunebody_index:]
+
+        metadata_lines = [line + "\n" for line in metadata_lines]
         if self.stream:
-            if not abc_code.endswith('\n'):
-                tunebody_lines = [tunebody_lines[i] + '\n' for i in range(len(tunebody_lines) - 1)] + [tunebody_lines[-1]]
+            if not abc_code.endswith("\n"):
+                tunebody_lines = [
+                    tunebody_lines[i] + "\n" for i in range(len(tunebody_lines) - 1)
+                ] + [tunebody_lines[-1]]
             else:
-                tunebody_lines = [tunebody_lines[i] + '\n' for i in range(len(tunebody_lines))]
+                tunebody_lines = [
+                    tunebody_lines[i] + "\n" for i in range(len(tunebody_lines))
+                ]
         else:
-            tunebody_lines = [line + '\n' for line in tunebody_lines]
-    
+            tunebody_lines = [line + "\n" for line in tunebody_lines]
+
         metadata_patches = self.patchilize_metadata(metadata_lines)
-        tunebody_patches = self.patchilize_tunebody(tunebody_lines, encode_mode='generate')
-    
+        tunebody_patches = self.patchilize_tunebody(
+            tunebody_lines, encode_mode="generate"
+        )
+
         if add_special_patches:
-            bos_patch = chr(self.bos_token_id) * (patch_size - 1) + chr(self.eos_token_id)
+            bos_patch = chr(self.bos_token_id) * (patch_size - 1) + chr(
+                self.eos_token_id
+            )
 
             metadata_patches = [bos_patch] + metadata_patches
-    
+
         patches = metadata_patches + tunebody_patches
-        patches = patches[ : patch_length]
+        patches = patches[:patch_length]
 
         # encode to ids
         id_patches = []
@@ -205,34 +254,33 @@ class Patchilizer:
             if len(patch) < PATCH_SIZE and patch[-1] != chr(self.eos_token_id):
                 id_patch = [ord(c) for c in patch]
             else:
-                id_patch = [ord(c) for c in patch] + [self.special_token_id] * (patch_size - len(patch))
+                id_patch = [ord(c) for c in patch] + [self.special_token_id] * (
+                    patch_size - len(patch)
+                )
             id_patches.append(id_patch)
-        
+
         return id_patches
 
     def decode(self, patches):
         """
         Decode patches into music.
         """
-        return ''.join(self.patch2chars(patch) for patch in patches)
-
-        
+        return "".join(self.patch2chars(patch) for patch in patches)
 
 
 class PatchLevelDecoder(PreTrainedModel):
     """
-    A Patch-level Decoder model for generating patch features in an auto-regressive manner. 
+    A Patch-level Decoder model for generating patch features in an auto-regressive manner.
     It inherits PreTrainedModel from transformers.
     """
+
     def __init__(self, config):
         super().__init__(config)
         self.patch_embedding = torch.nn.Linear(PATCH_SIZE * 128, config.n_embd)
         torch.nn.init.normal_(self.patch_embedding.weight, std=0.02)
         self.base = GPT2Model(config)
 
-    def forward(self,
-                patches: torch.Tensor,
-                masks=None) -> torch.Tensor:
+    def forward(self, patches: torch.Tensor, masks=None) -> torch.Tensor:
         """
         The forward pass of the patch-level decoder model.
         :param patches: the patches to be encoded
@@ -243,11 +291,10 @@ class PatchLevelDecoder(PreTrainedModel):
         patches = patches.reshape(len(patches), -1, PATCH_SIZE * (128))
         patches = self.patch_embedding(patches.to(self.device))
 
-        if masks==None:
+        if masks == None:
             return self.base(inputs_embeds=patches)
         else:
-            return self.base(inputs_embeds=patches,
-                             attention_mask=masks)
+            return self.base(inputs_embeds=patches, attention_mask=masks)
 
 
 class CharLevelDecoder(PreTrainedModel):
@@ -255,6 +302,7 @@ class CharLevelDecoder(PreTrainedModel):
     A Char-level Decoder model for generating the chars within each patch in an auto-regressive manner
     based on the encoded patch features. It inherits PreTrainedModel from transformers.
     """
+
     def __init__(self, config):
         super().__init__(config)
         self.special_token_id = 0
@@ -262,9 +310,7 @@ class CharLevelDecoder(PreTrainedModel):
 
         self.base = GPT2LMHeadModel(config)
 
-    def forward(self,
-                encoded_patches: torch.Tensor,
-                target_patches: torch.Tensor):
+    def forward(self, encoded_patches: torch.Tensor, target_patches: torch.Tensor):
         """
         The forward pass of the char-level decoder model.
         :param encoded_patches: the encoded patches
@@ -272,7 +318,13 @@ class CharLevelDecoder(PreTrainedModel):
         :return: the output of the model
         """
         # preparing the labels for model training
-        target_patches = torch.cat((torch.ones_like(target_patches[:,0:1])*self.bos_token_id, target_patches), dim=1)
+        target_patches = torch.cat(
+            (
+                torch.ones_like(target_patches[:, 0:1]) * self.bos_token_id,
+                target_patches,
+            ),
+            dim=1,
+        )
         # print('target_patches shape:', target_patches.shape)
 
         target_masks = target_patches == self.special_token_id
@@ -283,53 +335,61 @@ class CharLevelDecoder(PreTrainedModel):
         target_masks = target_masks.masked_fill_(labels == -100, 0)
 
         # select patches
-        if PATCH_SAMPLING_BATCH_SIZE!=0 and PATCH_SAMPLING_BATCH_SIZE<target_patches.shape[0]:
+        if (
+            PATCH_SAMPLING_BATCH_SIZE != 0
+            and PATCH_SAMPLING_BATCH_SIZE < target_patches.shape[0]
+        ):
             indices = list(range(len(target_patches)))
             random.shuffle(indices)
             selected_indices = sorted(indices[:PATCH_SAMPLING_BATCH_SIZE])
 
-            target_patches = target_patches[selected_indices,:]
-            target_masks = target_masks[selected_indices,:]
-            encoded_patches = encoded_patches[selected_indices,:]
+            target_patches = target_patches[selected_indices, :]
+            target_masks = target_masks[selected_indices, :]
+            encoded_patches = encoded_patches[selected_indices, :]
 
         # get input embeddings
-        inputs_embeds = torch.nn.functional.embedding(target_patches, self.base.transformer.wte.weight)
+        inputs_embeds = torch.nn.functional.embedding(
+            target_patches, self.base.transformer.wte.weight
+        )
 
         # concatenate the encoded patches with the input embeddings
-        inputs_embeds = torch.cat((encoded_patches.unsqueeze(1), inputs_embeds[:,1:,:]), dim=1)
+        inputs_embeds = torch.cat(
+            (encoded_patches.unsqueeze(1), inputs_embeds[:, 1:, :]), dim=1
+        )
 
-        output = self.base(inputs_embeds=inputs_embeds, 
-                         attention_mask=target_masks,
-                         labels=labels)
-                         # output_hidden_states=True=True)
+        output = self.base(
+            inputs_embeds=inputs_embeds, attention_mask=target_masks, labels=labels
+        )
+        # output_hidden_states=True=True)
 
         return output
 
-    def generate(self,
-                 encoded_patch: torch.Tensor,   # [hidden_size]
-                 tokens: torch.Tensor): # [1]
+    def generate(
+        self, encoded_patch: torch.Tensor, tokens: torch.Tensor  # [hidden_size]
+    ):  # [1]
         """
         The generate function for generating a patch based on the encoded patch and already generated tokens.
         :param encoded_patch: the encoded patch
         :param tokens: already generated tokens in the patch
         :return: the probability distribution of next token
         """
-        encoded_patch = encoded_patch.reshape(1, 1, -1) # [1, 1, hidden_size]
+        encoded_patch = encoded_patch.reshape(1, 1, -1)  # [1, 1, hidden_size]
         tokens = tokens.reshape(1, -1)
 
         # Get input embeddings
         tokens = torch.nn.functional.embedding(tokens, self.base.transformer.wte.weight)
 
         # Concatenate the encoded patch with the input embeddings
-        tokens = torch.cat((encoded_patch, tokens[:,1:,:]), dim=1)
-        
+        tokens = torch.cat((encoded_patch, tokens[:, 1:, :]), dim=1)
+
         # Get output from model
         outputs = self.base(inputs_embeds=tokens)
-        
+
         # Get probabilities of next token
         probs = torch.nn.functional.softmax(outputs.logits.squeeze(0)[-1], dim=-1)
 
         return probs
+
 
 def safe_normalize_probs(probs):
     epsilon = 1e-12  # Smallest value to avoid log(0) and maintain precision
@@ -344,6 +404,7 @@ def safe_normalize_probs(probs):
         probs[0] = 1.0
     return probs
 
+
 class NotaGenLMHeadModel(PreTrainedModel):
     """
     NotaGen is a language model with a hierarchical structure.
@@ -352,6 +413,7 @@ class NotaGenLMHeadModel(PreTrainedModel):
     The char-level decoder is used to generate the chars within each patch in an auto-regressive manner.
     It inherits PreTrainedModel from transformers.
     """
+
     def __init__(self, encoder_config, decoder_config):
         super().__init__(encoder_config)
         self.special_token_id = 0
@@ -360,9 +422,7 @@ class NotaGenLMHeadModel(PreTrainedModel):
         self.patch_level_decoder = PatchLevelDecoder(encoder_config)
         self.char_level_decoder = CharLevelDecoder(decoder_config)
 
-    def forward(self,
-                patches: torch.Tensor,
-                masks: torch.Tensor):
+    def forward(self, patches: torch.Tensor, masks: torch.Tensor):
         """
         The forward pass of the bGPT model.
         :param patches: the patches to be encoded
@@ -371,20 +431,16 @@ class NotaGenLMHeadModel(PreTrainedModel):
         """
         patches = patches.reshape(len(patches), -1, PATCH_SIZE)
         encoded_patches = self.patch_level_decoder(patches, masks)["last_hidden_state"]
-        
+
         left_shift_masks = masks * (masks.flip(1).cumsum(1).flip(1) > 1)
         masks[:, 0] = 0
-        
+
         encoded_patches = encoded_patches[left_shift_masks == 1]
-        patches = patches[masks == 1]        
+        patches = patches[masks == 1]
 
         return self.char_level_decoder(encoded_patches, patches)
-        
-    def generate(self,
-                 patches: torch.Tensor,
-                 top_k=0,
-                 top_p=1,
-                 temperature=1.0):
+
+    def generate(self, patches: torch.Tensor, top_k=0, top_p=1, temperature=1.0):
         """
         The generate function for generating patches based on patches.
         :param patches: the patches to be encoded
@@ -394,30 +450,41 @@ class NotaGenLMHeadModel(PreTrainedModel):
         :return: the generated patches
         """
         if patches.shape[-1] % PATCH_SIZE != 0:
-            tokens = patches[:,:,-(patches.shape[-1]%PATCH_SIZE):].squeeze(0, 1)
-            tokens = torch.cat((torch.tensor([self.bos_token_id], device=self.device), tokens), dim=-1)
-            patches = patches[:,:,:-(patches.shape[-1]%PATCH_SIZE)]
+            tokens = patches[:, :, -(patches.shape[-1] % PATCH_SIZE) :].squeeze(0, 1)
+            tokens = torch.cat(
+                (torch.tensor([self.bos_token_id], device=self.device), tokens), dim=-1
+            )
+            patches = patches[:, :, : -(patches.shape[-1] % PATCH_SIZE)]
         else:
-            tokens =  torch.tensor([self.bos_token_id], device=self.device)
+            tokens = torch.tensor([self.bos_token_id], device=self.device)
 
-        patches = patches.reshape(len(patches), -1, PATCH_SIZE) # [bs, seq, patch_size]
-        encoded_patches = self.patch_level_decoder(patches)["last_hidden_state"]    # [bs, seq, hidden_size]
-        generated_patch = []            
+        patches = patches.reshape(len(patches), -1, PATCH_SIZE)  # [bs, seq, patch_size]
+        encoded_patches = self.patch_level_decoder(patches)[
+            "last_hidden_state"
+        ]  # [bs, seq, hidden_size]
+        generated_patch = []
 
         while True:
-            prob = self.char_level_decoder.generate(encoded_patches[0][-1], tokens).cpu().detach().numpy()  # [128]
+            prob = (
+                self.char_level_decoder.generate(encoded_patches[0][-1], tokens)
+                .cpu()
+                .detach()
+                .numpy()
+            )  # [128]
             prob = safe_normalize_probs(prob)
-            prob = top_k_sampling(prob, top_k=top_k, return_probs=True) # [128]
+            prob = top_k_sampling(prob, top_k=top_k, return_probs=True)  # [128]
             prob = safe_normalize_probs(prob)
-            prob = top_p_sampling(prob, top_p=top_p, return_probs=True) # [128]
+            prob = top_p_sampling(prob, top_p=top_p, return_probs=True)  # [128]
             prob = safe_normalize_probs(prob)
-            token = temperature_sampling(prob, temperature=temperature) # int
+            token = temperature_sampling(prob, temperature=temperature)  # int
             char = chr(token)
             generated_patch.append(token)
 
-            if len(tokens) >= PATCH_SIZE:# or token == self.eos_token_id:
+            if len(tokens) >= PATCH_SIZE:  # or token == self.eos_token_id:
                 break
             else:
-                tokens = torch.cat((tokens, torch.tensor([token], device=self.device)), dim=0)
-        
+                tokens = torch.cat(
+                    (tokens, torch.tensor([token], device=self.device)), dim=0
+                )
+
         return generated_patch

--- a/inference/config.py
+++ b/inference/config.py
@@ -1,18 +1,38 @@
 import os
 
 # Configurations for inference
-INFERENCE_WEIGHTS_PATH = ''               # Path to weights for inference# Folder to save output files
-NUM_SAMPLES = 1000                                               # Number of samples to generate (only for generate mode)
-TOP_K = 9                                                       # Top k for sampling
-TOP_P = 0.9                                                      # Top p for sampling
-TEMPERATURE = 1.2                                                 # Temperature for sampling
-ORIGINAL_OUTPUT_FOLDER = os.path.join('../output/original', os.path.splitext(os.path.split(INFERENCE_WEIGHTS_PATH)[-1])[0] + '_k_' + str(TOP_K) + '_p_' + str(TOP_P) + '_temp_' + str(TEMPERATURE))
-INTERLEAVED_OUTPUT_FOLDER = os.path.join('../output/interleaved', os.path.splitext(os.path.split(INFERENCE_WEIGHTS_PATH)[-1])[0] + '_k_' + str(TOP_K) + '_p_' + str(TOP_P) + '_temp_' + str(TEMPERATURE))
+INFERENCE_WEIGHTS_PATH = (
+    ""  # Path to weights for inference# Folder to save output files
+)
+NUM_SAMPLES = 1000  # Number of samples to generate (only for generate mode)
+TOP_K = 9  # Top k for sampling
+TOP_P = 0.9  # Top p for sampling
+TEMPERATURE = 1.2  # Temperature for sampling
+ORIGINAL_OUTPUT_FOLDER = os.path.join(
+    "../output/original",
+    os.path.splitext(os.path.split(INFERENCE_WEIGHTS_PATH)[-1])[0]
+    + "_k_"
+    + str(TOP_K)
+    + "_p_"
+    + str(TOP_P)
+    + "_temp_"
+    + str(TEMPERATURE),
+)
+INTERLEAVED_OUTPUT_FOLDER = os.path.join(
+    "../output/interleaved",
+    os.path.splitext(os.path.split(INFERENCE_WEIGHTS_PATH)[-1])[0]
+    + "_k_"
+    + str(TOP_K)
+    + "_p_"
+    + str(TOP_P)
+    + "_temp_"
+    + str(TEMPERATURE),
+)
 
 # Configurations for model
-PATCH_STREAM = True                                             # Stream training / inference
-PATCH_SIZE = 16                                                # Patch Size
-PATCH_LENGTH = 1024                                             # Patch Length
-CHAR_NUM_LAYERS = 6                                             # Number of layers in the decoder
-PATCH_NUM_LAYERS = 20                                           # Number of layers in the encoder
-HIDDEN_SIZE = 1280                                               # Hidden Size
+PATCH_STREAM = True  # Stream training / inference
+PATCH_SIZE = 16  # Patch Size
+PATCH_LENGTH = 1024  # Patch Length
+CHAR_NUM_LAYERS = 6  # Number of layers in the decoder
+PATCH_NUM_LAYERS = 20  # Number of layers in the encoder
+HIDDEN_SIZE = 1280  # Hidden Size

--- a/inference/inference.py
+++ b/inference/inference.py
@@ -1,15 +1,14 @@
-
 import os
 import time
 import torch
 from utils import *
 from config import *
-from transformers import GPT2Config, LlamaConfig
-from abctoolkit.utils import Exclaim_re, Quote_re, SquareBracket_re, Barline_regexPattern
-from abctoolkit.transpose import Note_list, Pitch_sign_list
+from transformers import GPT2Config
+from abctoolkit.utils import Barline_regexPattern
+from abctoolkit.transpose import Note_list
 from abctoolkit.duration import calculate_bartext_duration
 
-Note_list = Note_list + ['z', 'x']
+Note_list = Note_list + ["z", "x"]
 
 if torch.cuda.is_available():
     device = torch.device("cuda")
@@ -21,25 +20,32 @@ os.makedirs(INTERLEAVED_OUTPUT_FOLDER, exist_ok=True)
 
 patchilizer = Patchilizer()
 
-patch_config = GPT2Config(num_hidden_layers=PATCH_NUM_LAYERS,
-                          max_length=PATCH_LENGTH,
-                          max_position_embeddings=PATCH_LENGTH,
-                          n_embd=HIDDEN_SIZE,
-                          num_attention_heads=HIDDEN_SIZE // 64,
-                          vocab_size=1)
-byte_config = GPT2Config(num_hidden_layers=CHAR_NUM_LAYERS,
-                         max_length=PATCH_SIZE + 1,
-                         max_position_embeddings=PATCH_SIZE + 1,
-                         hidden_size=HIDDEN_SIZE,
-                         num_attention_heads=HIDDEN_SIZE // 64,
-                         vocab_size=128)
+patch_config = GPT2Config(
+    num_hidden_layers=PATCH_NUM_LAYERS,
+    max_length=PATCH_LENGTH,
+    max_position_embeddings=PATCH_LENGTH,
+    n_embd=HIDDEN_SIZE,
+    num_attention_heads=HIDDEN_SIZE // 64,
+    vocab_size=1,
+)
+byte_config = GPT2Config(
+    num_hidden_layers=CHAR_NUM_LAYERS,
+    max_length=PATCH_SIZE + 1,
+    max_position_embeddings=PATCH_SIZE + 1,
+    hidden_size=HIDDEN_SIZE,
+    num_attention_heads=HIDDEN_SIZE // 64,
+    vocab_size=128,
+)
 
 model = NotaGenLMHeadModel(encoder_config=patch_config, decoder_config=byte_config)
 
-print("Parameter Number: " + str(sum(p.numel() for p in model.parameters() if p.requires_grad)))
+print(
+    "Parameter Number: "
+    + str(sum(p.numel() for p in model.parameters() if p.requires_grad))
+)
 
 checkpoint = torch.load(INFERENCE_WEIGHTS_PATH, map_location=torch.device(device))
-model.load_state_dict(checkpoint['model'])
+model.load_state_dict(checkpoint["model"])
 model = model.to(device)
 model.eval()
 
@@ -48,21 +54,21 @@ def rest_unreduce(abc_lines):
 
     tunebody_index = None
     for i in range(len(abc_lines)):
-        if '[V:' in abc_lines[i]:
+        if "[V:" in abc_lines[i]:
             tunebody_index = i
             break
 
-    metadata_lines = abc_lines[: tunebody_index]
+    metadata_lines = abc_lines[:tunebody_index]
     tunebody_lines = abc_lines[tunebody_index:]
 
     part_symbol_list = []
     voice_group_list = []
     for line in metadata_lines:
-        if line.startswith('%%score'):
-            for round_bracket_match in re.findall(r'\((.*?)\)', line):
+        if line.startswith("%%score"):
+            for round_bracket_match in re.findall(r"\((.*?)\)", line):
                 voice_group_list.append(round_bracket_match.split())
             existed_voices = [item for sublist in voice_group_list for item in sublist]
-        if line.startswith('V:'):
+        if line.startswith("V:"):
             symbol = line.split()[0]
             part_symbol_list.append(symbol)
             if symbol[2:] not in existed_voices:
@@ -70,33 +76,33 @@ def rest_unreduce(abc_lines):
     z_symbol_list = []  # voices that use z as rest
     x_symbol_list = []  # voices that use x as rest
     for voice_group in voice_group_list:
-        z_symbol_list.append('V:' + voice_group[0])
+        z_symbol_list.append("V:" + voice_group[0])
         for j in range(1, len(voice_group)):
-            x_symbol_list.append('V:' + voice_group[j])
+            x_symbol_list.append("V:" + voice_group[j])
 
     part_symbol_list.sort(key=lambda x: int(x[2:]))
 
     unreduced_tunebody_lines = []
 
     for i, line in enumerate(tunebody_lines):
-        unreduced_line = ''
+        unreduced_line = ""
 
-        line = re.sub(r'^\[r:[^\]]*\]', '', line)
+        line = re.sub(r"^\[r:[^\]]*\]", "", line)
 
-        pattern = r'\[V:(\d+)\](.*?)(?=\[V:|$)'
+        pattern = r"\[V:(\d+)\](.*?)(?=\[V:|$)"
         matches = re.findall(pattern, line)
 
         line_bar_dict = {}
         for match in matches:
-            key = f'V:{match[0]}'
+            key = f"V:{match[0]}"
             value = match[1]
             line_bar_dict[key] = value
 
         # calculate duration and collect barline
-        dur_dict = {}  
+        dur_dict = {}
         for symbol, bartext in line_bar_dict.items():
-            right_barline = ''.join(re.split(Barline_regexPattern, bartext)[-2:])
-            bartext = bartext[:-len(right_barline)]
+            right_barline = "".join(re.split(Barline_regexPattern, bartext)[-2:])
+            bartext = bartext[: -len(right_barline)]
             try:
                 bar_dur = calculate_bartext_duration(bartext)
             except:
@@ -110,24 +116,28 @@ def rest_unreduce(abc_lines):
         try:
             ref_dur = max(dur_dict, key=dur_dict.get)
         except:
-            pass    # use last ref_dur
+            pass  # use last ref_dur
 
         if i == 0:
-            prefix_left_barline = line.split('[V:')[0]
+            prefix_left_barline = line.split("[V:")[0]
         else:
-            prefix_left_barline = ''
+            prefix_left_barline = ""
 
         for symbol in part_symbol_list:
             if symbol in line_bar_dict.keys():
                 symbol_bartext = line_bar_dict[symbol]
             else:
                 if symbol in z_symbol_list:
-                    symbol_bartext = prefix_left_barline + 'z' + str(ref_dur) + right_barline
+                    symbol_bartext = (
+                        prefix_left_barline + "z" + str(ref_dur) + right_barline
+                    )
                 elif symbol in x_symbol_list:
-                    symbol_bartext = prefix_left_barline + 'x' + str(ref_dur) + right_barline
-            unreduced_line += '[' + symbol + ']' + symbol_bartext
+                    symbol_bartext = (
+                        prefix_left_barline + "x" + str(ref_dur) + right_barline
+                    )
+            unreduced_line += "[" + symbol + "]" + symbol_bartext
 
-        unreduced_tunebody_lines.append(unreduced_line + '\n')
+        unreduced_tunebody_lines.append(unreduced_line + "\n")
 
     unreduced_lines = metadata_lines + unreduced_tunebody_lines
 
@@ -138,7 +148,9 @@ def inference_patch(prompt_lines=[], pieces=NUM_SAMPLES):
 
     file_no = 1
 
-    bos_patch = [patchilizer.bos_token_id] * (PATCH_SIZE - 1) + [patchilizer.eos_token_id]
+    bos_patch = [patchilizer.bos_token_id] * (PATCH_SIZE - 1) + [
+        patchilizer.eos_token_id
+    ]
 
     while file_no <= pieces:
 
@@ -146,11 +158,14 @@ def inference_patch(prompt_lines=[], pieces=NUM_SAMPLES):
         start_time_format = time.strftime("%Y%m%d-%H%M%S")
 
         prompt_patches = patchilizer.patchilize_metadata(prompt_lines)
-        byte_list = list(''.join(prompt_lines))
-        print(''.join(byte_list), end='')
+        byte_list = list("".join(prompt_lines))
+        print("".join(byte_list), end="")
 
-        prompt_patches = [[ord(c) for c in patch] + [patchilizer.special_token_id] * (PATCH_SIZE - len(patch)) for patch
-                          in prompt_patches]
+        prompt_patches = [
+            [ord(c) for c in patch]
+            + [patchilizer.special_token_id] * (PATCH_SIZE - len(patch))
+            for patch in prompt_patches
+        ]
         prompt_patches.insert(0, bos_patch)
 
         input_patches = torch.tensor(prompt_patches, device=device).reshape(1, -1)
@@ -161,27 +176,38 @@ def inference_patch(prompt_lines=[], pieces=NUM_SAMPLES):
 
         tunebody_flag = False
         while True:
-            predicted_patch = model.generate(input_patches.unsqueeze(0),
-                                             top_k=TOP_K,
-                                             top_p=TOP_P,
-                                             temperature=TEMPERATURE)
-            if not tunebody_flag and patchilizer.decode([predicted_patch]).startswith('[r:'):  # start with [r:0/
+            predicted_patch = model.generate(
+                input_patches.unsqueeze(0),
+                top_k=TOP_K,
+                top_p=TOP_P,
+                temperature=TEMPERATURE,
+            )
+            if not tunebody_flag and patchilizer.decode([predicted_patch]).startswith(
+                "[r:"
+            ):  # start with [r:0/
                 tunebody_flag = True
-                r0_patch = torch.tensor([ord(c) for c in '[r:0/']).unsqueeze(0).to(device)
+                r0_patch = (
+                    torch.tensor([ord(c) for c in "[r:0/"]).unsqueeze(0).to(device)
+                )
                 temp_input_patches = torch.concat([input_patches, r0_patch], axis=-1)
-                predicted_patch = model.generate(temp_input_patches.unsqueeze(0),
-                                                 top_k=TOP_K,
-                                                 top_p=TOP_P,
-                                                 temperature=TEMPERATURE)
-                predicted_patch = [ord(c) for c in '[r:0/'] + predicted_patch
-            if predicted_patch[0] == patchilizer.bos_token_id and predicted_patch[1] == patchilizer.eos_token_id:
+                predicted_patch = model.generate(
+                    temp_input_patches.unsqueeze(0),
+                    top_k=TOP_K,
+                    top_p=TOP_P,
+                    temperature=TEMPERATURE,
+                )
+                predicted_patch = [ord(c) for c in "[r:0/"] + predicted_patch
+            if (
+                predicted_patch[0] == patchilizer.bos_token_id
+                and predicted_patch[1] == patchilizer.eos_token_id
+            ):
                 end_flag = True
                 break
             next_patch = patchilizer.decode([predicted_patch])
 
             for char in next_patch:
                 byte_list.append(char)
-                print(char, end='')
+                print(char, end="")
 
             patch_end_flag = False
             for j in range(len(predicted_patch)):
@@ -191,23 +217,25 @@ def inference_patch(prompt_lines=[], pieces=NUM_SAMPLES):
                     patch_end_flag = True
 
             predicted_patch = torch.tensor([predicted_patch], device=device)  # (1, 16)
-            input_patches = torch.cat([input_patches, predicted_patch], dim=1)  # (1, 16 * patch_len)
+            input_patches = torch.cat(
+                [input_patches, predicted_patch], dim=1
+            )  # (1, 16 * patch_len)
 
-            if len(byte_list) > 102400:  
+            if len(byte_list) > 102400:
                 failure_flag = True
                 break
-            if time.time() - start_time > 20 * 60:  
+            if time.time() - start_time > 20 * 60:
                 failure_flag = True
                 break
 
             if input_patches.shape[1] >= PATCH_LENGTH * PATCH_SIZE and not end_flag:
-                print('Stream generating...')
-                abc_code = ''.join(byte_list)
-                abc_lines = abc_code.split('\n')
+                print("Stream generating...")
+                abc_code = "".join(byte_list)
+                abc_lines = abc_code.split("\n")
 
                 tunebody_index = None
                 for i, line in enumerate(abc_lines):
-                    if line.startswith('[r:') or line.startswith('[V:'):
+                    if line.startswith("[r:") or line.startswith("[V:"):
                         tunebody_index = i
                         break
                 if tunebody_index is None or tunebody_index == len(abc_lines) - 1:
@@ -216,17 +244,20 @@ def inference_patch(prompt_lines=[], pieces=NUM_SAMPLES):
                 metadata_lines = abc_lines[:tunebody_index]
                 tunebody_lines = abc_lines[tunebody_index:]
 
-                metadata_lines = [line + '\n' for line in metadata_lines]
-                if not abc_code.endswith('\n'):  
-                    tunebody_lines = [tunebody_lines[i] + '\n' for i in range(len(tunebody_lines) - 1)] + [
-                        tunebody_lines[-1]]
+                metadata_lines = [line + "\n" for line in metadata_lines]
+                if not abc_code.endswith("\n"):
+                    tunebody_lines = [
+                        tunebody_lines[i] + "\n" for i in range(len(tunebody_lines) - 1)
+                    ] + [tunebody_lines[-1]]
                 else:
-                    tunebody_lines = [tunebody_lines[i] + '\n' for i in range(len(tunebody_lines))]
+                    tunebody_lines = [
+                        tunebody_lines[i] + "\n" for i in range(len(tunebody_lines))
+                    ]
 
                 if cut_index is None:
                     cut_index = len(tunebody_lines) // 2
 
-                abc_code_slice = ''.join(metadata_lines + tunebody_lines[-cut_index:])
+                abc_code_slice = "".join(metadata_lines + tunebody_lines[-cut_index:])
                 input_patches = patchilizer.encode_generate(abc_code_slice)
 
                 input_patches = [item for sublist in input_patches for item in sublist]
@@ -236,36 +267,41 @@ def inference_patch(prompt_lines=[], pieces=NUM_SAMPLES):
         if not failure_flag:
             generation_time_cost = time.time() - start_time
 
-            abc_text = ''.join(byte_list)
-            filename = time.strftime("%Y%m%d-%H%M%S") + \
-                    "_" + format(generation_time_cost, '.2f') + '_' + str(file_no) + ".abc"
-                    
+            abc_text = "".join(byte_list)
+            filename = (
+                time.strftime("%Y%m%d-%H%M%S")
+                + "_"
+                + format(generation_time_cost, ".2f")
+                + "_"
+                + str(file_no)
+                + ".abc"
+            )
+
             # unreduce
             unreduced_output_path = os.path.join(INTERLEAVED_OUTPUT_FOLDER, filename)
-            
-            abc_lines = abc_text.split('\n')
+
+            abc_lines = abc_text.split("\n")
             abc_lines = list(filter(None, abc_lines))
-            abc_lines = [line + '\n' for line in abc_lines]
+            abc_lines = [line + "\n" for line in abc_lines]
             try:
                 abc_lines = rest_unreduce(abc_lines)
 
-                with open(unreduced_output_path, 'w') as file:
+                with open(unreduced_output_path, "w") as file:
                     file.writelines(abc_lines)
             except:
                 pass
             else:
                 # original
                 original_output_path = os.path.join(ORIGINAL_OUTPUT_FOLDER, filename)
-                with open(original_output_path, 'w') as w:
+                with open(original_output_path, "w") as w:
                     w.write(abc_text)
 
                 file_no += 1
 
         else:
-            print('failed')
+            print("failed")
 
 
-
-if __name__ == '__main__':
+if __name__ == "__main__":
 
     inference_patch()

--- a/inference/utils.py
+++ b/inference/utils.py
@@ -1,20 +1,18 @@
 import torch
 import random
 import bisect
-import json
 import re
 import numpy as np
 from config import *
-from transformers import GPT2Model, GPT2LMHeadModel, LlamaModel, LlamaForCausalLM, PreTrainedModel
+from transformers import GPT2Model, GPT2LMHeadModel, PreTrainedModel
 from samplings import top_p_sampling, top_k_sampling, temperature_sampling
-from tokenizers import Tokenizer
 
 
 class Patchilizer:
     def __init__(self, stream=PATCH_STREAM):
         self.stream = stream
         self.delimiters = ["|:", "::", ":|", "[|", "||", "|]", "|"]
-        self.regexPattern = '(' + '|'.join(map(re.escape, self.delimiters)) + ')'
+        self.regexPattern = "(" + "|".join(map(re.escape, self.delimiters)) + ")"
         self.bos_token_id = 1
         self.eos_token_id = 2
         self.special_token_id = 0
@@ -34,11 +32,19 @@ class Patchilizer:
                     new_line_bars = line_bars
                 else:
                     if line_bars[0] in self.delimiters:
-                        new_line_bars = [line_bars[i] + line_bars[i + 1] for i in range(0, len(line_bars), 2)]
+                        new_line_bars = [
+                            line_bars[i] + line_bars[i + 1]
+                            for i in range(0, len(line_bars), 2)
+                        ]
                     else:
-                        new_line_bars = [line_bars[0]] + [line_bars[i] + line_bars[i + 1] for i in range(1, len(line_bars), 2)]
-                    if 'V' not in new_line_bars[-1]:
-                        new_line_bars[-2] += new_line_bars[-1]  # 吸收最后一个 小节线+\n 的组合
+                        new_line_bars = [line_bars[0]] + [
+                            line_bars[i] + line_bars[i + 1]
+                            for i in range(1, len(line_bars), 2)
+                        ]
+                    if "V" not in new_line_bars[-1]:
+                        new_line_bars[-2] += new_line_bars[
+                            -1
+                        ]  # 吸收最后一个 小节线+\n 的组合
                         new_line_bars = new_line_bars[:-1]
                 new_bars += new_line_bars
         except:
@@ -49,14 +55,16 @@ class Patchilizer:
     def split_patches(self, abc_text, patch_size=PATCH_SIZE, generate_last=False):
         if not generate_last and len(abc_text) % patch_size != 0:
             abc_text += chr(self.eos_token_id)
-        patches = [abc_text[i : i + patch_size] for i in range(0, len(abc_text), patch_size)]
+        patches = [
+            abc_text[i : i + patch_size] for i in range(0, len(abc_text), patch_size)
+        ]
         return patches
 
     def patch2chars(self, patch):
         """
         Convert a patch into a bar.
         """
-        bytes = ''
+        bytes = ""
         for idx in patch:
             if idx == self.eos_token_id:
                 break
@@ -64,7 +72,6 @@ class Patchilizer:
                 pass
             bytes += chr(idx)
         return bytes
-        
 
     def patchilize_metadata(self, metadata_lines):
 
@@ -73,77 +80,103 @@ class Patchilizer:
             metadata_patches += self.split_patches(line)
 
         return metadata_patches
-    
-    def patchilize_tunebody(self, tunebody_lines, encode_mode='train'):
+
+    def patchilize_tunebody(self, tunebody_lines, encode_mode="train"):
 
         tunebody_patches = []
         bars = self.split_bars(tunebody_lines)
-        if encode_mode == 'train':
+        if encode_mode == "train":
             for bar in bars:
                 tunebody_patches += self.split_patches(bar)
-        elif encode_mode == 'generate':
+        elif encode_mode == "generate":
             for bar in bars[:-1]:
                 tunebody_patches += self.split_patches(bar)
             tunebody_patches += self.split_patches(bars[-1], generate_last=True)
-       
+
         return tunebody_patches
 
-    def encode_train(self, abc_text, patch_length=PATCH_LENGTH, patch_size=PATCH_SIZE, add_special_patches=True, cut=True):
+    def encode_train(
+        self,
+        abc_text,
+        patch_length=PATCH_LENGTH,
+        patch_size=PATCH_SIZE,
+        add_special_patches=True,
+        cut=True,
+    ):
 
-        lines = abc_text.split('\n')
+        lines = abc_text.split("\n")
         lines = list(filter(None, lines))
-        lines = [line + '\n' for line in lines]
+        lines = [line + "\n" for line in lines]
 
         tunebody_index = -1
         for i, line in enumerate(lines):
-            if '[V:' in line:
+            if "[V:" in line:
                 tunebody_index = i
                 break
 
-        metadata_lines = lines[ : tunebody_index]
-        tunebody_lines = lines[tunebody_index : ]
+        metadata_lines = lines[:tunebody_index]
+        tunebody_lines = lines[tunebody_index:]
 
         if self.stream:
-            tunebody_lines = ['[r:' + str(line_index) + '/' + str(len(tunebody_lines) - line_index - 1) + ']' + line for line_index, line in
-                                enumerate(tunebody_lines)]    
+            tunebody_lines = [
+                "[r:"
+                + str(line_index)
+                + "/"
+                + str(len(tunebody_lines) - line_index - 1)
+                + "]"
+                + line
+                for line_index, line in enumerate(tunebody_lines)
+            ]
 
         metadata_patches = self.patchilize_metadata(metadata_lines)
-        tunebody_patches = self.patchilize_tunebody(tunebody_lines, encode_mode='train')
+        tunebody_patches = self.patchilize_tunebody(tunebody_lines, encode_mode="train")
 
         if add_special_patches:
-            bos_patch = chr(self.bos_token_id) * (patch_size - 1) + chr(self.eos_token_id)
-            eos_patch = chr(self.bos_token_id) + chr(self.eos_token_id) * (patch_size - 1)
+            bos_patch = chr(self.bos_token_id) * (patch_size - 1) + chr(
+                self.eos_token_id
+            )
+            eos_patch = chr(self.bos_token_id) + chr(self.eos_token_id) * (
+                patch_size - 1
+            )
 
             metadata_patches = [bos_patch] + metadata_patches
             tunebody_patches = tunebody_patches + [eos_patch]
 
         if self.stream:
             if len(metadata_patches) + len(tunebody_patches) > patch_length:
-                available_cut_indexes = [0] + [index + 1 for index, patch in enumerate(tunebody_patches) if '\n' in patch]
-                line_index_for_cut_index = list(range(len(available_cut_indexes)))  
+                available_cut_indexes = [0] + [
+                    index + 1
+                    for index, patch in enumerate(tunebody_patches)
+                    if "\n" in patch
+                ]
+                line_index_for_cut_index = list(range(len(available_cut_indexes)))
                 end_index = len(metadata_patches) + len(tunebody_patches) - patch_length
-                biggest_index = bisect.bisect_left(available_cut_indexes, end_index) 
-                available_cut_indexes = available_cut_indexes[:biggest_index + 1]
+                biggest_index = bisect.bisect_left(available_cut_indexes, end_index)
+                available_cut_indexes = available_cut_indexes[: biggest_index + 1]
 
                 if len(available_cut_indexes) == 1:
-                    choices = ['head']
+                    choices = ["head"]
                 elif len(available_cut_indexes) == 2:
-                    choices = ['head', 'tail']
+                    choices = ["head", "tail"]
                 else:
-                    choices = ['head', 'tail', 'middle']
+                    choices = ["head", "tail", "middle"]
                 choice = random.choice(choices)
-                if choice == 'head':
+                if choice == "head":
                     patches = metadata_patches + tunebody_patches[0:]
                 else:
-                    if choice == 'tail':
+                    if choice == "tail":
                         cut_index = len(available_cut_indexes) - 1
                     else:
-                        cut_index = random.choice(range(1, len(available_cut_indexes) - 1))
+                        cut_index = random.choice(
+                            range(1, len(available_cut_indexes) - 1)
+                        )
 
-                    line_index = line_index_for_cut_index[cut_index] 
-                    stream_tunebody_lines = tunebody_lines[line_index : ]
-                    
-                    stream_tunebody_patches = self.patchilize_tunebody(stream_tunebody_lines, encode_mode='train')
+                    line_index = line_index_for_cut_index[cut_index]
+                    stream_tunebody_lines = tunebody_lines[line_index:]
+
+                    stream_tunebody_patches = self.patchilize_tunebody(
+                        stream_tunebody_lines, encode_mode="train"
+                    )
                     if add_special_patches:
                         stream_tunebody_patches = stream_tunebody_patches + [eos_patch]
                     patches = metadata_patches + stream_tunebody_patches
@@ -152,52 +185,68 @@ class Patchilizer:
         else:
             patches = metadata_patches + tunebody_patches
 
-        if cut: 
-            patches = patches[ : patch_length]
-        else:   
+        if cut:
+            patches = patches[:patch_length]
+        else:
             pass
 
         # encode to ids
         id_patches = []
         for patch in patches:
-            id_patch = [ord(c) for c in patch] + [self.special_token_id] * (patch_size - len(patch))
+            id_patch = [ord(c) for c in patch] + [self.special_token_id] * (
+                patch_size - len(patch)
+            )
             id_patches.append(id_patch)
 
         return id_patches
 
-    def encode_generate(self, abc_code, patch_length=PATCH_LENGTH, patch_size=PATCH_SIZE, add_special_patches=True):
+    def encode_generate(
+        self,
+        abc_code,
+        patch_length=PATCH_LENGTH,
+        patch_size=PATCH_SIZE,
+        add_special_patches=True,
+    ):
 
-        lines = abc_code.split('\n')
+        lines = abc_code.split("\n")
         lines = list(filter(None, lines))
-    
+
         tunebody_index = None
         for i, line in enumerate(lines):
-            if line.startswith('[V:') or line.startswith('[r:'):
+            if line.startswith("[V:") or line.startswith("[r:"):
                 tunebody_index = i
                 break
-    
-        metadata_lines = lines[ : tunebody_index]
-        tunebody_lines = lines[tunebody_index : ]   
-    
-        metadata_lines = [line + '\n' for line in metadata_lines]
+
+        metadata_lines = lines[:tunebody_index]
+        tunebody_lines = lines[tunebody_index:]
+
+        metadata_lines = [line + "\n" for line in metadata_lines]
         if self.stream:
-            if not abc_code.endswith('\n'):
-                tunebody_lines = [tunebody_lines[i] + '\n' for i in range(len(tunebody_lines) - 1)] + [tunebody_lines[-1]]
+            if not abc_code.endswith("\n"):
+                tunebody_lines = [
+                    tunebody_lines[i] + "\n" for i in range(len(tunebody_lines) - 1)
+                ] + [tunebody_lines[-1]]
             else:
-                tunebody_lines = [tunebody_lines[i] + '\n' for i in range(len(tunebody_lines))]
+                tunebody_lines = [
+                    tunebody_lines[i] + "\n" for i in range(len(tunebody_lines))
+                ]
         else:
-            tunebody_lines = [line + '\n' for line in tunebody_lines]
-    
+            tunebody_lines = [line + "\n" for line in tunebody_lines]
+
         metadata_patches = self.patchilize_metadata(metadata_lines)
-        tunebody_patches = self.patchilize_tunebody(tunebody_lines, encode_mode='generate')
-    
+        tunebody_patches = self.patchilize_tunebody(
+            tunebody_lines, encode_mode="generate"
+        )
+
         if add_special_patches:
-            bos_patch = chr(self.bos_token_id) * (patch_size - 1) + chr(self.eos_token_id)
+            bos_patch = chr(self.bos_token_id) * (patch_size - 1) + chr(
+                self.eos_token_id
+            )
 
             metadata_patches = [bos_patch] + metadata_patches
-    
+
         patches = metadata_patches + tunebody_patches
-        patches = patches[ : patch_length]
+        patches = patches[:patch_length]
 
         # encode to ids
         id_patches = []
@@ -205,34 +254,33 @@ class Patchilizer:
             if len(patch) < PATCH_SIZE and patch[-1] != chr(self.eos_token_id):
                 id_patch = [ord(c) for c in patch]
             else:
-                id_patch = [ord(c) for c in patch] + [self.special_token_id] * (patch_size - len(patch))
+                id_patch = [ord(c) for c in patch] + [self.special_token_id] * (
+                    patch_size - len(patch)
+                )
             id_patches.append(id_patch)
-        
+
         return id_patches
 
     def decode(self, patches):
         """
         Decode patches into music.
         """
-        return ''.join(self.patch2chars(patch) for patch in patches)
-
-        
+        return "".join(self.patch2chars(patch) for patch in patches)
 
 
 class PatchLevelDecoder(PreTrainedModel):
     """
-    A Patch-level Decoder model for generating patch features in an auto-regressive manner. 
+    A Patch-level Decoder model for generating patch features in an auto-regressive manner.
     It inherits PreTrainedModel from transformers.
     """
+
     def __init__(self, config):
         super().__init__(config)
         self.patch_embedding = torch.nn.Linear(PATCH_SIZE * 128, config.n_embd)
         torch.nn.init.normal_(self.patch_embedding.weight, std=0.02)
         self.base = GPT2Model(config)
 
-    def forward(self,
-                patches: torch.Tensor,
-                masks=None) -> torch.Tensor:
+    def forward(self, patches: torch.Tensor, masks=None) -> torch.Tensor:
         """
         The forward pass of the patch-level decoder model.
         :param patches: the patches to be encoded
@@ -243,11 +291,10 @@ class PatchLevelDecoder(PreTrainedModel):
         patches = patches.reshape(len(patches), -1, PATCH_SIZE * (128))
         patches = self.patch_embedding(patches.to(self.device))
 
-        if masks==None:
+        if masks == None:
             return self.base(inputs_embeds=patches)
         else:
-            return self.base(inputs_embeds=patches,
-                             attention_mask=masks)
+            return self.base(inputs_embeds=patches, attention_mask=masks)
 
 
 class CharLevelDecoder(PreTrainedModel):
@@ -255,6 +302,7 @@ class CharLevelDecoder(PreTrainedModel):
     A Char-level Decoder model for generating the chars within each patch in an auto-regressive manner
     based on the encoded patch features. It inherits PreTrainedModel from transformers.
     """
+
     def __init__(self, config):
         super().__init__(config)
         self.special_token_id = 0
@@ -262,9 +310,7 @@ class CharLevelDecoder(PreTrainedModel):
 
         self.base = GPT2LMHeadModel(config)
 
-    def forward(self,
-                encoded_patches: torch.Tensor,
-                target_patches: torch.Tensor):
+    def forward(self, encoded_patches: torch.Tensor, target_patches: torch.Tensor):
         """
         The forward pass of the char-level decoder model.
         :param encoded_patches: the encoded patches
@@ -272,7 +318,13 @@ class CharLevelDecoder(PreTrainedModel):
         :return: the output of the model
         """
         # preparing the labels for model training
-        target_patches = torch.cat((torch.ones_like(target_patches[:,0:1])*self.bos_token_id, target_patches), dim=1)
+        target_patches = torch.cat(
+            (
+                torch.ones_like(target_patches[:, 0:1]) * self.bos_token_id,
+                target_patches,
+            ),
+            dim=1,
+        )
         # print('target_patches shape:', target_patches.shape)
 
         target_masks = target_patches == self.special_token_id
@@ -283,53 +335,61 @@ class CharLevelDecoder(PreTrainedModel):
         target_masks = target_masks.masked_fill_(labels == -100, 0)
 
         # select patches
-        if PATCH_SAMPLING_BATCH_SIZE!=0 and PATCH_SAMPLING_BATCH_SIZE<target_patches.shape[0]:
+        if (
+            PATCH_SAMPLING_BATCH_SIZE != 0
+            and PATCH_SAMPLING_BATCH_SIZE < target_patches.shape[0]
+        ):
             indices = list(range(len(target_patches)))
             random.shuffle(indices)
             selected_indices = sorted(indices[:PATCH_SAMPLING_BATCH_SIZE])
 
-            target_patches = target_patches[selected_indices,:]
-            target_masks = target_masks[selected_indices,:]
-            encoded_patches = encoded_patches[selected_indices,:]
+            target_patches = target_patches[selected_indices, :]
+            target_masks = target_masks[selected_indices, :]
+            encoded_patches = encoded_patches[selected_indices, :]
 
         # get input embeddings
-        inputs_embeds = torch.nn.functional.embedding(target_patches, self.base.transformer.wte.weight)
+        inputs_embeds = torch.nn.functional.embedding(
+            target_patches, self.base.transformer.wte.weight
+        )
 
         # concatenate the encoded patches with the input embeddings
-        inputs_embeds = torch.cat((encoded_patches.unsqueeze(1), inputs_embeds[:,1:,:]), dim=1)
+        inputs_embeds = torch.cat(
+            (encoded_patches.unsqueeze(1), inputs_embeds[:, 1:, :]), dim=1
+        )
 
-        output = self.base(inputs_embeds=inputs_embeds, 
-                         attention_mask=target_masks,
-                         labels=labels)
-                         # output_hidden_states=True=True)
+        output = self.base(
+            inputs_embeds=inputs_embeds, attention_mask=target_masks, labels=labels
+        )
+        # output_hidden_states=True=True)
 
         return output
 
-    def generate(self,
-                 encoded_patch: torch.Tensor,   # [hidden_size]
-                 tokens: torch.Tensor): # [1]
+    def generate(
+        self, encoded_patch: torch.Tensor, tokens: torch.Tensor  # [hidden_size]
+    ):  # [1]
         """
         The generate function for generating a patch based on the encoded patch and already generated tokens.
         :param encoded_patch: the encoded patch
         :param tokens: already generated tokens in the patch
         :return: the probability distribution of next token
         """
-        encoded_patch = encoded_patch.reshape(1, 1, -1) # [1, 1, hidden_size]
+        encoded_patch = encoded_patch.reshape(1, 1, -1)  # [1, 1, hidden_size]
         tokens = tokens.reshape(1, -1)
 
         # Get input embeddings
         tokens = torch.nn.functional.embedding(tokens, self.base.transformer.wte.weight)
 
         # Concatenate the encoded patch with the input embeddings
-        tokens = torch.cat((encoded_patch, tokens[:,1:,:]), dim=1)
-        
+        tokens = torch.cat((encoded_patch, tokens[:, 1:, :]), dim=1)
+
         # Get output from model
         outputs = self.base(inputs_embeds=tokens)
-        
+
         # Get probabilities of next token
         probs = torch.nn.functional.softmax(outputs.logits.squeeze(0)[-1], dim=-1)
 
         return probs
+
 
 def safe_normalize_probs(probs):
     epsilon = 1e-12
@@ -344,6 +404,7 @@ def safe_normalize_probs(probs):
         probs[0] = 1.0
     return probs
 
+
 class NotaGenLMHeadModel(PreTrainedModel):
     """
     NotaGen is a language model with a hierarchical structure.
@@ -352,6 +413,7 @@ class NotaGenLMHeadModel(PreTrainedModel):
     The char-level decoder is used to generate the chars within each patch in an auto-regressive manner.
     It inherits PreTrainedModel from transformers.
     """
+
     def __init__(self, encoder_config, decoder_config):
         super().__init__(encoder_config)
         self.special_token_id = 0
@@ -360,9 +422,7 @@ class NotaGenLMHeadModel(PreTrainedModel):
         self.patch_level_decoder = PatchLevelDecoder(encoder_config)
         self.char_level_decoder = CharLevelDecoder(decoder_config)
 
-    def forward(self,
-                patches: torch.Tensor,
-                masks: torch.Tensor):
+    def forward(self, patches: torch.Tensor, masks: torch.Tensor):
         """
         The forward pass of the bGPT model.
         :param patches: the patches to be encoded
@@ -371,20 +431,16 @@ class NotaGenLMHeadModel(PreTrainedModel):
         """
         patches = patches.reshape(len(patches), -1, PATCH_SIZE)
         encoded_patches = self.patch_level_decoder(patches, masks)["last_hidden_state"]
-        
+
         left_shift_masks = masks * (masks.flip(1).cumsum(1).flip(1) > 1)
         masks[:, 0] = 0
-        
+
         encoded_patches = encoded_patches[left_shift_masks == 1]
-        patches = patches[masks == 1]        
+        patches = patches[masks == 1]
 
         return self.char_level_decoder(encoded_patches, patches)
-        
-    def generate(self,
-                 patches: torch.Tensor,
-                 top_k=0,
-                 top_p=1,
-                 temperature=1.0):
+
+    def generate(self, patches: torch.Tensor, top_k=0, top_p=1, temperature=1.0):
         """
         The generate function for generating patches based on patches.
         :param patches: the patches to be encoded
@@ -394,30 +450,41 @@ class NotaGenLMHeadModel(PreTrainedModel):
         :return: the generated patches
         """
         if patches.shape[-1] % PATCH_SIZE != 0:
-            tokens = patches[:,:,-(patches.shape[-1]%PATCH_SIZE):].squeeze(0, 1)
-            tokens = torch.cat((torch.tensor([self.bos_token_id], device=self.device), tokens), dim=-1)
-            patches = patches[:,:,:-(patches.shape[-1]%PATCH_SIZE)]
+            tokens = patches[:, :, -(patches.shape[-1] % PATCH_SIZE) :].squeeze(0, 1)
+            tokens = torch.cat(
+                (torch.tensor([self.bos_token_id], device=self.device), tokens), dim=-1
+            )
+            patches = patches[:, :, : -(patches.shape[-1] % PATCH_SIZE)]
         else:
-            tokens =  torch.tensor([self.bos_token_id], device=self.device)
+            tokens = torch.tensor([self.bos_token_id], device=self.device)
 
-        patches = patches.reshape(len(patches), -1, PATCH_SIZE) # [bs, seq, patch_size]
-        encoded_patches = self.patch_level_decoder(patches)["last_hidden_state"]    # [bs, seq, hidden_size]
-        generated_patch = []            
+        patches = patches.reshape(len(patches), -1, PATCH_SIZE)  # [bs, seq, patch_size]
+        encoded_patches = self.patch_level_decoder(patches)[
+            "last_hidden_state"
+        ]  # [bs, seq, hidden_size]
+        generated_patch = []
 
         while True:
-            prob = self.char_level_decoder.generate(encoded_patches[0][-1], tokens).cpu().detach().numpy()  # [128]
+            prob = (
+                self.char_level_decoder.generate(encoded_patches[0][-1], tokens)
+                .cpu()
+                .detach()
+                .numpy()
+            )  # [128]
             prob = safe_normalize_probs(prob)
-            prob = top_k_sampling(prob, top_k=top_k, return_probs=True) # [128]
+            prob = top_k_sampling(prob, top_k=top_k, return_probs=True)  # [128]
             prob = safe_normalize_probs(prob)
-            prob = top_p_sampling(prob, top_p=top_p, return_probs=True) # [128]
+            prob = top_p_sampling(prob, top_p=top_p, return_probs=True)  # [128]
             prob = safe_normalize_probs(prob)
-            token = temperature_sampling(prob, temperature=temperature) # int
+            token = temperature_sampling(prob, temperature=temperature)  # int
             char = chr(token)
             generated_patch.append(token)
 
-            if len(tokens) >= PATCH_SIZE:# or token == self.eos_token_id:
+            if len(tokens) >= PATCH_SIZE:  # or token == self.eos_token_id:
                 break
             else:
-                tokens = torch.cat((tokens, torch.tensor([token], device=self.device)), dim=0)
-        
+                tokens = torch.cat(
+                    (tokens, torch.tensor([token], device=self.device)), dim=0
+                )
+
         return generated_patch

--- a/notebook/abc2xml.py
+++ b/notebook/abc2xml.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # coding=latin-1
-'''
+"""
 Copyright (C) 2012-2018: Willem G. Vree
 Contributions: Nils Liberg, Nicolas Froment, Norman Schmidt, Reinier Maliepaard, Martin Tarenskeen,
                Paul Villiger, Alexander Scheutzow, Herbert Schneider, David Randolph, Michael Strasser
@@ -11,21 +11,28 @@ Lesser GNU General Public License as published by the Free Software Foundation;
 This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
 without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 See the Lesser GNU General Public License for more details. <http://www.gnu.org/licenses/lgpl.html>.
-'''
+"""
 
 from functools import reduce
-from pyparsing import Word, OneOrMore, Optional, Literal, NotAny, MatchFirst
+from pyparsing import Word, OneOrMore, Optional, Literal, MatchFirst
 from pyparsing import Group, oneOf, Suppress, ZeroOrMore, Combine, FollowedBy
-from pyparsing import srange, CharsNotIn, StringEnd, LineEnd, White, Regex
-from pyparsing import nums, alphas, alphanums, ParseException, Forward
-try:    import xml.etree.cElementTree as E
-except: import xml.etree.ElementTree as E
-import types, sys, os, re, datetime
+from pyparsing import srange, CharsNotIn, StringEnd, Regex
+from pyparsing import nums, alphanums, ParseException, Forward
+
+try:
+    import xml.etree.cElementTree as E
+except:
+    import xml.etree.ElementTree as E
+import types
+import sys
+import os
+import re
+import datetime
 
 VERSION = 245
 
 python3 = sys.version_info[0] > 2
-lmap = lambda f, xs: list (map (f, xs))   # eager map for python 3
+lmap = lambda f, xs: list(map(f, xs))  # eager map for python 3
 if python3:
     int_type = int
     list_type = list
@@ -40,2213 +47,3491 @@ else:
     stdin = sys.stdin
 
 info_list = []  # diagnostic messages
-def info (s, warn=1):
-    x = (warn and '-- ' or '') + s
-    info_list.append (x + '\n')         # collect messages
-    if __name__ == '__main__':          # only write to stdout when called as main progeam
-        try: sys.stderr.write (x + '\n')
-        except: sys.stderr.write (repr (x) + '\n')
 
-def getInfo (): # get string of diagnostic messages, then clear messages
+
+def info(s, warn=1):
+    x = (warn and "-- " or "") + s
+    info_list.append(x + "\n")  # collect messages
+    if __name__ == "__main__":  # only write to stdout when called as main progeam
+        try:
+            sys.stderr.write(x + "\n")
+        except:
+            sys.stderr.write(repr(x) + "\n")
+
+
+def getInfo():  # get string of diagnostic messages, then clear messages
     global info_list
-    xs = ''.join (info_list)
+    xs = "".join(info_list)
     info_list = []
     return xs
 
-def abc_grammar ():     # header, voice and lyrics grammar for ABC
-    #-----------------------------------------------------------------
+
+def abc_grammar():  # header, voice and lyrics grammar for ABC
+    # -----------------------------------------------------------------
     # expressions that catch and skip some syntax errors (see corresponding parse expressions)
-    #-----------------------------------------------------------------
-    b1 = Word (u"-,'<>\u2019#", exact=1)    # catch misplaced chars in chords
-    b2 = Regex ('[^H-Wh-w~=]*')             # same in user defined symbol definition
-    b3 = Regex ('[^=]*')                    # same, second part
+    # -----------------------------------------------------------------
+    b1 = Word("-,'<>\u2019#", exact=1)  # catch misplaced chars in chords
+    b2 = Regex("[^H-Wh-w~=]*")  # same in user defined symbol definition
+    b3 = Regex("[^=]*")  # same, second part
 
-    #-----------------------------------------------------------------
+    # -----------------------------------------------------------------
     # ABC header (field_str elements are matched later with reg. epr's)
-    #-----------------------------------------------------------------
+    # -----------------------------------------------------------------
 
-    number = Word (nums).setParseAction (lambda t: int (t[0]))
-    field_str = Regex (r'[^]]*')  # match anything until end of field
-    field_str.setParseAction (lambda t: t[0].strip ())  # and strip spacing
+    number = Word(nums).setParseAction(lambda t: int(t[0]))
+    field_str = Regex(r"[^]]*")  # match anything until end of field
+    field_str.setParseAction(lambda t: t[0].strip())  # and strip spacing
 
-    userdef_symbol  = Word (srange ('[H-Wh-w~]'), exact=1)
-    fieldId = oneOf ('K L M Q P I T C O A Z N G H R B D F S E r Y') # info fields
-    X_field = Literal ('X') + Suppress (':') + field_str
-    U_field = Literal ('U') + Suppress (':') + b2 + Optional (userdef_symbol, 'H') + b3 + Suppress ('=') + field_str
-    V_field = Literal ('V') + Suppress (':') + Word (alphanums + '_') + field_str
-    inf_fld = fieldId + Suppress (':') + field_str
-    ifield = Suppress ('[') + (X_field | U_field | V_field | inf_fld) + Suppress (']')
-    abc_header = OneOrMore (ifield) + StringEnd ()
+    userdef_symbol = Word(srange("[H-Wh-w~]"), exact=1)
+    fieldId = oneOf("K L M Q P I T C O A Z N G H R B D F S E r Y")  # info fields
+    X_field = Literal("X") + Suppress(":") + field_str
+    U_field = (
+        Literal("U")
+        + Suppress(":")
+        + b2
+        + Optional(userdef_symbol, "H")
+        + b3
+        + Suppress("=")
+        + field_str
+    )
+    V_field = Literal("V") + Suppress(":") + Word(alphanums + "_") + field_str
+    inf_fld = fieldId + Suppress(":") + field_str
+    ifield = Suppress("[") + (X_field | U_field | V_field | inf_fld) + Suppress("]")
+    abc_header = OneOrMore(ifield) + StringEnd()
 
-    #---------------------------------------------------------------------------------
+    # ---------------------------------------------------------------------------------
     # I:score with recursive part groups and {* grand staff marker
-    #---------------------------------------------------------------------------------
+    # ---------------------------------------------------------------------------------
 
-    voiceId = Suppress (Optional ('*')) + Word (alphanums + '_')
-    voice_gr = Suppress ('(') + OneOrMore (voiceId | Suppress ('|')) + Suppress (')')
-    simple_part = voiceId | voice_gr | Suppress ('|')
-    grand_staff = oneOf ('{* {') + OneOrMore (simple_part) + Suppress ('}')
-    part = Forward ()
-    part_seq = OneOrMore (part | Suppress ('|'))
-    brace_gr = Suppress ('{') + part_seq + Suppress ('}')
-    bracket_gr = Suppress ('[') + part_seq + Suppress (']')
-    part <<= MatchFirst (simple_part | grand_staff | brace_gr | bracket_gr | Suppress ('|'))
-    abc_scoredef = Suppress (oneOf ('staves score')) + OneOrMore (part)
+    voiceId = Suppress(Optional("*")) + Word(alphanums + "_")
+    voice_gr = Suppress("(") + OneOrMore(voiceId | Suppress("|")) + Suppress(")")
+    simple_part = voiceId | voice_gr | Suppress("|")
+    grand_staff = oneOf("{* {") + OneOrMore(simple_part) + Suppress("}")
+    part = Forward()
+    part_seq = OneOrMore(part | Suppress("|"))
+    brace_gr = Suppress("{") + part_seq + Suppress("}")
+    bracket_gr = Suppress("[") + part_seq + Suppress("]")
+    part <<= MatchFirst(
+        simple_part | grand_staff | brace_gr | bracket_gr | Suppress("|")
+    )
+    abc_scoredef = Suppress(oneOf("staves score")) + OneOrMore(part)
 
-    #----------------------------------------
+    # ----------------------------------------
     # ABC lyric lines (white space sensitive)
-    #----------------------------------------
+    # ----------------------------------------
 
-    skip_note   = oneOf ('* -')
-    extend_note = Literal ('_')
-    measure_end = Literal ('|')
-    syl_str     = CharsNotIn ('*-_| \t\n\\]')
-    syl_chars   = Combine (OneOrMore (syl_str | Regex (r'\\.')))
-    white       = Word (' \t')
-    syllable    = syl_chars + Optional ('-')
-    lyr_elem    = (syllable | skip_note | extend_note | measure_end) + Optional (white).suppress ()
-    lyr_line    = Optional (white).suppress () + ZeroOrMore (lyr_elem)
-    
-    syllable.setParseAction (lambda t: pObj ('syl', t))
-    skip_note.setParseAction (lambda t: pObj ('skip', t))
-    extend_note.setParseAction (lambda t: pObj ('ext', t))
-    measure_end.setParseAction (lambda t: pObj ('sbar', t))
-    lyr_line_wsp = lyr_line.leaveWhitespace ()   # parse actions must be set before calling leaveWhitespace
+    skip_note = oneOf("* -")
+    extend_note = Literal("_")
+    measure_end = Literal("|")
+    syl_str = CharsNotIn("*-_| \t\n\\]")
+    syl_chars = Combine(OneOrMore(syl_str | Regex(r"\\.")))
+    white = Word(" \t")
+    syllable = syl_chars + Optional("-")
+    lyr_elem = (syllable | skip_note | extend_note | measure_end) + Optional(
+        white
+    ).suppress()
+    lyr_line = Optional(white).suppress() + ZeroOrMore(lyr_elem)
 
-    #---------------------------------------------------------------------------------
+    syllable.setParseAction(lambda t: pObj("syl", t))
+    skip_note.setParseAction(lambda t: pObj("skip", t))
+    extend_note.setParseAction(lambda t: pObj("ext", t))
+    measure_end.setParseAction(lambda t: pObj("sbar", t))
+    lyr_line_wsp = (
+        lyr_line.leaveWhitespace()
+    )  # parse actions must be set before calling leaveWhitespace
+
+    # ---------------------------------------------------------------------------------
     # ABC voice (not white space sensitive, beams detected in note/rest parse actions)
-    #---------------------------------------------------------------------------------
+    # ---------------------------------------------------------------------------------
 
-    inline_field =  Suppress ('[') + (inf_fld | U_field | V_field) + Suppress (']')
-    lyr_fld = Suppress ('[') + Suppress ('w') + Suppress (':') + lyr_line_wsp + Suppress (']')  # lyric line
-    lyr_blk = OneOrMore (lyr_fld)       # verses
-    fld_or_lyr = inline_field | lyr_blk # inline field or block of lyric verses
+    inline_field = Suppress("[") + (inf_fld | U_field | V_field) + Suppress("]")
+    lyr_fld = (
+        Suppress("[") + Suppress("w") + Suppress(":") + lyr_line_wsp + Suppress("]")
+    )  # lyric line
+    lyr_blk = OneOrMore(lyr_fld)  # verses
+    fld_or_lyr = inline_field | lyr_blk  # inline field or block of lyric verses
 
-    note_length = Optional (number, 1) + Group (ZeroOrMore ('/')) + Optional (number, 2)
-    octaveHigh = OneOrMore ("'").setParseAction (lambda t: len(t))
-    octaveLow = OneOrMore (',').setParseAction (lambda t: -len(t))
-    octave  = octaveHigh | octaveLow
+    note_length = Optional(number, 1) + Group(ZeroOrMore("/")) + Optional(number, 2)
+    octaveHigh = OneOrMore("'").setParseAction(lambda t: len(t))
+    octaveLow = OneOrMore(",").setParseAction(lambda t: -len(t))
+    octave = octaveHigh | octaveLow
 
-    basenote = oneOf ('C D E F G A B c d e f g a b y')  # includes spacer for parse efficiency
-    accidental = oneOf ('^^ __ ^ _ =')
-    rest_sym  = oneOf ('x X z Z')
-    slur_beg = oneOf ("( (, (' .( .(, .('") + ~Word (nums)    # no tuplet_start
-    slur_ends = OneOrMore (oneOf (') .)'))
+    basenote = oneOf(
+        "C D E F G A B c d e f g a b y"
+    )  # includes spacer for parse efficiency
+    accidental = oneOf("^^ __ ^ _ =")
+    rest_sym = oneOf("x X z Z")
+    slur_beg = oneOf("( (, (' .( .(, .('") + ~Word(nums)  # no tuplet_start
+    slur_ends = OneOrMore(oneOf(") .)"))
 
-    long_decoration = Combine (oneOf ('! +') + CharsNotIn ('!+ \n') + oneOf ('! +'))
-    staccato        = Literal ('.') + ~Literal ('|')    # avoid dotted barline
-    pizzicato       = Literal ('!+!')   # special case: plus sign is old style deco marker
-    decoration      = slur_beg | staccato | userdef_symbol | long_decoration | pizzicato
-    decorations     = OneOrMore (decoration)
+    long_decoration = Combine(oneOf("! +") + CharsNotIn("!+ \n") + oneOf("! +"))
+    staccato = Literal(".") + ~Literal("|")  # avoid dotted barline
+    pizzicato = Literal("!+!")  # special case: plus sign is old style deco marker
+    decoration = slur_beg | staccato | userdef_symbol | long_decoration | pizzicato
+    decorations = OneOrMore(decoration)
 
-    tie = oneOf ('.- -')
-    rest = Optional (accidental) + rest_sym + note_length
-    pitch = Optional (accidental) + basenote + Optional (octave, 0)
-    note = pitch + note_length + Optional (tie) + Optional (slur_ends)
-    dec_note = Optional (decorations) + pitch + note_length + Optional (tie) + Optional (slur_ends)
+    tie = oneOf(".- -")
+    rest = Optional(accidental) + rest_sym + note_length
+    pitch = Optional(accidental) + basenote + Optional(octave, 0)
+    note = pitch + note_length + Optional(tie) + Optional(slur_ends)
+    dec_note = (
+        Optional(decorations)
+        + pitch
+        + note_length
+        + Optional(tie)
+        + Optional(slur_ends)
+    )
     chord_note = dec_note | rest | b1
-    grace_notes = Forward ()
-    chord = Suppress ('[') + OneOrMore (chord_note | grace_notes) + Suppress (']') + note_length + Optional (tie) + Optional (slur_ends)
+    grace_notes = Forward()
+    chord = (
+        Suppress("[")
+        + OneOrMore(chord_note | grace_notes)
+        + Suppress("]")
+        + note_length
+        + Optional(tie)
+        + Optional(slur_ends)
+    )
     stem = note | chord | rest
 
-    broken = Combine (OneOrMore ('<') | OneOrMore ('>'))
+    broken = Combine(OneOrMore("<") | OneOrMore(">"))
 
-    tuplet_num   = Suppress ('(') + number
-    tuplet_into  = Suppress (':') + Optional (number, 0)
-    tuplet_notes = Suppress (':') + Optional (number, 0)
-    tuplet_start = tuplet_num + Optional (tuplet_into + Optional (tuplet_notes))
+    tuplet_num = Suppress("(") + number
+    tuplet_into = Suppress(":") + Optional(number, 0)
+    tuplet_notes = Suppress(":") + Optional(number, 0)
+    tuplet_start = tuplet_num + Optional(tuplet_into + Optional(tuplet_notes))
 
-    acciaccatura    = Literal ('/')
-    grace_stem      = Optional (decorations) + stem
-    grace_notes     <<= Group (Suppress ('{') + Optional (acciaccatura) + OneOrMore (grace_stem) + Suppress ('}'))
+    acciaccatura = Literal("/")
+    grace_stem = Optional(decorations) + stem
+    grace_notes <<= Group(
+        Suppress("{") + Optional(acciaccatura) + OneOrMore(grace_stem) + Suppress("}")
+    )
 
-    text_expression  = Optional (oneOf ('^ _ < > @'), '^') + Optional (CharsNotIn ('"'), "")
-    chord_accidental = oneOf ('# b =')
-    triad            = oneOf ('ma Maj maj M mi min m aug dim o + -')
-    seventh          = oneOf ('7 ma7 Maj7 M7 maj7 mi7 min7 m7 dim7 o7 -7 aug7 +7 m7b5 mi7b5')
-    sixth            = oneOf ('6 ma6 M6 mi6 min6 m6')
-    ninth            = oneOf ('9 ma9 M9 maj9 Maj9 mi9 min9 m9')
-    elevn            = oneOf ('11 ma11 M11 maj11 Maj11 mi11 min11 m11')
-    thirt            = oneOf ('13 ma13 M13 maj13 Maj13 mi13 min13 m13')
-    suspended        = oneOf ('sus sus2 sus4')
-    chord_degree     = Combine (Optional (chord_accidental) + oneOf ('2 4 5 6 7 9 11 13'))
-    chord_kind       = Optional (seventh | sixth | ninth | elevn | thirt | triad) + Optional (suspended)
-    chord_root       = oneOf ('C D E F G A B') + Optional (chord_accidental)
-    chord_bass       = oneOf ('C D E F G A B') + Optional (chord_accidental) # needs a different parse action
-    chordsym         = chord_root + chord_kind + ZeroOrMore (chord_degree) + Optional (Suppress ('/') + chord_bass)
-    chord_sym        = chordsym + Optional (Literal ('(') + CharsNotIn (')') + Literal (')')).suppress ()
-    chord_or_text    = Suppress ('"') + (chord_sym ^ text_expression) + Suppress ('"')
+    text_expression = Optional(oneOf("^ _ < > @"), "^") + Optional(CharsNotIn('"'), "")
+    chord_accidental = oneOf("# b =")
+    triad = oneOf("ma Maj maj M mi min m aug dim o + -")
+    seventh = oneOf("7 ma7 Maj7 M7 maj7 mi7 min7 m7 dim7 o7 -7 aug7 +7 m7b5 mi7b5")
+    sixth = oneOf("6 ma6 M6 mi6 min6 m6")
+    ninth = oneOf("9 ma9 M9 maj9 Maj9 mi9 min9 m9")
+    elevn = oneOf("11 ma11 M11 maj11 Maj11 mi11 min11 m11")
+    thirt = oneOf("13 ma13 M13 maj13 Maj13 mi13 min13 m13")
+    suspended = oneOf("sus sus2 sus4")
+    chord_degree = Combine(Optional(chord_accidental) + oneOf("2 4 5 6 7 9 11 13"))
+    chord_kind = Optional(seventh | sixth | ninth | elevn | thirt | triad) + Optional(
+        suspended
+    )
+    chord_root = oneOf("C D E F G A B") + Optional(chord_accidental)
+    chord_bass = oneOf("C D E F G A B") + Optional(
+        chord_accidental
+    )  # needs a different parse action
+    chordsym = (
+        chord_root
+        + chord_kind
+        + ZeroOrMore(chord_degree)
+        + Optional(Suppress("/") + chord_bass)
+    )
+    chord_sym = (
+        chordsym + Optional(Literal("(") + CharsNotIn(")") + Literal(")")).suppress()
+    )
+    chord_or_text = Suppress('"') + (chord_sym ^ text_expression) + Suppress('"')
 
-    volta_nums = Optional ('[').suppress () + Combine (Word (nums) + ZeroOrMore (oneOf (', -') + Word (nums)))
-    volta_text = Literal ('[').suppress () + Regex (r'"[^"]+"')
+    volta_nums = Optional("[").suppress() + Combine(
+        Word(nums) + ZeroOrMore(oneOf(", -") + Word(nums))
+    )
+    volta_text = Literal("[").suppress() + Regex(r'"[^"]+"')
     volta = volta_nums | volta_text
-    invisible_barline = oneOf ('[|] []')
-    dashed_barline = oneOf (': .|')
-    double_rep = Literal (':') + FollowedBy (':')   # otherwise ambiguity with dashed barline
-    voice_overlay = Combine (OneOrMore ('&'))
-    bare_volta = FollowedBy (Literal ('[') + Word (nums))   # no barline, but volta follows (volta is parsed in next measure)
-    bar_left = (oneOf ('[|: |: [: :') + Optional (volta)) | Optional ('|').suppress () + volta | oneOf ('| [|')
-    bars = ZeroOrMore (':') + ZeroOrMore ('[') + OneOrMore (oneOf ('| ]'))
-    bar_right = invisible_barline | double_rep | Combine (bars) | dashed_barline | voice_overlay | bare_volta
-    
-    errors =  ~bar_right + Optional (Word (' \n')) + CharsNotIn (':&|', exact=1)
-    linebreak = Literal ('$') | ~decorations + Literal ('!')    # no need for I:linebreak !!!
-    element = fld_or_lyr | broken | decorations | stem | chord_or_text | grace_notes | tuplet_start | linebreak | errors
-    measure      = Group (ZeroOrMore (inline_field) + Optional (bar_left) + ZeroOrMore (element) + bar_right + Optional (linebreak) + Optional (lyr_blk))
-    noBarMeasure = Group (ZeroOrMore (inline_field) + Optional (bar_left) + OneOrMore (element) + Optional (linebreak) + Optional (lyr_blk))
-    abc_voice = ZeroOrMore (measure) + Optional (noBarMeasure | Group (bar_left)) + ZeroOrMore (inline_field).suppress () + StringEnd ()
+    invisible_barline = oneOf("[|] []")
+    dashed_barline = oneOf(": .|")
+    double_rep = Literal(":") + FollowedBy(
+        ":"
+    )  # otherwise ambiguity with dashed barline
+    voice_overlay = Combine(OneOrMore("&"))
+    bare_volta = FollowedBy(
+        Literal("[") + Word(nums)
+    )  # no barline, but volta follows (volta is parsed in next measure)
+    bar_left = (
+        (oneOf("[|: |: [: :") + Optional(volta))
+        | Optional("|").suppress() + volta
+        | oneOf("| [|")
+    )
+    bars = ZeroOrMore(":") + ZeroOrMore("[") + OneOrMore(oneOf("| ]"))
+    bar_right = (
+        invisible_barline
+        | double_rep
+        | Combine(bars)
+        | dashed_barline
+        | voice_overlay
+        | bare_volta
+    )
 
-    #----------------------------------------
+    errors = ~bar_right + Optional(Word(" \n")) + CharsNotIn(":&|", exact=1)
+    linebreak = Literal("$") | ~decorations + Literal(
+        "!"
+    )  # no need for I:linebreak !!!
+    element = (
+        fld_or_lyr
+        | broken
+        | decorations
+        | stem
+        | chord_or_text
+        | grace_notes
+        | tuplet_start
+        | linebreak
+        | errors
+    )
+    measure = Group(
+        ZeroOrMore(inline_field)
+        + Optional(bar_left)
+        + ZeroOrMore(element)
+        + bar_right
+        + Optional(linebreak)
+        + Optional(lyr_blk)
+    )
+    noBarMeasure = Group(
+        ZeroOrMore(inline_field)
+        + Optional(bar_left)
+        + OneOrMore(element)
+        + Optional(linebreak)
+        + Optional(lyr_blk)
+    )
+    abc_voice = (
+        ZeroOrMore(measure)
+        + Optional(noBarMeasure | Group(bar_left))
+        + ZeroOrMore(inline_field).suppress()
+        + StringEnd()
+    )
+
+    # ----------------------------------------
     # I:percmap note [step] [midi] [note-head]
-    #----------------------------------------
+    # ----------------------------------------
 
-    white2 = (white | StringEnd ()).suppress ()
-    w3 = Optional (white2)
-    percid = Word (alphanums + '-')
-    step = basenote + Optional (octave, 0)
-    pitchg = Group (Optional (accidental, '') + step + FollowedBy (white2))
-    stepg = Group (step + FollowedBy (white2)) | Literal ('*')
-    midi = (Literal ('*') | number | pitchg | percid)
-    nhd = Optional (Combine (percid + Optional ('+')), '')
-    perc_wsp = Literal ('percmap') + w3 + pitchg + w3 + Optional (stepg, '*') + w3 + Optional (midi, '*') + w3 + nhd
-    abc_percmap = perc_wsp.leaveWhitespace ()
+    white2 = (white | StringEnd()).suppress()
+    w3 = Optional(white2)
+    percid = Word(alphanums + "-")
+    step = basenote + Optional(octave, 0)
+    pitchg = Group(Optional(accidental, "") + step + FollowedBy(white2))
+    stepg = Group(step + FollowedBy(white2)) | Literal("*")
+    midi = Literal("*") | number | pitchg | percid
+    nhd = Optional(Combine(percid + Optional("+")), "")
+    perc_wsp = (
+        Literal("percmap")
+        + w3
+        + pitchg
+        + w3
+        + Optional(stepg, "*")
+        + w3
+        + Optional(midi, "*")
+        + w3
+        + nhd
+    )
+    abc_percmap = perc_wsp.leaveWhitespace()
 
-    #----------------------------------------------------------------
+    # ----------------------------------------------------------------
     # Parse actions to convert all relevant results into an abstract
     # syntax tree where all tree nodes are instances of pObj
-    #----------------------------------------------------------------
+    # ----------------------------------------------------------------
 
-    ifield.setParseAction (lambda t: pObj ('field', t))
-    grand_staff.setParseAction (lambda t: pObj ('grand', t, 1)) # 1 = keep ordered list of results
-    brace_gr.setParseAction (lambda t: pObj ('bracegr', t, 1))
-    bracket_gr.setParseAction (lambda t: pObj ('bracketgr', t, 1))
-    voice_gr.setParseAction (lambda t: pObj ('voicegr', t, 1))
-    voiceId.setParseAction (lambda t: pObj ('vid', t, 1))
-    abc_scoredef.setParseAction (lambda t: pObj ('score', t, 1))
-    note_length.setParseAction (lambda t: pObj ('dur', (t[0], (t[2] << len (t[1])) >> 1)))
-    chordsym.setParseAction (lambda t: pObj ('chordsym', t))
-    chord_root.setParseAction (lambda t: pObj ('root', t))
-    chord_kind.setParseAction (lambda t: pObj ('kind', t))
-    chord_degree.setParseAction (lambda t: pObj ('degree', t))
-    chord_bass.setParseAction (lambda t: pObj ('bass', t))
-    text_expression.setParseAction (lambda t: pObj ('text', t))
-    inline_field.setParseAction (lambda t: pObj ('inline', t))
-    lyr_fld.setParseAction (lambda t: pObj ('lyr_fld', t, 1))
-    lyr_blk.setParseAction (lambda t: pObj ('lyr_blk', t, 1)) # 1 = keep ordered list of lyric lines
-    grace_notes.setParseAction (doGrace)
-    acciaccatura.setParseAction (lambda t: pObj ('accia', t))
-    note.setParseAction (noteActn)
-    rest.setParseAction (restActn)
-    decorations.setParseAction (lambda t: pObj ('deco', t))
-    pizzicato.setParseAction (lambda t: ['!plus!']) # translate !+!
-    slur_ends.setParseAction (lambda t: pObj ('slurs', t))
-    chord.setParseAction (lambda t: pObj ('chord', t, 1))
-    dec_note.setParseAction (noteActn)
-    tie.setParseAction (lambda t: pObj ('tie', t))
-    pitch.setParseAction (lambda t: pObj ('pitch', t))
-    bare_volta.setParseAction (lambda t: ['|']) # return barline that user forgot
-    dashed_barline.setParseAction (lambda t: ['.|'])
-    bar_right.setParseAction (lambda t: pObj ('rbar', t))
-    bar_left.setParseAction (lambda t: pObj ('lbar', t))
-    broken.setParseAction (lambda t: pObj ('broken', t))
-    tuplet_start.setParseAction (lambda t: pObj ('tup', t))
-    linebreak.setParseAction (lambda t: pObj ('linebrk', t))
-    measure.setParseAction (doMaat)
-    noBarMeasure.setParseAction (doMaat)
-    b1.setParseAction (errorWarn)
-    b2.setParseAction (errorWarn)
-    b3.setParseAction (errorWarn)
-    errors.setParseAction (errorWarn)
+    ifield.setParseAction(lambda t: pObj("field", t))
+    grand_staff.setParseAction(
+        lambda t: pObj("grand", t, 1)
+    )  # 1 = keep ordered list of results
+    brace_gr.setParseAction(lambda t: pObj("bracegr", t, 1))
+    bracket_gr.setParseAction(lambda t: pObj("bracketgr", t, 1))
+    voice_gr.setParseAction(lambda t: pObj("voicegr", t, 1))
+    voiceId.setParseAction(lambda t: pObj("vid", t, 1))
+    abc_scoredef.setParseAction(lambda t: pObj("score", t, 1))
+    note_length.setParseAction(lambda t: pObj("dur", (t[0], (t[2] << len(t[1])) >> 1)))
+    chordsym.setParseAction(lambda t: pObj("chordsym", t))
+    chord_root.setParseAction(lambda t: pObj("root", t))
+    chord_kind.setParseAction(lambda t: pObj("kind", t))
+    chord_degree.setParseAction(lambda t: pObj("degree", t))
+    chord_bass.setParseAction(lambda t: pObj("bass", t))
+    text_expression.setParseAction(lambda t: pObj("text", t))
+    inline_field.setParseAction(lambda t: pObj("inline", t))
+    lyr_fld.setParseAction(lambda t: pObj("lyr_fld", t, 1))
+    lyr_blk.setParseAction(
+        lambda t: pObj("lyr_blk", t, 1)
+    )  # 1 = keep ordered list of lyric lines
+    grace_notes.setParseAction(doGrace)
+    acciaccatura.setParseAction(lambda t: pObj("accia", t))
+    note.setParseAction(noteActn)
+    rest.setParseAction(restActn)
+    decorations.setParseAction(lambda t: pObj("deco", t))
+    pizzicato.setParseAction(lambda t: ["!plus!"])  # translate !+!
+    slur_ends.setParseAction(lambda t: pObj("slurs", t))
+    chord.setParseAction(lambda t: pObj("chord", t, 1))
+    dec_note.setParseAction(noteActn)
+    tie.setParseAction(lambda t: pObj("tie", t))
+    pitch.setParseAction(lambda t: pObj("pitch", t))
+    bare_volta.setParseAction(lambda t: ["|"])  # return barline that user forgot
+    dashed_barline.setParseAction(lambda t: [".|"])
+    bar_right.setParseAction(lambda t: pObj("rbar", t))
+    bar_left.setParseAction(lambda t: pObj("lbar", t))
+    broken.setParseAction(lambda t: pObj("broken", t))
+    tuplet_start.setParseAction(lambda t: pObj("tup", t))
+    linebreak.setParseAction(lambda t: pObj("linebrk", t))
+    measure.setParseAction(doMaat)
+    noBarMeasure.setParseAction(doMaat)
+    b1.setParseAction(errorWarn)
+    b2.setParseAction(errorWarn)
+    b3.setParseAction(errorWarn)
+    errors.setParseAction(errorWarn)
 
     return abc_header, abc_voice, abc_scoredef, abc_percmap
 
-class pObj (object):    # every relevant parse result is converted into a pObj
-    def __init__ (s, name, t, seq=0):   # t = list of nested parse results
-        s.name = name   # name uniqueliy identifies this pObj
-        rest = []       # collect parse results that are not a pObj
-        attrs = {}      # new attributes
-        for x in t:     # nested pObj's become attributes of this pObj
-            if type (x) == pObj:
-                attrs [x.name] = attrs.get (x.name, []) + [x]
-            else:
-                rest.append (x)             # collect non-pObj's (mostly literals)
-        for name, xs in attrs.items ():
-            if len (xs) == 1: xs = xs[0]    # only list if more then one pObj
-            setattr (s, name, xs)           # create the new attributes
-        s.t = rest      # all nested non-pObj's (mostly literals)
-        s.objs = seq and t or []            # for nested ordered (lyric) pObj's
 
-    def __repr__ (s):   # make a nice string representation of a pObj
+class pObj(object):  # every relevant parse result is converted into a pObj
+    def __init__(s, name, t, seq=0):  # t = list of nested parse results
+        s.name = name  # name uniqueliy identifies this pObj
+        rest = []  # collect parse results that are not a pObj
+        attrs = {}  # new attributes
+        for x in t:  # nested pObj's become attributes of this pObj
+            if type(x) == pObj:
+                attrs[x.name] = attrs.get(x.name, []) + [x]
+            else:
+                rest.append(x)  # collect non-pObj's (mostly literals)
+        for name, xs in attrs.items():
+            if len(xs) == 1:
+                xs = xs[0]  # only list if more then one pObj
+            setattr(s, name, xs)  # create the new attributes
+        s.t = rest  # all nested non-pObj's (mostly literals)
+        s.objs = seq and t or []  # for nested ordered (lyric) pObj's
+
+    def __repr__(s):  # make a nice string representation of a pObj
         r = []
-        for nm in dir (s):
-            if nm.startswith ('_'): continue # skip build in attributes
-            elif nm == 'name': continue     # redundant
+        for nm in dir(s):
+            if nm.startswith("_"):
+                continue  # skip build in attributes
+            elif nm == "name":
+                continue  # redundant
             else:
-                x = getattr (s, nm)
-                if not x: continue          # s.t may be empty (list of non-pObj's)
-                if type (x) == list_type:  r.extend (x)
-                else:                           r.append (x)
+                x = getattr(s, nm)
+                if not x:
+                    continue  # s.t may be empty (list of non-pObj's)
+                if type(x) == list_type:
+                    r.extend(x)
+                else:
+                    r.append(x)
         xs = []
-        for x in r:     # recursively call __repr__ and convert all strings to latin-1
-            if isinstance (x, str_type): xs.append (x)          # string -> no recursion
-            else:                        xs.append (repr (x))   # pObj -> recursive call
-        return '(' + s.name + ' ' +','.join (xs) + ')'
+        for x in r:  # recursively call __repr__ and convert all strings to latin-1
+            if isinstance(x, str_type):
+                xs.append(x)  # string -> no recursion
+            else:
+                xs.append(repr(x))  # pObj -> recursive call
+        return "(" + s.name + " " + ",".join(xs) + ")"
 
-global prevloc                  # global to remember previous match position of a note/rest
+
+global prevloc  # global to remember previous match position of a note/rest
 prevloc = 0
-def detectBeamBreak (line, loc, t):
-    global prevloc              # location in string 'line' of previous note match
-    xs = line[prevloc:loc+1]    # string between previous and current note match
-    xs = xs.lstrip ()           # first note match starts on a space!
-    prevloc = loc               # location in string 'line' of current note match
-    b = pObj ('bbrk', [' ' in xs])      # space somewhere between two notes -> beambreak
-    t.insert (0, b)             # insert beambreak as a nested parse result
 
-def noteActn (line, loc, t):    # detect beambreak between previous and current note/rest
-    if 'y' in t[0].t: return [] # discard spacer
-    detectBeamBreak (line, loc, t)      # adds beambreak to parse result t as side effect
-    return pObj ('note', t)
 
-def restActn (line, loc, t):    # detect beambreak between previous and current note/rest
-    detectBeamBreak (line, loc, t)  # adds beambreak to parse result t as side effect
-    return pObj ('rest', t)
+def detectBeamBreak(line, loc, t):
+    global prevloc  # location in string 'line' of previous note match
+    xs = line[prevloc : loc + 1]  # string between previous and current note match
+    xs = xs.lstrip()  # first note match starts on a space!
+    prevloc = loc  # location in string 'line' of current note match
+    b = pObj("bbrk", [" " in xs])  # space somewhere between two notes -> beambreak
+    t.insert(0, b)  # insert beambreak as a nested parse result
 
-def errorWarn (line, loc, t):   # warning for misplaced symbols and skip them
-    if not t[0]: return []      # only warn if catched string not empty
-    info ('**misplaced symbol: %s' % t[0], warn=0)
-    lineCopy = line [:]
+
+def noteActn(line, loc, t):  # detect beambreak between previous and current note/rest
+    if "y" in t[0].t:
+        return []  # discard spacer
+    detectBeamBreak(line, loc, t)  # adds beambreak to parse result t as side effect
+    return pObj("note", t)
+
+
+def restActn(line, loc, t):  # detect beambreak between previous and current note/rest
+    detectBeamBreak(line, loc, t)  # adds beambreak to parse result t as side effect
+    return pObj("rest", t)
+
+
+def errorWarn(line, loc, t):  # warning for misplaced symbols and skip them
+    if not t[0]:
+        return []  # only warn if catched string not empty
+    info("**misplaced symbol: %s" % t[0], warn=0)
+    lineCopy = line[:]
     if loc > 40:
-        lineCopy = line [loc - 40: loc + 40]
+        lineCopy = line[loc - 40 : loc + 40]
         loc = 40
-    info (lineCopy.replace ('\n', ' '), warn=0)
-    info (loc * '-' + '^', warn=0)
+    info(lineCopy.replace("\n", " "), warn=0)
+    info(loc * "-" + "^", warn=0)
     return []
 
-#-------------------------------------------------------------
-# transformations of a measure (called by parse action doMaat)
-#-------------------------------------------------------------
 
-def simplify (a, b):    # divide a and b by their greatest common divisor
+# -------------------------------------------------------------
+# transformations of a measure (called by parse action doMaat)
+# -------------------------------------------------------------
+
+
+def simplify(a, b):  # divide a and b by their greatest common divisor
     x, y = a, b
-    while b: a, b = b, a % b
+    while b:
+        a, b = b, a % b
     return x // a, y // a
 
-def doBroken (prev, brk, x):
-    if not prev: info ('error in broken rhythm: %s' % x); return    # no changes
-    nom1, den1 = prev.dur.t # duration of first note/chord
-    nom2, den2 = x.dur.t    # duration of second note/chord
-    if  brk == '>':
-        nom1, den1  = simplify (3 * nom1, 2 * den1)
-        nom2, den2  = simplify (1 * nom2, 2 * den2)
-    elif brk == '<':
-        nom1, den1  = simplify (1 * nom1, 2 * den1)
-        nom2, den2  = simplify (3 * nom2, 2 * den2)
-    elif brk == '>>':
-        nom1, den1  = simplify (7 * nom1, 4 * den1)
-        nom2, den2  = simplify (1 * nom2, 4 * den2)
-    elif brk == '<<':
-        nom1, den1  = simplify (1 * nom1, 4 * den1)
-        nom2, den2  = simplify (7 * nom2, 4 * den2)
-    else: return            # give up
-    prev.dur.t = nom1, den1 # change duration of previous note/chord
-    x.dur.t = nom2, den2    # and current note/chord
 
-def convertBroken (t):  # convert broken rhythms to normal note durations
-    prev = None # the last note/chord before the broken symbol
-    brk = ''    # the broken symbol
-    remove = [] # indexes to broken symbols (to be deleted) in measure
-    for i, x in enumerate (t):  # scan all elements in measure
-        if x.name == 'note' or x.name == 'chord' or x.name == 'rest':
-            if brk:                 # a broken symbol was encountered before
-                doBroken (prev, brk, x) # change duration previous note/chord/rest and current one
-                brk = ''
+def doBroken(prev, brk, x):
+    if not prev:
+        info("error in broken rhythm: %s" % x)
+        return  # no changes
+    nom1, den1 = prev.dur.t  # duration of first note/chord
+    nom2, den2 = x.dur.t  # duration of second note/chord
+    if brk == ">":
+        nom1, den1 = simplify(3 * nom1, 2 * den1)
+        nom2, den2 = simplify(1 * nom2, 2 * den2)
+    elif brk == "<":
+        nom1, den1 = simplify(1 * nom1, 2 * den1)
+        nom2, den2 = simplify(3 * nom2, 2 * den2)
+    elif brk == ">>":
+        nom1, den1 = simplify(7 * nom1, 4 * den1)
+        nom2, den2 = simplify(1 * nom2, 4 * den2)
+    elif brk == "<<":
+        nom1, den1 = simplify(1 * nom1, 4 * den1)
+        nom2, den2 = simplify(7 * nom2, 4 * den2)
+    else:
+        return  # give up
+    prev.dur.t = nom1, den1  # change duration of previous note/chord
+    x.dur.t = nom2, den2  # and current note/chord
+
+
+def convertBroken(t):  # convert broken rhythms to normal note durations
+    prev = None  # the last note/chord before the broken symbol
+    brk = ""  # the broken symbol
+    remove = []  # indexes to broken symbols (to be deleted) in measure
+    for i, x in enumerate(t):  # scan all elements in measure
+        if x.name == "note" or x.name == "chord" or x.name == "rest":
+            if brk:  # a broken symbol was encountered before
+                doBroken(
+                    prev, brk, x
+                )  # change duration previous note/chord/rest and current one
+                brk = ""
             else:
-                prev = x            # remember the last note/chord/rest
-        elif x.name == 'broken':
-            brk = x.t[0]            # remember the broken symbol (=string)
-            remove.insert (0, i)    # and its index, highest index first
-    for i in remove: del t[i]       # delete broken symbols from high to low
+                prev = x  # remember the last note/chord/rest
+        elif x.name == "broken":
+            brk = x.t[0]  # remember the broken symbol (=string)
+            remove.insert(0, i)  # and its index, highest index first
+    for i in remove:
+        del t[i]  # delete broken symbols from high to low
 
-def ptc2midi (n):       # convert parsed pitch attribute to a midi number
-    pt = getattr (n, 'pitch', '')
+
+def ptc2midi(n):  # convert parsed pitch attribute to a midi number
+    pt = getattr(n, "pitch", "")
     if pt:
         p = pt.t
-        if len (p) == 3: acc, step, oct = p
-        else:       acc = ''; step, oct = p
-        nUp = step.upper ()
-        oct = (4 if nUp == step else 5) + int (oct)
-        midi = oct * 12 + [0,2,4,5,7,9,11]['CDEFGAB'.index (nUp)] + {'^':1,'_':-1}.get (acc, 0) + 12
-    else: midi = 130    # all non pitch objects first
+        if len(p) == 3:
+            acc, step, oct = p
+        else:
+            acc = ""
+            step, oct = p
+        nUp = step.upper()
+        oct = (4 if nUp == step else 5) + int(oct)
+        midi = (
+            oct * 12
+            + [0, 2, 4, 5, 7, 9, 11]["CDEFGAB".index(nUp)]
+            + {"^": 1, "_": -1}.get(acc, 0)
+            + 12
+        )
+    else:
+        midi = 130  # all non pitch objects first
     return midi
 
-def convertChord (t):   # convert chord to sequence of notes in musicXml-style
+
+def convertChord(t):  # convert chord to sequence of notes in musicXml-style
     ins = []
-    for i, x in enumerate (t):
-        if x.name == 'chord':
-            if hasattr (x, 'rest') and not hasattr (x, 'note'): # chords containing only rests
-                if type (x.rest) == list_type: x.rest = x.rest[0] # more rests == one rest
-                ins.insert (0, (i, [x.rest]))   # just output a single rest, no chord
+    for i, x in enumerate(t):
+        if x.name == "chord":
+            if hasattr(x, "rest") and not hasattr(
+                x, "note"
+            ):  # chords containing only rests
+                if type(x.rest) == list_type:
+                    x.rest = x.rest[0]  # more rests == one rest
+                ins.insert(0, (i, [x.rest]))  # just output a single rest, no chord
                 continue
-            num1, den1 = x.dur.t                # chord duration
-            tie = getattr (x, 'tie', None)      # chord tie
-            slurs = getattr (x, 'slurs', [])    # slur endings
-            if type (x.note) != list_type: x.note = [x.note]    # when chord has only one note ...
-            elms = []; j = 0                    # sort chord notes, highest first
-            nss = sorted (x.objs, key = ptc2midi, reverse=1) if mxm.orderChords else x.objs
-            for nt in nss:   # all chord elements (note | decorations | rest | grace note)
-                if nt.name == 'note':
-                    num2, den2 = nt.dur.t           # note duration * chord duration
-                    nt.dur.t = simplify (num1 * num2, den1 * den2)
-                    if tie: nt.tie = tie            # tie on all chord notes
-                    if j == 0 and slurs: nt.slurs = slurs   # slur endings only on first chord note
-                    if j > 0: nt.chord = pObj ('chord', [1]) # label all but first as chord notes
-                    else:                           # remember all pitches of the chord in the first note
-                        pitches = [n.pitch for n in x.note] # to implement conversion of erroneous ties to slurs
-                        nt.pitches = pObj ('pitches', pitches)
+            num1, den1 = x.dur.t  # chord duration
+            tie = getattr(x, "tie", None)  # chord tie
+            slurs = getattr(x, "slurs", [])  # slur endings
+            if type(x.note) != list_type:
+                x.note = [x.note]  # when chord has only one note ...
+            elms = []
+            j = 0  # sort chord notes, highest first
+            nss = sorted(x.objs, key=ptc2midi, reverse=1) if mxm.orderChords else x.objs
+            for (
+                nt
+            ) in nss:  # all chord elements (note | decorations | rest | grace note)
+                if nt.name == "note":
+                    num2, den2 = nt.dur.t  # note duration * chord duration
+                    nt.dur.t = simplify(num1 * num2, den1 * den2)
+                    if tie:
+                        nt.tie = tie  # tie on all chord notes
+                    if j == 0 and slurs:
+                        nt.slurs = slurs  # slur endings only on first chord note
+                    if j > 0:
+                        nt.chord = pObj(
+                            "chord", [1]
+                        )  # label all but first as chord notes
+                    else:  # remember all pitches of the chord in the first note
+                        pitches = [
+                            n.pitch for n in x.note
+                        ]  # to implement conversion of erroneous ties to slurs
+                        nt.pitches = pObj("pitches", pitches)
                     j += 1
-                if nt.name not in ['dur','tie','slurs','rest']: elms.append (nt)
-            ins.insert (0, (i, elms))           # chord position, [note|decotation|grace note]
-    for i, notes in ins:                        # insert from high to low
-        for nt in reversed (notes):
-            t.insert (i+1, nt)                  # insert chord notes after chord
-        del t[i]                                # remove chord itself
+                if nt.name not in ["dur", "tie", "slurs", "rest"]:
+                    elms.append(nt)
+            ins.insert(0, (i, elms))  # chord position, [note|decotation|grace note]
+    for i, notes in ins:  # insert from high to low
+        for nt in reversed(notes):
+            t.insert(i + 1, nt)  # insert chord notes after chord
+        del t[i]  # remove chord itself
 
-def doMaat (t):             # t is a Group() result -> the measure is in t[0]
-    convertBroken (t[0])    # remove all broken rhythms and convert to normal durations
-    convertChord (t[0])     # replace chords by note sequences in musicXML style
 
-def doGrace (t):        # t is a Group() result -> the grace sequence is in t[0]
-    convertChord (t[0]) # a grace sequence may have chords
-    for nt in t[0]:     # flag all notes within the grace sequence
-        if nt.name == 'note': nt.grace = 1 # set grace attribute
-    return t[0]         # ungroup the parse result
-#--------------------
+def doMaat(t):  # t is a Group() result -> the measure is in t[0]
+    convertBroken(t[0])  # remove all broken rhythms and convert to normal durations
+    convertChord(t[0])  # replace chords by note sequences in musicXML style
+
+
+def doGrace(t):  # t is a Group() result -> the grace sequence is in t[0]
+    convertChord(t[0])  # a grace sequence may have chords
+    for nt in t[0]:  # flag all notes within the grace sequence
+        if nt.name == "note":
+            nt.grace = 1  # set grace attribute
+    return t[0]  # ungroup the parse result
+
+
+# --------------------
 # musicXML generation
-#----------------------------------
+# ----------------------------------
 
-def compChordTab ():    # avoid some typing work: returns mapping constant {ABC chordsyms -> musicXML kind}
-    maj, min, aug, dim, dom, ch7, ch6, ch9, ch11, ch13, hd = 'major minor augmented diminished dominant -seventh -sixth -ninth -11th -13th half-diminished'.split ()
-    triad   = zip ('ma Maj maj M mi min m aug dim o + -'.split (), [maj, maj, maj, maj, min, min, min, aug, dim, dim, aug, min])
-    seventh = zip ('7 ma7 Maj7 M7 maj7 mi7 min7 m7 dim7 o7 -7 aug7 +7 m7b5 mi7b5'.split (),
-                   [dom, maj+ch7, maj+ch7, maj+ch7, maj+ch7, min+ch7, min+ch7, min+ch7, dim+ch7, dim+ch7, min+ch7, aug+ch7, aug+ch7, hd, hd])
-    sixth   = zip ('6 ma6 M6 mi6 min6 m6'.split (), [maj+ch6, maj+ch6, maj+ch6, min+ch6, min+ch6, min+ch6])
-    ninth   = zip ('9 ma9 M9 maj9 Maj9 mi9 min9 m9'.split (), [dom+ch9, maj+ch9, maj+ch9, maj+ch9, maj+ch9, min+ch9, min+ch9, min+ch9])
-    elevn   = zip ('11 ma11 M11 maj11 Maj11 mi11 min11 m11'.split (), [dom+ch11, maj+ch11, maj+ch11, maj+ch11, maj+ch11, min+ch11, min+ch11, min+ch11])
-    thirt   = zip ('13 ma13 M13 maj13 Maj13 mi13 min13 m13'.split (), [dom+ch13, maj+ch13, maj+ch13, maj+ch13, maj+ch13, min+ch13, min+ch13, min+ch13])
-    sus     = zip ('sus sus4 sus2'.split (), ['suspended-fourth', 'suspended-fourth', 'suspended-second'])
-    return dict (list (triad) + list (seventh) + list (sixth) + list (ninth) + list (elevn) + list (thirt) + list (sus))
 
-def addElem (parent, child, level):
+def compChordTab():  # avoid some typing work: returns mapping constant {ABC chordsyms -> musicXML kind}
+    maj, min, aug, dim, dom, ch7, ch6, ch9, ch11, ch13, hd = (
+        "major minor augmented diminished dominant -seventh -sixth -ninth -11th -13th half-diminished".split()
+    )
+    triad = zip(
+        "ma Maj maj M mi min m aug dim o + -".split(),
+        [maj, maj, maj, maj, min, min, min, aug, dim, dim, aug, min],
+    )
+    seventh = zip(
+        "7 ma7 Maj7 M7 maj7 mi7 min7 m7 dim7 o7 -7 aug7 +7 m7b5 mi7b5".split(),
+        [
+            dom,
+            maj + ch7,
+            maj + ch7,
+            maj + ch7,
+            maj + ch7,
+            min + ch7,
+            min + ch7,
+            min + ch7,
+            dim + ch7,
+            dim + ch7,
+            min + ch7,
+            aug + ch7,
+            aug + ch7,
+            hd,
+            hd,
+        ],
+    )
+    sixth = zip(
+        "6 ma6 M6 mi6 min6 m6".split(),
+        [maj + ch6, maj + ch6, maj + ch6, min + ch6, min + ch6, min + ch6],
+    )
+    ninth = zip(
+        "9 ma9 M9 maj9 Maj9 mi9 min9 m9".split(),
+        [
+            dom + ch9,
+            maj + ch9,
+            maj + ch9,
+            maj + ch9,
+            maj + ch9,
+            min + ch9,
+            min + ch9,
+            min + ch9,
+        ],
+    )
+    elevn = zip(
+        "11 ma11 M11 maj11 Maj11 mi11 min11 m11".split(),
+        [
+            dom + ch11,
+            maj + ch11,
+            maj + ch11,
+            maj + ch11,
+            maj + ch11,
+            min + ch11,
+            min + ch11,
+            min + ch11,
+        ],
+    )
+    thirt = zip(
+        "13 ma13 M13 maj13 Maj13 mi13 min13 m13".split(),
+        [
+            dom + ch13,
+            maj + ch13,
+            maj + ch13,
+            maj + ch13,
+            maj + ch13,
+            min + ch13,
+            min + ch13,
+            min + ch13,
+        ],
+    )
+    sus = zip(
+        "sus sus4 sus2".split(),
+        ["suspended-fourth", "suspended-fourth", "suspended-second"],
+    )
+    return dict(
+        list(triad)
+        + list(seventh)
+        + list(sixth)
+        + list(ninth)
+        + list(elevn)
+        + list(thirt)
+        + list(sus)
+    )
+
+
+def addElem(parent, child, level):
     indent = 2
-    chldrn = list (parent)
+    chldrn = list(parent)
     if chldrn:
-        chldrn[-1].tail += indent * ' '
+        chldrn[-1].tail += indent * " "
     else:
-        parent.text = '\n' + level * indent * ' '
-    parent.append (child)
-    child.tail = '\n' + (level-1) * indent * ' '
+        parent.text = "\n" + level * indent * " "
+    parent.append(child)
+    child.tail = "\n" + (level - 1) * indent * " "
 
-def addElemT (parent, tag, text, level):
-    e = E.Element (tag)
+
+def addElemT(parent, tag, text, level):
+    e = E.Element(tag)
     e.text = text
-    addElem (parent, e, level)
+    addElem(parent, e, level)
     return e
-    
-def mkTmod (tmnum, tmden, lev):
-    tmod = E.Element ('time-modification')
-    addElemT (tmod, 'actual-notes', str (tmnum), lev + 1)
-    addElemT (tmod, 'normal-notes', str (tmden), lev + 1)
+
+
+def mkTmod(tmnum, tmden, lev):
+    tmod = E.Element("time-modification")
+    addElemT(tmod, "actual-notes", str(tmnum), lev + 1)
+    addElemT(tmod, "normal-notes", str(tmden), lev + 1)
     return tmod
 
-def addDirection (parent, elems, lev, gstaff, subelms=[], placement='below', cue_on=0):
-    dir = E.Element ('direction', placement=placement)
-    addElem (parent, dir, lev)
-    if type (elems) != list_type: elems = [(elems, subelms)]    # ugly hack to provide for multiple direction types
-    for elem, subelms in elems: # add direction types
-        typ = E.Element ('direction-type')
-        addElem (dir, typ, lev + 1)
-        addElem (typ, elem, lev + 2)
-        for subel in subelms: addElem (elem, subel, lev + 3)
-    if cue_on: addElem (dir, E.Element ('level', size='cue'), lev + 1)
-    if gstaff: addElemT (dir, 'staff', str (gstaff), lev + 1)
+
+def addDirection(parent, elems, lev, gstaff, subelms=[], placement="below", cue_on=0):
+    dir = E.Element("direction", placement=placement)
+    addElem(parent, dir, lev)
+    if type(elems) != list_type:
+        elems = [(elems, subelms)]  # ugly hack to provide for multiple direction types
+    for elem, subelms in elems:  # add direction types
+        typ = E.Element("direction-type")
+        addElem(dir, typ, lev + 1)
+        addElem(typ, elem, lev + 2)
+        for subel in subelms:
+            addElem(elem, subel, lev + 3)
+    if cue_on:
+        addElem(dir, E.Element("level", size="cue"), lev + 1)
+    if gstaff:
+        addElemT(dir, "staff", str(gstaff), lev + 1)
     return dir
 
-def removeElems (root_elem, parent_str, elem_str):
-    for p in root_elem.findall (parent_str):
-        e = p.find (elem_str)
-        if e != None: p.remove (e)
 
-def alignLyr (vce, lyrs):
-    empty_el = pObj ('leeg', '*')
-    for k, lyr in enumerate (lyrs): # lyr = one full line of lyrics
-        i = 0               # syl counter
-        for elem in vce:    # reiterate the voice block for each lyrics line
-            if elem.name == 'note' and not (hasattr (elem, 'chord') or hasattr (elem, 'grace')):
-                if i >= len (lyr): lr = empty_el
-                else: lr = lyr [i]
-                lr.t[0] = lr.t[0].replace ('%5d',']')
-                elem.objs.append (lr)
-                if lr.name != 'sbar': i += 1
-            if elem.name == 'rbar' and i < len (lyr) and lyr[i].name == 'sbar': i += 1
+def removeElems(root_elem, parent_str, elem_str):
+    for p in root_elem.findall(parent_str):
+        e = p.find(elem_str)
+        if e != None:
+            p.remove(e)
+
+
+def alignLyr(vce, lyrs):
+    empty_el = pObj("leeg", "*")
+    for k, lyr in enumerate(lyrs):  # lyr = one full line of lyrics
+        i = 0  # syl counter
+        for elem in vce:  # reiterate the voice block for each lyrics line
+            if elem.name == "note" and not (
+                hasattr(elem, "chord") or hasattr(elem, "grace")
+            ):
+                if i >= len(lyr):
+                    lr = empty_el
+                else:
+                    lr = lyr[i]
+                lr.t[0] = lr.t[0].replace("%5d", "]")
+                elem.objs.append(lr)
+                if lr.name != "sbar":
+                    i += 1
+            if elem.name == "rbar" and i < len(lyr) and lyr[i].name == "sbar":
+                i += 1
     return vce
 
-slur_move = re.compile (r'(?<![!+])([}><][<>]?)(\)+)')  # (?<!...) means: not preceeded by ...
-mm_rest = re.compile (r'([XZ])(\d+)')
-bar_space = re.compile (r'([:|][ |\[\]]+[:|])')         # barlines with spaces
-def fixSlurs (x):   # repair slurs when after broken sign or grace-close
-    def f (mo):     # replace a multi-measure rest by single measure rests
-        n = int (mo.group (2))
-        return (n * (mo.group (1) + '|')) [:-1]
-    def g (mo):     # squash spaces in barline expressions
-        return mo.group (1).replace (' ','')
-    x = mm_rest.sub (f, x)
-    x = bar_space.sub (g, x)
-    return slur_move.sub (r'\2\1', x)
 
-def splitHeaderVoices (abctext):
-    escField = lambda x: '[' + x.replace (']',r'%5d') + ']' # hope nobody uses %5d in a field
-    r1 = re.compile (r'%.*$')           # comments
-    r2 = re.compile (r'^([A-Zw]:.*$)|\[[A-Zw]:[^]]*]$')     # information field, including lyrics
-    r3 = re.compile (r'^%%(?=[^%])')    # directive: ^%% folowed by not a %
-    xs, nx, mcont, fcont = [], 0, 0, 0  # result lines, X-encountered, music continuation, field continuation
-    mln = fln = ''                      # music line, field line
-    for x in abctext.splitlines ():
-        x = x.strip ()
-        if not x and nx == 1: break     # end of tune (empty line)
-        if x.startswith ('X:'):
-            if nx == 1: break           # second tune starts without an empty line !!
-            nx = 1                      # start first tune
-        x = r3.sub ('I:', x)            # replace %% -> I:
-        x2 = r1.sub ('', x)             # remove comment
-        while x2.endswith ('*') and not (x2.startswith ('w:') or x2.startswith ('+:') or 'percmap' in x2):
-            x2 = x2[:-1]                # remove old syntax for right adjusting
-        if not x2: continue             # empty line
-        if x2[:2] == 'W:':
-            field = x2 [2:].strip ()
-            ftype = mxm.metaMap.get ('W', 'W')  # respect the (user defined --meta) mapping of various ABC fields to XML meta data types
-            c = mxm.metadata.get (ftype, '')
-            mxm.metadata [ftype] = c + '\n' + field if c else field   # concatenate multiple info fields with new line as separator
-            continue                    # skip W: lyrics
-        if x2[:2] == '+:':              # field continuation
+slur_move = re.compile(
+    r"(?<![!+])([}><][<>]?)(\)+)"
+)  # (?<!...) means: not preceeded by ...
+mm_rest = re.compile(r"([XZ])(\d+)")
+bar_space = re.compile(r"([:|][ |\[\]]+[:|])")  # barlines with spaces
+
+
+def fixSlurs(x):  # repair slurs when after broken sign or grace-close
+    def f(mo):  # replace a multi-measure rest by single measure rests
+        n = int(mo.group(2))
+        return (n * (mo.group(1) + "|"))[:-1]
+
+    def g(mo):  # squash spaces in barline expressions
+        return mo.group(1).replace(" ", "")
+
+    x = mm_rest.sub(f, x)
+    x = bar_space.sub(g, x)
+    return slur_move.sub(r"\2\1", x)
+
+
+def splitHeaderVoices(abctext):
+    escField = (
+        lambda x: "[" + x.replace("]", r"%5d") + "]"
+    )  # hope nobody uses %5d in a field
+    r1 = re.compile(r"%.*$")  # comments
+    r2 = re.compile(
+        r"^([A-Zw]:.*$)|\[[A-Zw]:[^]]*]$"
+    )  # information field, including lyrics
+    r3 = re.compile(r"^%%(?=[^%])")  # directive: ^%% folowed by not a %
+    xs, nx, mcont, fcont = (
+        [],
+        0,
+        0,
+        0,
+    )  # result lines, X-encountered, music continuation, field continuation
+    mln = fln = ""  # music line, field line
+    for x in abctext.splitlines():
+        x = x.strip()
+        if not x and nx == 1:
+            break  # end of tune (empty line)
+        if x.startswith("X:"):
+            if nx == 1:
+                break  # second tune starts without an empty line !!
+            nx = 1  # start first tune
+        x = r3.sub("I:", x)  # replace %% -> I:
+        x2 = r1.sub("", x)  # remove comment
+        while x2.endswith("*") and not (
+            x2.startswith("w:") or x2.startswith("+:") or "percmap" in x2
+        ):
+            x2 = x2[:-1]  # remove old syntax for right adjusting
+        if not x2:
+            continue  # empty line
+        if x2[:2] == "W:":
+            field = x2[2:].strip()
+            ftype = mxm.metaMap.get(
+                "W", "W"
+            )  # respect the (user defined --meta) mapping of various ABC fields to XML meta data types
+            c = mxm.metadata.get(ftype, "")
+            mxm.metadata[ftype] = (
+                c + "\n" + field if c else field
+            )  # concatenate multiple info fields with new line as separator
+            continue  # skip W: lyrics
+        if x2[:2] == "+:":  # field continuation
             fln += x2[2:]
             continue
-        ro = r2.match (x2)              # single field on a line
-        if ro:                          # field -> inline_field, escape all ']'
-            if fcont:                   # old style \-info-continuation active
-                fcont = x2 [-1] == '\\' # possible further \-info-continuation
-                fln += re.sub (r'^.:(.*?)\\*$', r'\1', x2) # add continuation, remove .: and \
+        ro = r2.match(x2)  # single field on a line
+        if ro:  # field -> inline_field, escape all ']'
+            if fcont:  # old style \-info-continuation active
+                fcont = x2[-1] == "\\"  # possible further \-info-continuation
+                fln += re.sub(
+                    r"^.:(.*?)\\*$", r"\1", x2
+                )  # add continuation, remove .: and \
                 continue
-            if fln: mln += escField (fln)
-            if x2.startswith ('['): x2 = x2.strip ('[]')
-            fcont = x2 [-1] == '\\'     # first encounter of old style \-info-continuation
-            fln = x2.rstrip ('\\')      # remove continuation from field and inline brackets
-            continue
-        if nx == 1:                     # x2 is a new music line
-            fcont = 0                   # stop \-continuations (-> only adjacent \-info-continuations are joined)
             if fln:
-                mln +=  escField (fln)
-                fln = ''
+                mln += escField(fln)
+            if x2.startswith("["):
+                x2 = x2.strip("[]")
+            fcont = x2[-1] == "\\"  # first encounter of old style \-info-continuation
+            fln = x2.rstrip("\\")  # remove continuation from field and inline brackets
+            continue
+        if nx == 1:  # x2 is a new music line
+            fcont = 0  # stop \-continuations (-> only adjacent \-info-continuations are joined)
+            if fln:
+                mln += escField(fln)
+                fln = ""
             if mcont:
-                mcont = x2 [-1] == '\\' 
-                mln += x2.rstrip ('\\')
+                mcont = x2[-1] == "\\"
+                mln += x2.rstrip("\\")
             else:
-                if mln: xs.append (mln); mln = ''
-                mcont = x2 [-1] == '\\'
-                mln = x2.rstrip ('\\')
-            if not mcont: xs.append (mln); mln = ''
-    if fln: mln += escField (fln)
-    if mln: xs.append (mln)
+                if mln:
+                    xs.append(mln)
+                    mln = ""
+                mcont = x2[-1] == "\\"
+                mln = x2.rstrip("\\")
+            if not mcont:
+                xs.append(mln)
+                mln = ""
+    if fln:
+        mln += escField(fln)
+    if mln:
+        xs.append(mln)
 
-    hs = re.split (r'(\[K:[^]]*\])', xs [0])   # look for end of header K:
-    if len (hs) == 1: header = hs[0]; xs [0] = ''               # no K: present
-    else: header = hs [0] + hs [1]; xs [0] = ''.join (hs[2:])   # h[1] is the first K:
-    abctext = '\n'.join (xs)                    # the rest is body text
-    hfs, vfs = [], []
-    for x in header[1:-1].split (']['):
-        if x[0] == 'V': vfs.append (x)          # filter voice- and midi-definitions
-        elif x[:6] == 'I:MIDI': vfs.append (x)  # from the header to vfs
-        elif x[:9] == 'I:percmap': vfs.append (x)  # and also percmap
-        else: hfs.append (x)                    # all other fields stay in header
-    header = '[' + ']['.join (hfs) + ']'        # restore the header
-    abctext = ('[' + ']['.join (vfs) + ']' if vfs else '') + abctext    # prepend voice/midi from header before abctext
-
-    xs = abctext.split ('[V:')
-    if len (xs) == 1: abctext = '[V:1]' + abctext # abc has no voice defs at all
-    elif re.sub (r'\[[A-Z]:[^]]*\]', '', xs[0]).strip ():   # remove inline fields from starting text, if any
-        abctext = '[V:1]' + abctext     # abc with voices has no V: at start
-
-    r1 = re.compile (r'\[V:\s*(\S*)[ \]]') # get voice id from V: field (skip spaces betwee V: and ID)
-    vmap = {}                           # {voice id -> [voice abc string]}
-    vorder = {}                         # mark document order of voices
-    xs = re.split (r'(\[V:[^]]*\])', abctext)   # split on every V-field (V-fields included in split result list)
-    if len (xs) == 1: raise ValueError ('bugs ...')
+    hs = re.split(r"(\[K:[^]]*\])", xs[0])  # look for end of header K:
+    if len(hs) == 1:
+        header = hs[0]
+        xs[0] = ""  # no K: present
     else:
-        pm = re.findall (r'\[P:.\]', xs[0])         # all P:-marks after K: but before first V:
-        if pm: xs[2] = ''.join (pm) + xs[2]         # prepend P:-marks to the text of the first voice
-        header += re.sub (r'\[P:.\]', '', xs[0])    # clear all P:-marks from text between K: and first V: and put text in the header
+        header = hs[0] + hs[1]
+        xs[0] = "".join(hs[2:])  # h[1] is the first K:
+    abctext = "\n".join(xs)  # the rest is body text
+    hfs, vfs = [], []
+    for x in header[1:-1].split("]["):
+        if x[0] == "V":
+            vfs.append(x)  # filter voice- and midi-definitions
+        elif x[:6] == "I:MIDI":
+            vfs.append(x)  # from the header to vfs
+        elif x[:9] == "I:percmap":
+            vfs.append(x)  # and also percmap
+        else:
+            hfs.append(x)  # all other fields stay in header
+    header = "[" + "][".join(hfs) + "]"  # restore the header
+    abctext = (
+        "[" + "][".join(vfs) + "]" if vfs else ""
+    ) + abctext  # prepend voice/midi from header before abctext
+
+    xs = abctext.split("[V:")
+    if len(xs) == 1:
+        abctext = "[V:1]" + abctext  # abc has no voice defs at all
+    elif re.sub(
+        r"\[[A-Z]:[^]]*\]", "", xs[0]
+    ).strip():  # remove inline fields from starting text, if any
+        abctext = "[V:1]" + abctext  # abc with voices has no V: at start
+
+    r1 = re.compile(
+        r"\[V:\s*(\S*)[ \]]"
+    )  # get voice id from V: field (skip spaces betwee V: and ID)
+    vmap = {}  # {voice id -> [voice abc string]}
+    vorder = {}  # mark document order of voices
+    xs = re.split(
+        r"(\[V:[^]]*\])", abctext
+    )  # split on every V-field (V-fields included in split result list)
+    if len(xs) == 1:
+        raise ValueError("bugs ...")
+    else:
+        pm = re.findall(r"\[P:.\]", xs[0])  # all P:-marks after K: but before first V:
+        if pm:
+            xs[2] = (
+                "".join(pm) + xs[2]
+            )  # prepend P:-marks to the text of the first voice
+        header += re.sub(
+            r"\[P:.\]", "", xs[0]
+        )  # clear all P:-marks from text between K: and first V: and put text in the header
         i = 1
-        while i < len (xs):             # xs = ['', V-field, voice abc, V-field, voice abc, ...]
-            vce, abc = xs[i:i+2]
-            id = r1.search (vce).group (1)                  # get voice ID from V-field
-            if not id: id, vce = '1', '[V:1]'               # voice def has no ID
-            vmap[id] = vmap.get (id, []) + [vce, abc]       # collect abc-text for each voice id (include V-fields)
-            if id not in vorder: vorder [id] = i            # store document order of first occurrence of voice id
+        while i < len(xs):  # xs = ['', V-field, voice abc, V-field, voice abc, ...]
+            vce, abc = xs[i : i + 2]
+            id = r1.search(vce).group(1)  # get voice ID from V-field
+            if not id:
+                id, vce = "1", "[V:1]"  # voice def has no ID
+            vmap[id] = vmap.get(id, []) + [
+                vce,
+                abc,
+            ]  # collect abc-text for each voice id (include V-fields)
+            if id not in vorder:
+                vorder[id] = i  # store document order of first occurrence of voice id
             i += 2
     voices = []
-    ixs = sorted ([(i, id) for id, i in vorder.items ()])   # restore document order of voices
+    ixs = sorted(
+        [(i, id) for id, i in vorder.items()]
+    )  # restore document order of voices
     for i, id in ixs:
-        voice = ''.join (vmap [id])     # all abc of one voice
-        voice = fixSlurs (voice)        # put slurs right after the notes
-        voices.append ((id, voice))
+        voice = "".join(vmap[id])  # all abc of one voice
+        voice = fixSlurs(voice)  # put slurs right after the notes
+        voices.append((id, voice))
     return header, voices
 
-def mergeMeasure (m1, m2, slur_offset, voice_offset, rOpt, is_grand=0, is_overlay=0):
-    slurs = m2.findall ('note/notations/slur')
+
+def mergeMeasure(m1, m2, slur_offset, voice_offset, rOpt, is_grand=0, is_overlay=0):
+    slurs = m2.findall("note/notations/slur")
     for slr in slurs:
-        slrnum = int (slr.get ('number')) + slur_offset 
-        slr.set ('number', str (slrnum))    # make unique slurnums in m2
-    vs = m2.findall ('note/voice')          # set all voice number elements in m2
-    for v in vs: v.text  = str (voice_offset + int (v.text))
-    ls = m1.findall ('note/lyric')          # all lyric elements in m1
-    lnum_max = max ([int (l.get ('number')) for l in ls] + [0]) # highest lyric number in m1
-    ls = m2.findall ('note/lyric')          # update lyric elements in m2
+        slrnum = int(slr.get("number")) + slur_offset
+        slr.set("number", str(slrnum))  # make unique slurnums in m2
+    vs = m2.findall("note/voice")  # set all voice number elements in m2
+    for v in vs:
+        v.text = str(voice_offset + int(v.text))
+    ls = m1.findall("note/lyric")  # all lyric elements in m1
+    lnum_max = max(
+        [int(l.get("number")) for l in ls] + [0]
+    )  # highest lyric number in m1
+    ls = m2.findall("note/lyric")  # update lyric elements in m2
     for el in ls:
-        n = int (el.get ('number'))
-        el.set ('number', str (n + lnum_max))
-    ns = m1.findall ('note')    # determine the total duration of m1, subtract all backups
-    dur1 = sum (int (n.find ('duration').text) for n in ns
-                if n.find ('grace') == None and n.find ('chord') == None)
-    dur1 -= sum (int (b.text) for b in m1.findall ('backup/duration'))
+        n = int(el.get("number"))
+        el.set("number", str(n + lnum_max))
+    ns = m1.findall("note")  # determine the total duration of m1, subtract all backups
+    dur1 = sum(
+        int(n.find("duration").text)
+        for n in ns
+        if n.find("grace") == None and n.find("chord") == None
+    )
+    dur1 -= sum(int(b.text) for b in m1.findall("backup/duration"))
     repbar, nns, es = 0, 0, []  # nns = number of real notes in m2
-    for e in list (m2): # scan all elements of m2
-        if e.tag == 'attributes':
-            if not is_grand: continue # no attribute merging for normal voices
-            else: nns += 1      # but we do merge (clef) attributes for a grand staff
-        if e.tag == 'print': continue
-        if e.tag == 'note' and (rOpt or e.find ('rest') == None): nns += 1
-        if e.tag == 'barline' and e.find ('repeat') != None: repbar = e;
-        es.append (e)           # buffer elements to be merged
-    if nns > 0:                 # only merge if m2 contains any real notes
-        if dur1 > 0:            # only insert backup if duration of m1 > 0
-            b = E.Element ('backup')
-            addElem (m1, b, level=3)
-            addElemT (b, 'duration', str (dur1), level=4)
-        for e in es: addElem (m1, e, level=3)   # merge buffered elements of m2
-    elif is_overlay and repbar: addElem (m1, repbar, level=3)   # merge repeat in empty overlay
+    for e in list(m2):  # scan all elements of m2
+        if e.tag == "attributes":
+            if not is_grand:
+                continue  # no attribute merging for normal voices
+            else:
+                nns += 1  # but we do merge (clef) attributes for a grand staff
+        if e.tag == "print":
+            continue
+        if e.tag == "note" and (rOpt or e.find("rest") == None):
+            nns += 1
+        if e.tag == "barline" and e.find("repeat") != None:
+            repbar = e
+        es.append(e)  # buffer elements to be merged
+    if nns > 0:  # only merge if m2 contains any real notes
+        if dur1 > 0:  # only insert backup if duration of m1 > 0
+            b = E.Element("backup")
+            addElem(m1, b, level=3)
+            addElemT(b, "duration", str(dur1), level=4)
+        for e in es:
+            addElem(m1, e, level=3)  # merge buffered elements of m2
+    elif is_overlay and repbar:
+        addElem(m1, repbar, level=3)  # merge repeat in empty overlay
 
-def mergePartList (parts, rOpt, is_grand=0):    # merge parts, make grand staff when is_grand true
 
-    def delAttrs (part):                # for the time being we only keep clef attributes
-        xs = [(m, e) for m in part.findall ('measure') for e in m.findall ('attributes')]
+def mergePartList(
+    parts, rOpt, is_grand=0
+):  # merge parts, make grand staff when is_grand true
+
+    def delAttrs(part):  # for the time being we only keep clef attributes
+        xs = [(m, e) for m in part.findall("measure") for e in m.findall("attributes")]
         for m, e in xs:
-            for c in list (e):
-                if c.tag == 'clef': continue    # keep clef attribute
-                if c.tag == 'staff-details': continue    # keep staff-details attribute
-                e.remove (c)                    # delete all other attrinutes for higher staff numbers
-            if len (list (e)) == 0: m.remove (e)    # remove empty attributes element
+            for c in list(e):
+                if c.tag == "clef":
+                    continue  # keep clef attribute
+                if c.tag == "staff-details":
+                    continue  # keep staff-details attribute
+                e.remove(c)  # delete all other attrinutes for higher staff numbers
+            if len(list(e)) == 0:
+                m.remove(e)  # remove empty attributes element
 
     p1 = parts[0]
     for p2 in parts[1:]:
-        if is_grand: delAttrs (p2)                          # delete all attributes except clef
-        for i in range (len (p1) + 1, len (p2) + 1):        # second part longer than first one
-            maat = E.Element ('measure', number = str(i))   # append empty measures
-            addElem (p1, maat, 2)
-        slurs = p1.findall ('measure/note/notations/slur')  # find highest slur num in first part
-        slur_max = max ([int (slr.get ('number')) for slr in slurs] + [0])
-        vs = p1.findall ('measure/note/voice')              # all voice number elements in first part
-        vnum_max = max ([int (v.text) for v in vs] + [0])   # highest voice number in first part
-        for im, m2 in enumerate (p2.findall ('measure')):   # merge all measures of p2 into p1
-            mergeMeasure (p1[im], m2, slur_max, vnum_max, rOpt, is_grand) # may change slur numbers in p1
+        if is_grand:
+            delAttrs(p2)  # delete all attributes except clef
+        for i in range(len(p1) + 1, len(p2) + 1):  # second part longer than first one
+            maat = E.Element("measure", number=str(i))  # append empty measures
+            addElem(p1, maat, 2)
+        slurs = p1.findall(
+            "measure/note/notations/slur"
+        )  # find highest slur num in first part
+        slur_max = max([int(slr.get("number")) for slr in slurs] + [0])
+        vs = p1.findall("measure/note/voice")  # all voice number elements in first part
+        vnum_max = max(
+            [int(v.text) for v in vs] + [0]
+        )  # highest voice number in first part
+        for im, m2 in enumerate(
+            p2.findall("measure")
+        ):  # merge all measures of p2 into p1
+            mergeMeasure(
+                p1[im], m2, slur_max, vnum_max, rOpt, is_grand
+            )  # may change slur numbers in p1
     return p1
 
-def mergeParts (parts, vids, staves, rOpt, is_grand=0):
-    if not staves: return parts, vids   # no voice mapping
+
+def mergeParts(parts, vids, staves, rOpt, is_grand=0):
+    if not staves:
+        return parts, vids  # no voice mapping
     partsnew, vidsnew = [], []
     for voice_ids in staves:
         pixs = []
         for vid in voice_ids:
-            if vid in vids: pixs.append (vids.index (vid))
-            else: info ('score partname %s does not exist' % vid)
+            if vid in vids:
+                pixs.append(vids.index(vid))
+            else:
+                info("score partname %s does not exist" % vid)
         if pixs:
             xparts = [parts[pix] for pix in pixs]
-            if len (xparts) > 1: mergedpart = mergePartList (xparts, rOpt, is_grand)
-            else:                mergedpart = xparts [0]
-            partsnew.append (mergedpart)
-            vidsnew.append (vids [pixs[0]])
+            if len(xparts) > 1:
+                mergedpart = mergePartList(xparts, rOpt, is_grand)
+            else:
+                mergedpart = xparts[0]
+            partsnew.append(mergedpart)
+            vidsnew.append(vids[pixs[0]])
     return partsnew, vidsnew
 
-def mergePartMeasure (part, msre, ovrlaynum, rOpt): # merge msre into last measure of part, only for overlays
-    slur_offset = 0;    # slur numbers determined by the slurstack size (as in a single voice)
-    last_msre = list (part)[-1] # last measure in part
-    mergeMeasure (last_msre, msre, slur_offset, ovrlaynum, rOpt, is_overlay=1) # voice offset = s.overlayVNum
 
-def pushSlur (boogStapel, stem):
-    if stem not in boogStapel: boogStapel [stem] = [] # initialize slurstack for stem
-    boognum = sum (map (len, boogStapel.values ())) + 1  # number of open slurs in all (overlay) voices
-    boogStapel [stem].append (boognum)
+def mergePartMeasure(
+    part, msre, ovrlaynum, rOpt
+):  # merge msre into last measure of part, only for overlays
+    slur_offset = (
+        0  # slur numbers determined by the slurstack size (as in a single voice)
+    )
+    last_msre = list(part)[-1]  # last measure in part
+    mergeMeasure(
+        last_msre, msre, slur_offset, ovrlaynum, rOpt, is_overlay=1
+    )  # voice offset = s.overlayVNum
+
+
+def pushSlur(boogStapel, stem):
+    if stem not in boogStapel:
+        boogStapel[stem] = []  # initialize slurstack for stem
+    boognum = (
+        sum(map(len, boogStapel.values())) + 1
+    )  # number of open slurs in all (overlay) voices
+    boogStapel[stem].append(boognum)
     return boognum
 
-def setFristVoiceNameFromGroup (vids, vdefs): # vids = [vid], vdef = {vid -> (name, subname, voicedef)}
+
+def setFristVoiceNameFromGroup(
+    vids, vdefs
+):  # vids = [vid], vdef = {vid -> (name, subname, voicedef)}
     vids = [v for v in vids if v in vdefs]  # only consider defined voices
-    if not vids: return vdefs
-    vid0 = vids [0]                         # first vid of the group
-    _, _, vdef0 = vdefs [vid0]              # keep de voice definition (vdef0) when renaming vid0
+    if not vids:
+        return vdefs
+    vid0 = vids[0]  # first vid of the group
+    _, _, vdef0 = vdefs[vid0]  # keep de voice definition (vdef0) when renaming vid0
     for vid in vids:
-        nm, snm, vdef = vdefs [vid]
-        if nm:                              # first non empty name encountered will become
-            vdefs [vid0] = nm, snm, vdef0   # name of merged group == name of first voice in group (vid0)
+        nm, snm, vdef = vdefs[vid]
+        if nm:  # first non empty name encountered will become
+            vdefs[vid0] = (
+                nm,
+                snm,
+                vdef0,
+            )  # name of merged group == name of first voice in group (vid0)
             break
     return vdefs
 
-def mkGrand (p, vdefs):             # transform parse subtree into list needed for s.grands
+
+def mkGrand(p, vdefs):  # transform parse subtree into list needed for s.grands
     xs = []
-    for i, x in enumerate (p.objs): # changing p.objs [i] alters the tree. changing x has no effect on the tree.
-        if type (x) == pObj:
-            us = mkGrand (x, vdefs) # first get transformation results of current pObj
-            if x.name == 'grand':   # x.objs contains ordered list of nested parse results within x
-                vids = [y.objs[0] for y in x.objs[1:]]  # the voice ids in the grand staff
-                nms = [vdefs [u][0] for u in vids if u in vdefs] # the names of those voices
-                accept = sum ([1 for nm in nms if nm]) == 1 # accept as grand staff when only one of the voices has a name
-                if accept or us[0] == '{*':
-                    xs.append (us[1:])      # append voice ids as a list (discard first item '{' or '{*')
-                    vdefs = setFristVoiceNameFromGroup (vids, vdefs)
-                    p.objs [i] = x.objs[1]  # replace voices by first one in the grand group (this modifies the parse tree)
+    for i, x in enumerate(
+        p.objs
+    ):  # changing p.objs [i] alters the tree. changing x has no effect on the tree.
+        if type(x) == pObj:
+            us = mkGrand(x, vdefs)  # first get transformation results of current pObj
+            if (
+                x.name == "grand"
+            ):  # x.objs contains ordered list of nested parse results within x
+                vids = [
+                    y.objs[0] for y in x.objs[1:]
+                ]  # the voice ids in the grand staff
+                nms = [
+                    vdefs[u][0] for u in vids if u in vdefs
+                ]  # the names of those voices
+                accept = (
+                    sum([1 for nm in nms if nm]) == 1
+                )  # accept as grand staff when only one of the voices has a name
+                if accept or us[0] == "{*":
+                    xs.append(
+                        us[1:]
+                    )  # append voice ids as a list (discard first item '{' or '{*')
+                    vdefs = setFristVoiceNameFromGroup(vids, vdefs)
+                    p.objs[i] = x.objs[
+                        1
+                    ]  # replace voices by first one in the grand group (this modifies the parse tree)
                 else:
-                    xs.extend (us[1:])      # extend current result with all voice ids of rejected grand staff
-            else: xs.extend (us)    # extend current result with transformed pObj
-        else: xs.append (p.t[0])    # append the non pObj (== voice id string)
-    return xs
-
-def mkStaves (p, vdefs):            # transform parse tree into list needed for s.staves
-    xs = []
-    for i, x in enumerate (p.objs): # structure and comments identical to mkGrand
-        if type (x) == pObj:
-            us = mkStaves (x, vdefs)
-            if x.name == 'voicegr':
-                xs.append (us)
-                vids = [y.objs[0] for y in x.objs]
-                vdefs = setFristVoiceNameFromGroup (vids, vdefs)
-                p.objs [i] = x.objs[0]
+                    xs.extend(
+                        us[1:]
+                    )  # extend current result with all voice ids of rejected grand staff
             else:
-                xs.extend (us)
+                xs.extend(us)  # extend current result with transformed pObj
         else:
-            if p.t[0] not in '{*':  xs.append (p.t[0])
+            xs.append(p.t[0])  # append the non pObj (== voice id string)
     return xs
 
-def mkGroups (p):                   # transform parse tree into list needed for s.groups
+
+def mkStaves(p, vdefs):  # transform parse tree into list needed for s.staves
+    xs = []
+    for i, x in enumerate(p.objs):  # structure and comments identical to mkGrand
+        if type(x) == pObj:
+            us = mkStaves(x, vdefs)
+            if x.name == "voicegr":
+                xs.append(us)
+                vids = [y.objs[0] for y in x.objs]
+                vdefs = setFristVoiceNameFromGroup(vids, vdefs)
+                p.objs[i] = x.objs[0]
+            else:
+                xs.extend(us)
+        else:
+            if p.t[0] not in "{*":
+                xs.append(p.t[0])
+    return xs
+
+
+def mkGroups(p):  # transform parse tree into list needed for s.groups
     xs = []
     for x in p.objs:
-        if type (x) == pObj:
-            if x.name == 'vid': xs.extend (mkGroups (x))
-            elif x.name == 'bracketgr': xs.extend (['['] + mkGroups (x) + [']'])
-            elif x.name == 'bracegr':   xs.extend (['{'] + mkGroups (x) + ['}'])
-            else: xs.extend (mkGroups (x) + ['}'])  # x.name == 'grand' == rejected grand staff
+        if type(x) == pObj:
+            if x.name == "vid":
+                xs.extend(mkGroups(x))
+            elif x.name == "bracketgr":
+                xs.extend(["["] + mkGroups(x) + ["]"])
+            elif x.name == "bracegr":
+                xs.extend(["{"] + mkGroups(x) + ["}"])
+            else:
+                xs.extend(
+                    mkGroups(x) + ["}"]
+                )  # x.name == 'grand' == rejected grand staff
         else:
-            xs.append (p.t[0])
+            xs.append(p.t[0])
     return xs
 
-def stepTrans (step, soct, clef):   # [A-G] (1...8)
-    if clef.startswith ('bass'):
-        nm7 = 'C,D,E,F,G,A,B'.split (',')
-        n = 14 + nm7.index (step) - 12  # two octaves extra to avoid negative numbers
-        step, soct = nm7 [n % 7], soct + n // 7 - 2  # subtract two octaves again
+
+def stepTrans(step, soct, clef):  # [A-G] (1...8)
+    if clef.startswith("bass"):
+        nm7 = "C,D,E,F,G,A,B".split(",")
+        n = 14 + nm7.index(step) - 12  # two octaves extra to avoid negative numbers
+        step, soct = nm7[n % 7], soct + n // 7 - 2  # subtract two octaves again
     return step, soct
 
-def reduceMids (parts, vidsnew, midiInst):       # remove redundant instruments from a part
-    for pid, part in zip (vidsnew, parts):
+
+def reduceMids(parts, vidsnew, midiInst):  # remove redundant instruments from a part
+    for pid, part in zip(vidsnew, parts):
         mids, repls, has_perc = {}, {}, 0
-        for ipid, ivid, ch, prg, vol, pan in sorted (list (midiInst.values ())):
-            if ipid != pid: continue                # only instruments from part pid
-            if ch == '10': has_perc = 1; continue   # only consider non percussion instruments
-            instId, inst = 'I%s-%s' % (ipid, ivid), (ch, prg)
-            if inst in mids:                        # midi instrument already defined in this part
-                repls [instId]  = mids [inst]       # remember to replace instId by inst (see below)
-                del midiInst [instId]               # instId is redundant
-            else: mids [inst] = instId              # collect unique instruments in this part
-        if len (mids) < 2 and not has_perc:         # only one instrument used -> no instrument tags needed in notes
-            removeElems (part, 'measure/note', 'instrument')    # no instrument tag needed for one- or no-instrument parts
+        for ipid, ivid, ch, prg, vol, pan in sorted(list(midiInst.values())):
+            if ipid != pid:
+                continue  # only instruments from part pid
+            if ch == "10":
+                has_perc = 1
+                continue  # only consider non percussion instruments
+            instId, inst = "I%s-%s" % (ipid, ivid), (ch, prg)
+            if inst in mids:  # midi instrument already defined in this part
+                repls[instId] = mids[
+                    inst
+                ]  # remember to replace instId by inst (see below)
+                del midiInst[instId]  # instId is redundant
+            else:
+                mids[inst] = instId  # collect unique instruments in this part
+        if (
+            len(mids) < 2 and not has_perc
+        ):  # only one instrument used -> no instrument tags needed in notes
+            removeElems(
+                part, "measure/note", "instrument"
+            )  # no instrument tag needed for one- or no-instrument parts
         else:
-            for e in part.findall ('measure/note/instrument'):
-                id = e.get ('id')                   # replace all redundant instrument Id's
-                if id in repls: e.set ('id', repls [id])
+            for e in part.findall("measure/note/instrument"):
+                id = e.get("id")  # replace all redundant instrument Id's
+                if id in repls:
+                    e.set("id", repls[id])
+
 
 class stringAlloc:
-    def __init__ (s):
-        s.snaarVrij = []    # [[(t1, t2) ...] for each string ]
-        s.snaarIx = []      # index in snaarVrij for each string
-        s.curstaff = -1     # staff being allocated
-    def beginZoek (s):      # reset snaarIx at start of each voice
+    def __init__(s):
+        s.snaarVrij = []  # [[(t1, t2) ...] for each string ]
+        s.snaarIx = []  # index in snaarVrij for each string
+        s.curstaff = -1  # staff being allocated
+
+    def beginZoek(s):  # reset snaarIx at start of each voice
         s.snaarIx = []
-        for i in range (len (s.snaarVrij)): s.snaarIx.append (0)
-    def setlines (s, stflines, stfnum):
-        if stfnum != s.curstaff:    # initialize for new staff
+        for i in range(len(s.snaarVrij)):
+            s.snaarIx.append(0)
+
+    def setlines(s, stflines, stfnum):
+        if stfnum != s.curstaff:  # initialize for new staff
             s.curstaff = stfnum
             s.snaarVrij = []
-            for i in range (stflines): s.snaarVrij.append ([])
-            s.beginZoek ()
-    def isVrij (s, snaar, t1, t2):  # see if string snaar is free between t1 and t2
-        xs = s.snaarVrij [snaar]
-        for i in range (s.snaarIx [snaar], len (xs)):
-            tb, te = xs [i]
-            if t1 >= te: continue   # te_prev < t1 <= te
-            if t1 >= tb: s.snaarIx [snaar] = i; return 0    # tb <= t1 < te
-            if t2 > tb: s.snaarIx [snaar] = i; return 0     # t1 < tb < t2
-            s.snaarIx [snaar] = i;  # remember position for next call
-            xs.insert (i, (t1,t2))  # te_prev < t1 < t2 < tb
+            for i in range(stflines):
+                s.snaarVrij.append([])
+            s.beginZoek()
+
+    def isVrij(s, snaar, t1, t2):  # see if string snaar is free between t1 and t2
+        xs = s.snaarVrij[snaar]
+        for i in range(s.snaarIx[snaar], len(xs)):
+            tb, te = xs[i]
+            if t1 >= te:
+                continue  # te_prev < t1 <= te
+            if t1 >= tb:
+                s.snaarIx[snaar] = i
+                return 0  # tb <= t1 < te
+            if t2 > tb:
+                s.snaarIx[snaar] = i
+                return 0  # t1 < tb < t2
+            s.snaarIx[snaar] = i  # remember position for next call
+            xs.insert(i, (t1, t2))  # te_prev < t1 < t2 < tb
             return 1
-        xs.append ((t1,t2))
-        s.snaarIx [snaar] = len (xs) - 1
+        xs.append((t1, t2))
+        s.snaarIx[snaar] = len(xs) - 1
         return 1
-    def bezet (s, snaar, t1, t2):   # force allocation of note (t1,t2) on string snaar
-        xs = s.snaarVrij [snaar]
-        for i, (tb, te) in enumerate (xs):
-            if t1 >= te: continue   # te_prev < t1 <= te
-            xs.insert (i, (t1, t2))
+
+    def bezet(s, snaar, t1, t2):  # force allocation of note (t1,t2) on string snaar
+        xs = s.snaarVrij[snaar]
+        for i, (tb, te) in enumerate(xs):
+            if t1 >= te:
+                continue  # te_prev < t1 <= te
+            xs.insert(i, (t1, t2))
             return
-        xs.append ((t1,t2))
+        xs.append((t1, t2))
+
 
 class MusicXml:
-    typeMap = {1:'long', 2:'breve', 4:'whole', 8:'half', 16:'quarter', 32:'eighth', 64:'16th', 128:'32nd', 256:'64th'}
-    dynaMap = {'p':1,'pp':1,'ppp':1,'pppp':1,'f':1,'ff':1,'fff':1,'ffff':1,'mp':1,'mf':1,'sfz':1}
-    tempoMap = {'larghissimo':40, 'moderato':104, 'adagissimo':44, 'allegretto':112, 'lentissimo':48, 'allegro':120, 'largo':56,
-            'vivace':168, 'adagio':59, 'vivo':180, 'lento':62, 'presto':192, 'larghetto':66, 'allegrissimo':208, 'adagietto':76,
-            'vivacissimo':220, 'andante':88, 'prestissimo':240, 'andantino':96}
-    wedgeMap = {'>(':1, '>)':1, '<(':1,'<)':1,'crescendo(':1,'crescendo)':1,'diminuendo(':1,'diminuendo)':1}
-    artMap = {'.':'staccato','>':'accent','accent':'accent','wedge':'staccatissimo','tenuto':'tenuto',
-              'breath':'breath-mark','marcato':'strong-accent','^':'strong-accent','slide':'scoop'}
-    ornMap = {'trill':'trill-mark','T':'trill-mark','turn':'turn','uppermordent':'inverted-mordent','lowermordent':'mordent',
-              'pralltriller':'inverted-mordent','mordent':'mordent','turn':'turn','invertedturn':'inverted-turn'}
-    tecMap = {'upbow':'up-bow', 'downbow':'down-bow', 'plus':'stopped','open':'open-string','snap':'snap-pizzicato',
-              'thumb':'thumb-position'}
-    capoMap = {'fine':('Fine','fine','yes'), 'D.S.':('D.S.','dalsegno','segno'), 'D.C.':('D.C.','dacapo','yes'),'dacapo':('D.C.','dacapo','yes'),
-               'dacoda':('To Coda','tocoda','coda'), 'coda':('coda','coda','coda'), 'segno':('segno','segno','segno')}
-    sharpness = ['Fb', 'Cb','Gb','Db','Ab','Eb','Bb','F','C','G','D','A', 'E', 'B', 'F#','C#','G#','D#','A#','E#','B#']
-    offTab = {'maj':8, 'm':11, 'min':11, 'mix':9, 'dor':10, 'phr':12, 'lyd':7, 'loc':13}
-    modTab = {'maj':'major', 'm':'minor', 'min':'minor', 'mix':'mixolydian', 'dor':'dorian', 'phr':'phrygian', 'lyd':'lydian', 'loc':'locrian'}
-    clefMap = { 'alto1':('C','1'), 'alto2':('C','2'), 'alto':('C','3'), 'alto4':('C','4'), 'tenor':('C','4'),
-                'bass3':('F','3'), 'bass':('F','4'), 'treble':('G','2'), 'perc':('percussion',''), 'none':('',''), 'tab':('TAB','5')}
-    clefLineMap = {'B':'treble', 'G':'alto1', 'E':'alto2', 'C':'alto', 'A':'tenor', 'F':'bass3', 'D':'bass'}
-    alterTab = {'=':'0', '_':'-1', '__':'-2', '^':'1', '^^':'2'}
-    accTab = {'=':'natural', '_':'flat', '__':'flat-flat', '^':'sharp', '^^':'sharp-sharp'}
-    chordTab = compChordTab ()
-    uSyms = {'~':'roll', 'H':'fermata','L':'>','M':'lowermordent','O':'coda',
-             'P':'uppermordent','S':'segno','T':'trill','u':'upbow','v':'downbow'}
-    pageFmtDef = [0.75,297,210,18,18,10,10] # the abcm2ps page formatting defaults for A4
-    metaTab = {'O':'origin', 'A':'area', 'Z':'transcription', 'N':'notes', 'G':'group', 'H':'history', 'R':'rhythm',
-                'B':'book', 'D':'discography', 'F':'fileurl', 'S':'source', 'P':'partmap', 'W':'lyrics'}
-    metaMap = {'C':'composer'}  # mapping of composer is fixed
-    metaTypes = {'composer':1,'lyricist':1,'poet':1,'arranger':1,'translator':1, 'rights':1} # valid MusicXML meta data types
-    tuningDef = 'E2,A2,D3,G3,B3,E4'.split (',') # default string tuning (guitar)
+    typeMap = {
+        1: "long",
+        2: "breve",
+        4: "whole",
+        8: "half",
+        16: "quarter",
+        32: "eighth",
+        64: "16th",
+        128: "32nd",
+        256: "64th",
+    }
+    dynaMap = {
+        "p": 1,
+        "pp": 1,
+        "ppp": 1,
+        "pppp": 1,
+        "f": 1,
+        "ff": 1,
+        "fff": 1,
+        "ffff": 1,
+        "mp": 1,
+        "mf": 1,
+        "sfz": 1,
+    }
+    tempoMap = {
+        "larghissimo": 40,
+        "moderato": 104,
+        "adagissimo": 44,
+        "allegretto": 112,
+        "lentissimo": 48,
+        "allegro": 120,
+        "largo": 56,
+        "vivace": 168,
+        "adagio": 59,
+        "vivo": 180,
+        "lento": 62,
+        "presto": 192,
+        "larghetto": 66,
+        "allegrissimo": 208,
+        "adagietto": 76,
+        "vivacissimo": 220,
+        "andante": 88,
+        "prestissimo": 240,
+        "andantino": 96,
+    }
+    wedgeMap = {
+        ">(": 1,
+        ">)": 1,
+        "<(": 1,
+        "<)": 1,
+        "crescendo(": 1,
+        "crescendo)": 1,
+        "diminuendo(": 1,
+        "diminuendo)": 1,
+    }
+    artMap = {
+        ".": "staccato",
+        ">": "accent",
+        "accent": "accent",
+        "wedge": "staccatissimo",
+        "tenuto": "tenuto",
+        "breath": "breath-mark",
+        "marcato": "strong-accent",
+        "^": "strong-accent",
+        "slide": "scoop",
+    }
+    ornMap = {
+        "trill": "trill-mark",
+        "T": "trill-mark",
+        "turn": "turn",
+        "uppermordent": "inverted-mordent",
+        "lowermordent": "mordent",
+        "pralltriller": "inverted-mordent",
+        "mordent": "mordent",
+        "turn": "turn",
+        "invertedturn": "inverted-turn",
+    }
+    tecMap = {
+        "upbow": "up-bow",
+        "downbow": "down-bow",
+        "plus": "stopped",
+        "open": "open-string",
+        "snap": "snap-pizzicato",
+        "thumb": "thumb-position",
+    }
+    capoMap = {
+        "fine": ("Fine", "fine", "yes"),
+        "D.S.": ("D.S.", "dalsegno", "segno"),
+        "D.C.": ("D.C.", "dacapo", "yes"),
+        "dacapo": ("D.C.", "dacapo", "yes"),
+        "dacoda": ("To Coda", "tocoda", "coda"),
+        "coda": ("coda", "coda", "coda"),
+        "segno": ("segno", "segno", "segno"),
+    }
+    sharpness = [
+        "Fb",
+        "Cb",
+        "Gb",
+        "Db",
+        "Ab",
+        "Eb",
+        "Bb",
+        "F",
+        "C",
+        "G",
+        "D",
+        "A",
+        "E",
+        "B",
+        "F#",
+        "C#",
+        "G#",
+        "D#",
+        "A#",
+        "E#",
+        "B#",
+    ]
+    offTab = {
+        "maj": 8,
+        "m": 11,
+        "min": 11,
+        "mix": 9,
+        "dor": 10,
+        "phr": 12,
+        "lyd": 7,
+        "loc": 13,
+    }
+    modTab = {
+        "maj": "major",
+        "m": "minor",
+        "min": "minor",
+        "mix": "mixolydian",
+        "dor": "dorian",
+        "phr": "phrygian",
+        "lyd": "lydian",
+        "loc": "locrian",
+    }
+    clefMap = {
+        "alto1": ("C", "1"),
+        "alto2": ("C", "2"),
+        "alto": ("C", "3"),
+        "alto4": ("C", "4"),
+        "tenor": ("C", "4"),
+        "bass3": ("F", "3"),
+        "bass": ("F", "4"),
+        "treble": ("G", "2"),
+        "perc": ("percussion", ""),
+        "none": ("", ""),
+        "tab": ("TAB", "5"),
+    }
+    clefLineMap = {
+        "B": "treble",
+        "G": "alto1",
+        "E": "alto2",
+        "C": "alto",
+        "A": "tenor",
+        "F": "bass3",
+        "D": "bass",
+    }
+    alterTab = {"=": "0", "_": "-1", "__": "-2", "^": "1", "^^": "2"}
+    accTab = {
+        "=": "natural",
+        "_": "flat",
+        "__": "flat-flat",
+        "^": "sharp",
+        "^^": "sharp-sharp",
+    }
+    chordTab = compChordTab()
+    uSyms = {
+        "~": "roll",
+        "H": "fermata",
+        "L": ">",
+        "M": "lowermordent",
+        "O": "coda",
+        "P": "uppermordent",
+        "S": "segno",
+        "T": "trill",
+        "u": "upbow",
+        "v": "downbow",
+    }
+    pageFmtDef = [
+        0.75,
+        297,
+        210,
+        18,
+        18,
+        10,
+        10,
+    ]  # the abcm2ps page formatting defaults for A4
+    metaTab = {
+        "O": "origin",
+        "A": "area",
+        "Z": "transcription",
+        "N": "notes",
+        "G": "group",
+        "H": "history",
+        "R": "rhythm",
+        "B": "book",
+        "D": "discography",
+        "F": "fileurl",
+        "S": "source",
+        "P": "partmap",
+        "W": "lyrics",
+    }
+    metaMap = {"C": "composer"}  # mapping of composer is fixed
+    metaTypes = {
+        "composer": 1,
+        "lyricist": 1,
+        "poet": 1,
+        "arranger": 1,
+        "translator": 1,
+        "rights": 1,
+    }  # valid MusicXML meta data types
+    tuningDef = "E2,A2,D3,G3,B3,E4".split(",")  # default string tuning (guitar)
 
-    def __init__ (s):
-        s.pageFmtCmd = []   # set by command line option -p
-        s.reset ()
-    def reset (s, fOpt=False):
-        s.divisions = 2520  # xml duration of 1/4 note, 2^3 * 3^2 * 5 * 7 => 5,7,9 tuplets
-        s.ties = {}         # {abc pitch tuple -> alteration} for all open ties
-        s.slurstack = {}    # stack of open slur numbers per (overlay) voice
-        s.slurbeg = []      # type of slurs to start (when slurs are detected at element-level)
-        s.tmnum = 0         # time modification, numerator
-        s.tmden = 0         # time modification, denominator
-        s.ntup = 0          # number of tuplet notes remaining
-        s.trem = 0          # number of bars for tremolo
-        s.intrem = 0        # mark tremolo sequence (for duration doubling)
-        s.tupnts = []       # all tuplet modifiers with corresp. durations: [(duration, modifier), ...]
-        s.irrtup = 0        # 1 if an irregular tuplet
-        s.ntype = ''        # the normal-type of a tuplet (== duration type of a normal tuplet note)
-        s.unitL =  (1, 8)   # default unit length
-        s.unitLcur = (1, 8) # unit length of current voice
-        s.keyAlts = {}      # alterations implied by key
-        s.msreAlts = {}     # temporarily alterations
-        s.curVolta = ''     # open volta bracket
-        s.title = ''        # title of music
-        s.creator = {}      # {creator-type -> creator string}
-        s.metadata = {}     # {metadata-type -> string}
-        s.lyrdash = {}      # {lyric number -> 1 if dash between syllables}
-        s.usrSyms = s.uSyms # user defined symbols
-        s.prevNote = None   # xml element of previous beamed note to correct beams (start, continue)
-        s.prevLyric = {}    # xml element of previous lyric to add/correct extend type (start, continue)
-        s.grcbbrk = False   # remember any bbrk in a grace sequence
-        s.linebrk = 0       # 1 if next measure should start with a line break
-        s.nextdecos = []    # decorations for the next note
-        s.prevmsre = None   # the previous measure
-        s.supports_tag = 0  # issue supports-tag in xml file when abc uses explicit linebreaks
-        s.staveDefs = []    # collected %%staves or %%score instructions from score
-        s.staves = []       # staves = [[voice names to be merged into one stave]]
-        s.groups = []       # list of merged part names with interspersed {[ and }]
-        s.grands = []       # [[vid1, vid2, ..], ...] voiceIds to be merged in a grand staff
-        s.gStaffNums = {}   # map each voice id in a grand staff to a staff number
-        s.gNstaves = {}     # map each voice id in a grand staff to total number of staves
-        s.pageFmtAbc = []   # formatting from abc directives
-        s.mdur = (4,4)      # duration of one measure
-        s.gtrans = 0        # octave transposition (by clef)
-        s.midprg = ['', '', '', ''] # MIDI channel nr, program nr, volume, panning for the current part
-        s.vid = ''          # abc voice id for the current voice
-        s.pid = ''          # xml part id for the current voice
-        s.gcue_on = 0       # insert <cue/> tag in each note
-        s.percVoice = 0     # 1 if percussion enabled
-        s.percMap = {}      # (part-id, abc_pitch, xml-octave) -> (abc staff step, midi note number, xml notehead)
-        s.pMapFound = 0     # at least one I:percmap has been found
-        s.vcepid = {}       # voice_id -> part_id
-        s.midiInst = {}     # inst_id -> (part_id, voice_id, channel, midi_number), remember instruments used
-        s.capo = 0          # fret position of the capodastro
-        s.tunmid = []       # midi numbers of strings
-        s.tunTup = []       # ordered midi numbers of strings [(midi_num, string_num), ...] (midi_num from high to low)
-        s.fOpt = fOpt       # force string/fret allocations for tab staves
-        s.orderChords = 0   # order notes in a chord
-        s.chordDecos = {}   # decos that should be distributed to all chord notes for xml
-        ch10 = 'acoustic-bass-drum,35;bass-drum-1,36;side-stick,37;acoustic-snare,38;hand-clap,39;electric-snare,40;low-floor-tom,41;closed-hi-hat,42;high-floor-tom,43;pedal-hi-hat,44;low-tom,45;open-hi-hat,46;low-mid-tom,47;hi-mid-tom,48;crash-cymbal-1,49;high-tom,50;ride-cymbal-1,51;chinese-cymbal,52;ride-bell,53;tambourine,54;splash-cymbal,55;cowbell,56;crash-cymbal-2,57;vibraslap,58;ride-cymbal-2,59;hi-bongo,60;low-bongo,61;mute-hi-conga,62;open-hi-conga,63;low-conga,64;high-timbale,65;low-timbale,66;high-agogo,67;low-agogo,68;cabasa,69;maracas,70;short-whistle,71;long-whistle,72;short-guiro,73;long-guiro,74;claves,75;hi-wood-block,76;low-wood-block,77;mute-cuica,78;open-cuica,79;mute-triangle,80;open-triangle,81'
-        s.percsnd = [x.split (',') for x in ch10.split (';')]   # {name -> midi number} of standard channel 10 sound names
-        s.gTime = (0,0)     # (XML begin time, XML end time) in divisions
-        s.tabStaff = ''     # == pid (part ID) for a tab staff
+    def __init__(s):
+        s.pageFmtCmd = []  # set by command line option -p
+        s.reset()
 
-    def mkPitch (s, acc, note, oct, lev):
-        if s.percVoice: # percussion map switched off by perc=off (see doClef)
-            octq = int (oct) + s.gtrans     # honour the octave= transposition when querying percmap
-            tup = s.percMap.get ((s.pid, acc+note, octq), s.percMap.get (('', acc+note, octq), 0))
-            if tup: step, soct, midi, notehead = tup
-            else: step, soct = note, octq
-            octnum = (4 if step.upper() == step else 5) + int (soct)
-            if not tup: # add percussion map for unmapped notes in this part
-                midi = str (octnum * 12 + [0,2,4,5,7,9,11]['CDEFGAB'.index (step.upper())] + {'^':1,'_':-1}.get (acc, 0) + 12)
-                notehead = {'^':'x', '_':'circle-x'}.get (acc, 'normal')
-                if s.pMapFound: info ('no I:percmap for: %s%s in part %s, voice %s' % (acc+note, -oct*',' if oct<0 else oct*"'", s.pid, s.vid))
-                s.percMap [(s.pid, acc+note, octq)] =  (note, octq, midi, notehead)
-            else:       # correct step value for clef
-                step, octnum = stepTrans (step.upper (), octnum, s.curClef)
-            pitch = E.Element ('unpitched')
-            addElemT (pitch, 'display-step', step.upper (), lev + 1)
-            addElemT (pitch, 'display-octave', str (octnum), lev + 1)
-            return pitch, '', midi, notehead
-        nUp = note.upper ()
-        octnum = (4 if nUp == note else 5) + int (oct) + s.gtrans
-        pitch = E.Element ('pitch')
-        addElemT (pitch, 'step', nUp, lev + 1)
-        alter = ''
+    def reset(s, fOpt=False):
+        s.divisions = (
+            2520  # xml duration of 1/4 note, 2^3 * 3^2 * 5 * 7 => 5,7,9 tuplets
+        )
+        s.ties = {}  # {abc pitch tuple -> alteration} for all open ties
+        s.slurstack = {}  # stack of open slur numbers per (overlay) voice
+        s.slurbeg = (
+            []
+        )  # type of slurs to start (when slurs are detected at element-level)
+        s.tmnum = 0  # time modification, numerator
+        s.tmden = 0  # time modification, denominator
+        s.ntup = 0  # number of tuplet notes remaining
+        s.trem = 0  # number of bars for tremolo
+        s.intrem = 0  # mark tremolo sequence (for duration doubling)
+        s.tupnts = (
+            []
+        )  # all tuplet modifiers with corresp. durations: [(duration, modifier), ...]
+        s.irrtup = 0  # 1 if an irregular tuplet
+        s.ntype = (
+            ""  # the normal-type of a tuplet (== duration type of a normal tuplet note)
+        )
+        s.unitL = (1, 8)  # default unit length
+        s.unitLcur = (1, 8)  # unit length of current voice
+        s.keyAlts = {}  # alterations implied by key
+        s.msreAlts = {}  # temporarily alterations
+        s.curVolta = ""  # open volta bracket
+        s.title = ""  # title of music
+        s.creator = {}  # {creator-type -> creator string}
+        s.metadata = {}  # {metadata-type -> string}
+        s.lyrdash = {}  # {lyric number -> 1 if dash between syllables}
+        s.usrSyms = s.uSyms  # user defined symbols
+        s.prevNote = None  # xml element of previous beamed note to correct beams (start, continue)
+        s.prevLyric = (
+            {}
+        )  # xml element of previous lyric to add/correct extend type (start, continue)
+        s.grcbbrk = False  # remember any bbrk in a grace sequence
+        s.linebrk = 0  # 1 if next measure should start with a line break
+        s.nextdecos = []  # decorations for the next note
+        s.prevmsre = None  # the previous measure
+        s.supports_tag = (
+            0  # issue supports-tag in xml file when abc uses explicit linebreaks
+        )
+        s.staveDefs = []  # collected %%staves or %%score instructions from score
+        s.staves = []  # staves = [[voice names to be merged into one stave]]
+        s.groups = []  # list of merged part names with interspersed {[ and }]
+        s.grands = []  # [[vid1, vid2, ..], ...] voiceIds to be merged in a grand staff
+        s.gStaffNums = {}  # map each voice id in a grand staff to a staff number
+        s.gNstaves = {}  # map each voice id in a grand staff to total number of staves
+        s.pageFmtAbc = []  # formatting from abc directives
+        s.mdur = (4, 4)  # duration of one measure
+        s.gtrans = 0  # octave transposition (by clef)
+        s.midprg = [
+            "",
+            "",
+            "",
+            "",
+        ]  # MIDI channel nr, program nr, volume, panning for the current part
+        s.vid = ""  # abc voice id for the current voice
+        s.pid = ""  # xml part id for the current voice
+        s.gcue_on = 0  # insert <cue/> tag in each note
+        s.percVoice = 0  # 1 if percussion enabled
+        s.percMap = (
+            {}
+        )  # (part-id, abc_pitch, xml-octave) -> (abc staff step, midi note number, xml notehead)
+        s.pMapFound = 0  # at least one I:percmap has been found
+        s.vcepid = {}  # voice_id -> part_id
+        s.midiInst = (
+            {}
+        )  # inst_id -> (part_id, voice_id, channel, midi_number), remember instruments used
+        s.capo = 0  # fret position of the capodastro
+        s.tunmid = []  # midi numbers of strings
+        s.tunTup = (
+            []
+        )  # ordered midi numbers of strings [(midi_num, string_num), ...] (midi_num from high to low)
+        s.fOpt = fOpt  # force string/fret allocations for tab staves
+        s.orderChords = 0  # order notes in a chord
+        s.chordDecos = {}  # decos that should be distributed to all chord notes for xml
+        ch10 = "acoustic-bass-drum,35;bass-drum-1,36;side-stick,37;acoustic-snare,38;hand-clap,39;electric-snare,40;low-floor-tom,41;closed-hi-hat,42;high-floor-tom,43;pedal-hi-hat,44;low-tom,45;open-hi-hat,46;low-mid-tom,47;hi-mid-tom,48;crash-cymbal-1,49;high-tom,50;ride-cymbal-1,51;chinese-cymbal,52;ride-bell,53;tambourine,54;splash-cymbal,55;cowbell,56;crash-cymbal-2,57;vibraslap,58;ride-cymbal-2,59;hi-bongo,60;low-bongo,61;mute-hi-conga,62;open-hi-conga,63;low-conga,64;high-timbale,65;low-timbale,66;high-agogo,67;low-agogo,68;cabasa,69;maracas,70;short-whistle,71;long-whistle,72;short-guiro,73;long-guiro,74;claves,75;hi-wood-block,76;low-wood-block,77;mute-cuica,78;open-cuica,79;mute-triangle,80;open-triangle,81"
+        s.percsnd = [
+            x.split(",") for x in ch10.split(";")
+        ]  # {name -> midi number} of standard channel 10 sound names
+        s.gTime = (0, 0)  # (XML begin time, XML end time) in divisions
+        s.tabStaff = ""  # == pid (part ID) for a tab staff
+
+    def mkPitch(s, acc, note, oct, lev):
+        if s.percVoice:  # percussion map switched off by perc=off (see doClef)
+            octq = (
+                int(oct) + s.gtrans
+            )  # honour the octave= transposition when querying percmap
+            tup = s.percMap.get(
+                (s.pid, acc + note, octq), s.percMap.get(("", acc + note, octq), 0)
+            )
+            if tup:
+                step, soct, midi, notehead = tup
+            else:
+                step, soct = note, octq
+            octnum = (4 if step.upper() == step else 5) + int(soct)
+            if not tup:  # add percussion map for unmapped notes in this part
+                midi = str(
+                    octnum * 12
+                    + [0, 2, 4, 5, 7, 9, 11]["CDEFGAB".index(step.upper())]
+                    + {"^": 1, "_": -1}.get(acc, 0)
+                    + 12
+                )
+                notehead = {"^": "x", "_": "circle-x"}.get(acc, "normal")
+                if s.pMapFound:
+                    info(
+                        "no I:percmap for: %s%s in part %s, voice %s"
+                        % (
+                            acc + note,
+                            -oct * "," if oct < 0 else oct * "'",
+                            s.pid,
+                            s.vid,
+                        )
+                    )
+                s.percMap[(s.pid, acc + note, octq)] = (note, octq, midi, notehead)
+            else:  # correct step value for clef
+                step, octnum = stepTrans(step.upper(), octnum, s.curClef)
+            pitch = E.Element("unpitched")
+            addElemT(pitch, "display-step", step.upper(), lev + 1)
+            addElemT(pitch, "display-octave", str(octnum), lev + 1)
+            return pitch, "", midi, notehead
+        nUp = note.upper()
+        octnum = (4 if nUp == note else 5) + int(oct) + s.gtrans
+        pitch = E.Element("pitch")
+        addElemT(pitch, "step", nUp, lev + 1)
+        alter = ""
         if (note, oct) in s.ties:
-            tied_alter, _, vnum, _ = s.ties [(note,oct)]            # vnum = overlay voice number when tie started
-            if vnum == s.overlayVnum: alter = tied_alter            # tied note in the same overlay -> same alteration
+            tied_alter, _, vnum, _ = s.ties[
+                (note, oct)
+            ]  # vnum = overlay voice number when tie started
+            if vnum == s.overlayVnum:
+                alter = tied_alter  # tied note in the same overlay -> same alteration
         elif acc:
-            s.msreAlts [(nUp, octnum)] = s.alterTab [acc]
-            alter = s.alterTab [acc]                                # explicit notated alteration
-        elif (nUp, octnum) in s.msreAlts:   alter = s.msreAlts [(nUp, octnum)]  # temporary alteration
-        elif nUp in s.keyAlts:              alter = s.keyAlts [nUp] # alteration implied by the key
-        if alter: addElemT (pitch, 'alter', alter, lev + 1)
-        addElemT (pitch, 'octave', str (octnum), lev + 1)
-        return pitch, alter, '', ''
+            s.msreAlts[(nUp, octnum)] = s.alterTab[acc]
+            alter = s.alterTab[acc]  # explicit notated alteration
+        elif (nUp, octnum) in s.msreAlts:
+            alter = s.msreAlts[(nUp, octnum)]  # temporary alteration
+        elif nUp in s.keyAlts:
+            alter = s.keyAlts[nUp]  # alteration implied by the key
+        if alter:
+            addElemT(pitch, "alter", alter, lev + 1)
+        addElemT(pitch, "octave", str(octnum), lev + 1)
+        return pitch, alter, "", ""
 
-    def getNoteDecos (s, n):
-        decos = s.nextdecos             # decorations encountered so far
-        ndeco = getattr (n, 'deco', 0)  # possible decorations of notes of a chord
-        if ndeco:                       # add decorations, translate used defined symbols
-            decos += [s.usrSyms.get (d, d).strip ('!+') for d in ndeco.t]
+    def getNoteDecos(s, n):
+        decos = s.nextdecos  # decorations encountered so far
+        ndeco = getattr(n, "deco", 0)  # possible decorations of notes of a chord
+        if ndeco:  # add decorations, translate used defined symbols
+            decos += [s.usrSyms.get(d, d).strip("!+") for d in ndeco.t]
         s.nextdecos = []
-        if s.tabStaff == s.pid and s.fOpt and n.name != 'rest':  # force fret/string allocation if explicit string decoration is missing
-            if [d for d in decos if d in '0123456789'] == []: decos.append ('0')
+        if (
+            s.tabStaff == s.pid and s.fOpt and n.name != "rest"
+        ):  # force fret/string allocation if explicit string decoration is missing
+            if [d for d in decos if d in "0123456789"] == []:
+                decos.append("0")
         return decos
 
-    def mkNote (s, n, lev):
-        isgrace = getattr (n, 'grace', '')
-        ischord = getattr (n, 'chord', '')
+    def mkNote(s, n, lev):
+        isgrace = getattr(n, "grace", "")
+        ischord = getattr(n, "chord", "")
         if s.ntup >= 0 and not isgrace and not ischord:
-            s.ntup -= 1                 # count tuplet notes only on non-chord, non grace notes
+            s.ntup -= 1  # count tuplet notes only on non-chord, non grace notes
             if s.ntup == -1 and s.trem <= 0:
-                s.intrem = 0            # tremolo pair ends at first note that is not a new tremolo pair (s.trem > 0)
-        nnum, nden = n.dur.t            # abc dutation of note
-        if s.intrem: nnum += nnum       # double duration of tremolo duplets
-        if nden == 0: nden = 1          # occurs with illegal ABC like: "A2 1". Now interpreted as A2/1
-        num, den = simplify (nnum * s.unitLcur[0], nden * s.unitLcur[1])  # normalised with unit length
-        if den > 64:    # limit denominator to 64
-            num = int (round (64 * float (num) / den))  # scale note to num/64
-            num, den  = simplify (max ([num, 1]), 64)   # smallest num == 1
-            info ('duration too small: rounded to %d/%d' % (num, den))
-        if n.name == 'rest' and ('Z' in n.t or 'X' in n.t):
-              num, den = s.mdur         # duration of one measure
-        noMsrRest = not (n.name == 'rest' and (num, den) == s.mdur) # not a measure rest
-        dvs = (4 * s.divisions * num) // den    # divisions is xml-duration of 1/4
-        rdvs = dvs                      # real duration (will be 0 for chord/grace)
-        num, den = simplify (num, den * 4)      # scale by 1/4 for s.typeMap
+                s.intrem = 0  # tremolo pair ends at first note that is not a new tremolo pair (s.trem > 0)
+        nnum, nden = n.dur.t  # abc dutation of note
+        if s.intrem:
+            nnum += nnum  # double duration of tremolo duplets
+        if nden == 0:
+            nden = 1  # occurs with illegal ABC like: "A2 1". Now interpreted as A2/1
+        num, den = simplify(
+            nnum * s.unitLcur[0], nden * s.unitLcur[1]
+        )  # normalised with unit length
+        if den > 64:  # limit denominator to 64
+            num = int(round(64 * float(num) / den))  # scale note to num/64
+            num, den = simplify(max([num, 1]), 64)  # smallest num == 1
+            info("duration too small: rounded to %d/%d" % (num, den))
+        if n.name == "rest" and ("Z" in n.t or "X" in n.t):
+            num, den = s.mdur  # duration of one measure
+        noMsrRest = not (
+            n.name == "rest" and (num, den) == s.mdur
+        )  # not a measure rest
+        dvs = (4 * s.divisions * num) // den  # divisions is xml-duration of 1/4
+        rdvs = dvs  # real duration (will be 0 for chord/grace)
+        num, den = simplify(num, den * 4)  # scale by 1/4 for s.typeMap
         ndot = 0
-        if num == 3 and noMsrRest: ndot = 1; den = den // 2 # look for dotted notes
-        if num == 7 and noMsrRest: ndot = 2; den = den // 4
-        nt = E.Element ('note')
-        if isgrace:                     # a grace note (and possibly a chord note)
-            grace = E.Element ('grace')
-            if s.acciatura: grace.set ('slash', 'yes'); s.acciatura = 0
-            addElem (nt, grace, lev + 1)
-            dvs = rdvs = 0              # no (real) duration for a grace note
-            if den <= 16: den = 32      # not longer than 1/8 for a grace note
-        if s.gcue_on:                   # insert cue tag
-            cue = E.Element ('cue')
-            addElem (nt, cue, lev + 1)
-        if ischord:                     # a chord note
-            chord = E.Element ('chord')
-            addElem (nt, chord, lev + 1)
-            rdvs = 0                    # chord notes no real duration
-        if den not in s.typeMap:        # take the nearest smaller legal duration
-            info ('illegal duration %d/%d' % (nnum, nden))
-            den = min (x for x in s.typeMap.keys () if x > den)
-        xmltype = str (s.typeMap [den]) # xml needs the note type in addition to duration
-        acc, step, oct = '', 'C', '0'   # abc-notated pitch elements (accidental, pitch step, octave)
-        alter, midi, notehead = '', '', ''      # xml alteration
-        if n.name == 'rest':
-            if 'x' in n.t or 'X' in n.t: nt.set ('print-object', 'no')
-            rest = E.Element ('rest')
-            if not noMsrRest: rest.set ('measure', 'yes')
-            addElem (nt, rest, lev + 1)
+        if num == 3 and noMsrRest:
+            ndot = 1
+            den = den // 2  # look for dotted notes
+        if num == 7 and noMsrRest:
+            ndot = 2
+            den = den // 4
+        nt = E.Element("note")
+        if isgrace:  # a grace note (and possibly a chord note)
+            grace = E.Element("grace")
+            if s.acciatura:
+                grace.set("slash", "yes")
+                s.acciatura = 0
+            addElem(nt, grace, lev + 1)
+            dvs = rdvs = 0  # no (real) duration for a grace note
+            if den <= 16:
+                den = 32  # not longer than 1/8 for a grace note
+        if s.gcue_on:  # insert cue tag
+            cue = E.Element("cue")
+            addElem(nt, cue, lev + 1)
+        if ischord:  # a chord note
+            chord = E.Element("chord")
+            addElem(nt, chord, lev + 1)
+            rdvs = 0  # chord notes no real duration
+        if den not in s.typeMap:  # take the nearest smaller legal duration
+            info("illegal duration %d/%d" % (nnum, nden))
+            den = min(x for x in s.typeMap.keys() if x > den)
+        xmltype = str(s.typeMap[den])  # xml needs the note type in addition to duration
+        acc, step, oct = (
+            "",
+            "C",
+            "0",
+        )  # abc-notated pitch elements (accidental, pitch step, octave)
+        alter, midi, notehead = "", "", ""  # xml alteration
+        if n.name == "rest":
+            if "x" in n.t or "X" in n.t:
+                nt.set("print-object", "no")
+            rest = E.Element("rest")
+            if not noMsrRest:
+                rest.set("measure", "yes")
+            addElem(nt, rest, lev + 1)
         else:
-            p = n.pitch.t           # get pitch elements from parsed tokens
-            if len (p) == 3:    acc, step, oct = p
-            else:               step, oct = p
-            pitch, alter, midi, notehead = s.mkPitch (acc, step, oct, lev + 1)
-            if midi: acc = ''       # erase accidental for percussion notes
-            addElem (nt, pitch, lev + 1)
-        if s.ntup >= 0:                 # modify duration for tuplet notes
+            p = n.pitch.t  # get pitch elements from parsed tokens
+            if len(p) == 3:
+                acc, step, oct = p
+            else:
+                step, oct = p
+            pitch, alter, midi, notehead = s.mkPitch(acc, step, oct, lev + 1)
+            if midi:
+                acc = ""  # erase accidental for percussion notes
+            addElem(nt, pitch, lev + 1)
+        if s.ntup >= 0:  # modify duration for tuplet notes
             dvs = dvs * s.tmden // s.tmnum
         if dvs:
-            addElemT (nt, 'duration', str (dvs), lev + 1)   # skip when dvs == 0, requirement of musicXML
-            if not ischord: s.gTime = s.gTime [1], s.gTime [1] + dvs
-        ptup = (step, oct)              # pitch tuple without alteration to check for ties
-        tstop = ptup in s.ties and s.ties[ptup][2] == s.overlayVnum  # open tie on this pitch tuple in this overlay
+            addElemT(
+                nt, "duration", str(dvs), lev + 1
+            )  # skip when dvs == 0, requirement of musicXML
+            if not ischord:
+                s.gTime = s.gTime[1], s.gTime[1] + dvs
+        ptup = (step, oct)  # pitch tuple without alteration to check for ties
+        tstop = (
+            ptup in s.ties and s.ties[ptup][2] == s.overlayVnum
+        )  # open tie on this pitch tuple in this overlay
         if tstop:
-            tie = E.Element ('tie', type='stop')
-            addElem (nt, tie, lev + 1)
-        if getattr (n, 'tie', 0):
-            tie = E.Element ('tie', type='start')
-            addElem (nt, tie, lev + 1)
-        if (s.midprg != ['', '', '', ''] or midi) and n.name != 'rest': # only add when %%midi was present or percussion
-            instId = 'I%s-%s' % (s.pid, 'X' + midi if midi else s.vid)
-            chan, midi = ('10', midi) if midi else s.midprg [:2]
-            inst = E.Element ('instrument', id=instId)  # instrument id for midi
-            addElem (nt, inst, lev + 1)
-            if instId not in s.midiInst: s.midiInst [instId] = (s.pid, s.vid, chan, midi, s.midprg [2], s.midprg [3]) # for instrument list in mkScorePart
-        addElemT (nt, 'voice', '1', lev + 1)    # default voice, for merging later
-        if noMsrRest: addElemT (nt, 'type', xmltype, lev + 1) # add note type if not a measure rest
-        for i in range (ndot):          # add dots
-            dot = E.Element ('dot')
-            addElem (nt, dot, lev + 1)
-        decos = s.getNoteDecos (n)      # get decorations for this note
-        if acc and not tstop:           # only add accidental if note not tied
-            e = E.Element ('accidental')
-            if 'courtesy' in decos:
-                e.set ('parentheses', 'yes')
-                decos.remove ('courtesy')
-            e.text = s.accTab [acc]
-            addElem (nt, e, lev + 1)
-        tupnotation = ''                # start/stop notation element for tuplets
-        if s.ntup >= 0:                 # add time modification element for tuplet notes
-            tmod = mkTmod (s.tmnum, s.tmden, lev + 1)
-            addElem (nt, tmod, lev + 1)
-            if s.ntup > 0 and not s.tupnts: tupnotation = 'start'
-            s.tupnts.append ((rdvs, tmod))      # remember all tuplet modifiers with corresp. durations
-            if s.ntup == 0:             # last tuplet note (and possible chord notes there after)
-                if rdvs: tupnotation = 'stop'   # only insert notation in the real note (rdvs > 0)
-                s.cmpNormType (rdvs, lev + 1)   # compute and/or add normal-type elements (-> s.ntype)
+            tie = E.Element("tie", type="stop")
+            addElem(nt, tie, lev + 1)
+        if getattr(n, "tie", 0):
+            tie = E.Element("tie", type="start")
+            addElem(nt, tie, lev + 1)
+        if (
+            s.midprg != ["", "", "", ""] or midi
+        ) and n.name != "rest":  # only add when %%midi was present or percussion
+            instId = "I%s-%s" % (s.pid, "X" + midi if midi else s.vid)
+            chan, midi = ("10", midi) if midi else s.midprg[:2]
+            inst = E.Element("instrument", id=instId)  # instrument id for midi
+            addElem(nt, inst, lev + 1)
+            if instId not in s.midiInst:
+                s.midiInst[instId] = (
+                    s.pid,
+                    s.vid,
+                    chan,
+                    midi,
+                    s.midprg[2],
+                    s.midprg[3],
+                )  # for instrument list in mkScorePart
+        addElemT(nt, "voice", "1", lev + 1)  # default voice, for merging later
+        if noMsrRest:
+            addElemT(
+                nt, "type", xmltype, lev + 1
+            )  # add note type if not a measure rest
+        for i in range(ndot):  # add dots
+            dot = E.Element("dot")
+            addElem(nt, dot, lev + 1)
+        decos = s.getNoteDecos(n)  # get decorations for this note
+        if acc and not tstop:  # only add accidental if note not tied
+            e = E.Element("accidental")
+            if "courtesy" in decos:
+                e.set("parentheses", "yes")
+                decos.remove("courtesy")
+            e.text = s.accTab[acc]
+            addElem(nt, e, lev + 1)
+        tupnotation = ""  # start/stop notation element for tuplets
+        if s.ntup >= 0:  # add time modification element for tuplet notes
+            tmod = mkTmod(s.tmnum, s.tmden, lev + 1)
+            addElem(nt, tmod, lev + 1)
+            if s.ntup > 0 and not s.tupnts:
+                tupnotation = "start"
+            s.tupnts.append(
+                (rdvs, tmod)
+            )  # remember all tuplet modifiers with corresp. durations
+            if s.ntup == 0:  # last tuplet note (and possible chord notes there after)
+                if rdvs:
+                    tupnotation = (
+                        "stop"  # only insert notation in the real note (rdvs > 0)
+                    )
+                s.cmpNormType(
+                    rdvs, lev + 1
+                )  # compute and/or add normal-type elements (-> s.ntype)
         hasStem = 1
-        if not ischord: s.chordDecos = {}       # clear on non chord note
-        if 'stemless' in decos or (s.nostems and n.name != 'rest') or 'stemless' in s.chordDecos:
+        if not ischord:
+            s.chordDecos = {}  # clear on non chord note
+        if (
+            "stemless" in decos
+            or (s.nostems and n.name != "rest")
+            or "stemless" in s.chordDecos
+        ):
             hasStem = 0
-            addElemT (nt, 'stem', 'none', lev + 1)
-            if 'stemless' in decos: decos.remove ('stemless')   # do not handle in doNotations
-            if hasattr (n, 'pitches'): s.chordDecos ['stemless'] = 1    # set on first chord note
+            addElemT(nt, "stem", "none", lev + 1)
+            if "stemless" in decos:
+                decos.remove("stemless")  # do not handle in doNotations
+            if hasattr(n, "pitches"):
+                s.chordDecos["stemless"] = 1  # set on first chord note
         if notehead:
-            nh = addElemT (nt, 'notehead', re.sub (r'[+-]$', '', notehead), lev + 1)
-            if notehead[-1] in '+-': nh.set ('filled', 'yes' if notehead[-1] == '+' else 'no')
-        gstaff = s.gStaffNums.get (s.vid, 0)    # staff number of the current voice
-        if gstaff: addElemT (nt, 'staff', str (gstaff), lev + 1)
-        if hasStem: s.doBeams (n, nt, den, lev + 1)   # no stems -> no beams in a tab staff
-        s.doNotations (n, decos, ptup, alter, tupnotation, tstop, nt, lev + 1)
-        if n.objs: s.doLyr (n, nt, lev + 1)
-        else: s.prevLyric = {}   # clear on note without lyrics
+            nh = addElemT(nt, "notehead", re.sub(r"[+-]$", "", notehead), lev + 1)
+            if notehead[-1] in "+-":
+                nh.set("filled", "yes" if notehead[-1] == "+" else "no")
+        gstaff = s.gStaffNums.get(s.vid, 0)  # staff number of the current voice
+        if gstaff:
+            addElemT(nt, "staff", str(gstaff), lev + 1)
+        if hasStem:
+            s.doBeams(n, nt, den, lev + 1)  # no stems -> no beams in a tab staff
+        s.doNotations(n, decos, ptup, alter, tupnotation, tstop, nt, lev + 1)
+        if n.objs:
+            s.doLyr(n, nt, lev + 1)
+        else:
+            s.prevLyric = {}  # clear on note without lyrics
         return nt
 
-    def cmpNormType (s, rdvs, lev): # compute the normal-type of a tuplet (only needed for Finale)
-        if rdvs:    # the last real tuplet note (chord notes can still follow afterwards with rdvs == 0)
+    def cmpNormType(
+        s, rdvs, lev
+    ):  # compute the normal-type of a tuplet (only needed for Finale)
+        if (
+            rdvs
+        ):  # the last real tuplet note (chord notes can still follow afterwards with rdvs == 0)
             durs = [dur for dur, tmod in s.tupnts if dur > 0]
-            ndur = sum (durs) // s.tmnum    # duration of the normal type
-            s.irrtup = any ((dur != ndur) for dur in durs)  # irregular tuplet
+            ndur = sum(durs) // s.tmnum  # duration of the normal type
+            s.irrtup = any((dur != ndur) for dur in durs)  # irregular tuplet
             tix = 16 * s.divisions // ndur  # index in typeMap of normal-type duration
             if tix in s.typeMap:
-                s.ntype = str (s.typeMap [tix]) # the normal-type
-            else: s.irrtup = 0          # give up, no normal type possible
-        if s.irrtup:                    # only add normal-type for irregular tuplets
+                s.ntype = str(s.typeMap[tix])  # the normal-type
+            else:
+                s.irrtup = 0  # give up, no normal type possible
+        if s.irrtup:  # only add normal-type for irregular tuplets
             for dur, tmod in s.tupnts:  # add normal-type to all modifiers
-                addElemT (tmod, 'normal-type', s.ntype, lev + 1)
-        s.tupnts = []                   # reset the tuplet buffer
+                addElemT(tmod, "normal-type", s.ntype, lev + 1)
+        s.tupnts = []  # reset the tuplet buffer
 
-    def doNotations (s, n, decos, ptup, alter, tupnotation, tstop, nt, lev):
-        slurs = getattr (n, 'slurs', 0) # slur ends
-        pts = getattr (n, 'pitches', [])            # all chord notes available in the first note
-        ov = s.overlayVnum                          # current overlay voice number (0 for the main voice)
-        if pts:                                     # make list of pitches in chord: [(pitch, octave), ..]
-            if type (pts.pitch) == pObj: pts = [pts.pitch]      # chord with one note
-            else: pts = [tuple (p.t[-2:]) for p in pts.pitch]   # normal chord
-        for pt, (tie_alter, nts, vnum, ntelm) in sorted (list (s.ties.items ())):  # scan all open ties and delete illegal ones
-            if vnum != s.overlayVnum: continue      # tie belongs to different overlay
-            if pts and pt in pts: continue          # pitch tuple of tie exists in chord
-            if getattr (n, 'chord', 0): continue    # skip chord notes
-            if pt == ptup: continue                 # skip correct single note tie
-            if getattr (n, 'grace', 0): continue    # skip grace notes
-            info ('tie between different pitches: %s%s converted to slur' % pt)
-            del s.ties [pt]                         # remove the note from pending ties
-            e = [t for t in ntelm.findall ('tie') if t.get ('type') == 'start'][0]  # get the tie start element
-            ntelm.remove (e)                        # delete start tie element
-            e = [t for t in nts.findall ('tied') if t.get ('type') == 'start'][0]   # get the tied start element
-            e.tag = 'slur'                          # convert tie into slur
-            slurnum = pushSlur (s.slurstack, ov)
-            e.set ('number', str (slurnum))
-            if slurs: slurs.t.append (')')          # close slur on this note
-            else: slurs = pObj ('slurs', [')'])
-        tstart = getattr (n, 'tie', 0)  # start a new tie
-        if not (tstop or tstart or decos or slurs or s.slurbeg or tupnotation or s.trem): return nt
-        nots = E.Element ('notations')  # notation element needed
+    def doNotations(s, n, decos, ptup, alter, tupnotation, tstop, nt, lev):
+        slurs = getattr(n, "slurs", 0)  # slur ends
+        pts = getattr(n, "pitches", [])  # all chord notes available in the first note
+        ov = s.overlayVnum  # current overlay voice number (0 for the main voice)
+        if pts:  # make list of pitches in chord: [(pitch, octave), ..]
+            if type(pts.pitch) == pObj:
+                pts = [pts.pitch]  # chord with one note
+            else:
+                pts = [tuple(p.t[-2:]) for p in pts.pitch]  # normal chord
+        for pt, (tie_alter, nts, vnum, ntelm) in sorted(
+            list(s.ties.items())
+        ):  # scan all open ties and delete illegal ones
+            if vnum != s.overlayVnum:
+                continue  # tie belongs to different overlay
+            if pts and pt in pts:
+                continue  # pitch tuple of tie exists in chord
+            if getattr(n, "chord", 0):
+                continue  # skip chord notes
+            if pt == ptup:
+                continue  # skip correct single note tie
+            if getattr(n, "grace", 0):
+                continue  # skip grace notes
+            info("tie between different pitches: %s%s converted to slur" % pt)
+            del s.ties[pt]  # remove the note from pending ties
+            e = [t for t in ntelm.findall("tie") if t.get("type") == "start"][
+                0
+            ]  # get the tie start element
+            ntelm.remove(e)  # delete start tie element
+            e = [t for t in nts.findall("tied") if t.get("type") == "start"][
+                0
+            ]  # get the tied start element
+            e.tag = "slur"  # convert tie into slur
+            slurnum = pushSlur(s.slurstack, ov)
+            e.set("number", str(slurnum))
+            if slurs:
+                slurs.t.append(")")  # close slur on this note
+            else:
+                slurs = pObj("slurs", [")"])
+        tstart = getattr(n, "tie", 0)  # start a new tie
+        if not (
+            tstop or tstart or decos or slurs or s.slurbeg or tupnotation or s.trem
+        ):
+            return nt
+        nots = E.Element("notations")  # notation element needed
         if s.trem:  # +/- => tuple tremolo sequence / single note tremolo
-            if s.trem < 0: tupnotation = 'single'; s.trem = -s.trem
-            if not tupnotation: return  # only add notation at first or last note of a tremolo sequence
-            orn = E.Element ('ornaments')
-            trm = E.Element ('tremolo', type=tupnotation)   # type = start, stop or single
-            trm.text = str (s.trem)     # the number of bars in a tremolo note
-            addElem (nots, orn, lev + 1)
-            addElem (orn, trm, lev + 2)
-            if tupnotation == 'stop' or tupnotation == 'single': s.trem = 0
-        elif tupnotation:       # add tuplet type
-            tup = E.Element ('tuplet', type=tupnotation)
-            if tupnotation == 'start': tup.set ('bracket', 'yes')
-            addElem (nots, tup, lev + 1)
-        if tstop:               # stop tie
-            del s.ties[ptup]    # remove flag
-            tie = E.Element ('tied', type='stop')
-            addElem (nots, tie, lev + 1)
-        if tstart:              # start a tie
-            s.ties[ptup] = (alter, nots, s.overlayVnum, nt) # remember pitch tuple to stop tie and apply same alteration
-            tie = E.Element ('tied', type='start')
-            if tstart.t[0] == '.-': tie.set ('line-type', 'dotted')
-            addElem (nots, tie, lev + 1)
-        if decos:               # look for slurs and decorations
-            slurMap = { '(':1, '.(':1, '(,':1, "('":1, '.(,':1, ".('":1 }
-            arts = []           # collect articulations
-            for d in decos:     # do all slurs and decos
-                if d in slurMap: s.slurbeg.append (d); continue # slurs made in while loop at the end
-                elif d == 'fermata' or d == 'H':
-                    ntn = E.Element ('fermata', type='upright')
-                elif d == 'arpeggio':
-                    ntn = E.Element ('arpeggiate', number='1')
-                elif d in ['~(', '~)']:
-                    if d[1] == '(': tp = 'start'; s.glisnum += 1; gn = s.glisnum
-                    else:           tp = 'stop'; gn = s.glisnum; s.glisnum -= 1
-                    if s.glisnum < 0: s.glisnum = 0; continue   # stop without previous start
-                    ntn = E.Element ('glissando', {'line-type':'wavy', 'number':'%d' % gn, 'type':tp})
-                elif d in ['-(', '-)']:
-                    if d[1] == '(': tp = 'start'; s.slidenum += 1; gn = s.slidenum
-                    else:           tp = 'stop'; gn = s.slidenum; s.slidenum -= 1
-                    if s.slidenum < 0: s.slidenum = 0; continue   # stop without previous start
-                    ntn = E.Element ('slide', {'line-type':'solid', 'number':'%d' % gn, 'type':tp})
-                else: arts.append (d); continue
-                addElem (nots, ntn, lev + 1)
-            if arts:        # do only note articulations and collect staff annotations in xmldecos
-                rest = s.doArticulations (nt, nots, arts, lev + 1)
-                if rest: info ('unhandled note decorations: %s' % rest)
-        if slurs:           # these are only slur endings
-            for d in slurs.t:           # slurs to be closed on this note
-                if not s.slurstack.get (ov, 0): break    # no more open old slurs for this (overlay) voice
-                slurnum = s.slurstack [ov].pop ()
-                slur = E.Element ('slur', number='%d' % slurnum, type='stop')
-                addElem (nots, slur, lev + 1)
-        while s.slurbeg:    # create slurs beginning on this note
-            stp = s.slurbeg.pop (0)
-            slurnum = pushSlur (s.slurstack, ov)
-            ntn = E.Element ('slur', number='%d' % slurnum, type='start')
-            if '.' in stp: ntn.set ('line-type', 'dotted')
-            if ',' in stp: ntn.set ('placement', 'below')
-            if "'" in stp: ntn.set ('placement', 'above')
-            addElem (nots, ntn, lev + 1)            
-        if list (nots) != []:    # only add notations if not empty
-            addElem (nt, nots, lev)
+            if s.trem < 0:
+                tupnotation = "single"
+                s.trem = -s.trem
+            if not tupnotation:
+                return  # only add notation at first or last note of a tremolo sequence
+            orn = E.Element("ornaments")
+            trm = E.Element("tremolo", type=tupnotation)  # type = start, stop or single
+            trm.text = str(s.trem)  # the number of bars in a tremolo note
+            addElem(nots, orn, lev + 1)
+            addElem(orn, trm, lev + 2)
+            if tupnotation == "stop" or tupnotation == "single":
+                s.trem = 0
+        elif tupnotation:  # add tuplet type
+            tup = E.Element("tuplet", type=tupnotation)
+            if tupnotation == "start":
+                tup.set("bracket", "yes")
+            addElem(nots, tup, lev + 1)
+        if tstop:  # stop tie
+            del s.ties[ptup]  # remove flag
+            tie = E.Element("tied", type="stop")
+            addElem(nots, tie, lev + 1)
+        if tstart:  # start a tie
+            s.ties[ptup] = (
+                alter,
+                nots,
+                s.overlayVnum,
+                nt,
+            )  # remember pitch tuple to stop tie and apply same alteration
+            tie = E.Element("tied", type="start")
+            if tstart.t[0] == ".-":
+                tie.set("line-type", "dotted")
+            addElem(nots, tie, lev + 1)
+        if decos:  # look for slurs and decorations
+            slurMap = {"(": 1, ".(": 1, "(,": 1, "('": 1, ".(,": 1, ".('": 1}
+            arts = []  # collect articulations
+            for d in decos:  # do all slurs and decos
+                if d in slurMap:
+                    s.slurbeg.append(d)
+                    continue  # slurs made in while loop at the end
+                elif d == "fermata" or d == "H":
+                    ntn = E.Element("fermata", type="upright")
+                elif d == "arpeggio":
+                    ntn = E.Element("arpeggiate", number="1")
+                elif d in ["~(", "~)"]:
+                    if d[1] == "(":
+                        tp = "start"
+                        s.glisnum += 1
+                        gn = s.glisnum
+                    else:
+                        tp = "stop"
+                        gn = s.glisnum
+                        s.glisnum -= 1
+                    if s.glisnum < 0:
+                        s.glisnum = 0
+                        continue  # stop without previous start
+                    ntn = E.Element(
+                        "glissando",
+                        {"line-type": "wavy", "number": "%d" % gn, "type": tp},
+                    )
+                elif d in ["-(", "-)"]:
+                    if d[1] == "(":
+                        tp = "start"
+                        s.slidenum += 1
+                        gn = s.slidenum
+                    else:
+                        tp = "stop"
+                        gn = s.slidenum
+                        s.slidenum -= 1
+                    if s.slidenum < 0:
+                        s.slidenum = 0
+                        continue  # stop without previous start
+                    ntn = E.Element(
+                        "slide", {"line-type": "solid", "number": "%d" % gn, "type": tp}
+                    )
+                else:
+                    arts.append(d)
+                    continue
+                addElem(nots, ntn, lev + 1)
+            if (
+                arts
+            ):  # do only note articulations and collect staff annotations in xmldecos
+                rest = s.doArticulations(nt, nots, arts, lev + 1)
+                if rest:
+                    info("unhandled note decorations: %s" % rest)
+        if slurs:  # these are only slur endings
+            for d in slurs.t:  # slurs to be closed on this note
+                if not s.slurstack.get(ov, 0):
+                    break  # no more open old slurs for this (overlay) voice
+                slurnum = s.slurstack[ov].pop()
+                slur = E.Element("slur", number="%d" % slurnum, type="stop")
+                addElem(nots, slur, lev + 1)
+        while s.slurbeg:  # create slurs beginning on this note
+            stp = s.slurbeg.pop(0)
+            slurnum = pushSlur(s.slurstack, ov)
+            ntn = E.Element("slur", number="%d" % slurnum, type="start")
+            if "." in stp:
+                ntn.set("line-type", "dotted")
+            if "," in stp:
+                ntn.set("placement", "below")
+            if "'" in stp:
+                ntn.set("placement", "above")
+            addElem(nots, ntn, lev + 1)
+        if list(nots) != []:  # only add notations if not empty
+            addElem(nt, nots, lev)
 
-    def doArticulations (s, nt, nots, arts, lev):
+    def doArticulations(s, nt, nots, arts, lev):
         decos = []
         for a in arts:
             if a in s.artMap:
-                art = E.Element ('articulations')
-                addElem (nots, art, lev)
-                addElem (art, E.Element (s.artMap[a]), lev + 1)
+                art = E.Element("articulations")
+                addElem(nots, art, lev)
+                addElem(art, E.Element(s.artMap[a]), lev + 1)
             elif a in s.ornMap:
-                orn = E.Element ('ornaments')
-                addElem (nots, orn, lev)
-                addElem (orn, E.Element (s.ornMap[a]), lev + 1)
-            elif a in ['trill(','trill)']:
-                orn = E.Element ('ornaments')
-                addElem (nots, orn, lev)
-                type = 'start' if a.endswith ('(') else 'stop'
-                if type == 'start': addElem (orn, E.Element ('trill-mark'), lev + 1)                
-                addElem (orn, E.Element ('wavy-line', type=type), lev + 1)                
+                orn = E.Element("ornaments")
+                addElem(nots, orn, lev)
+                addElem(orn, E.Element(s.ornMap[a]), lev + 1)
+            elif a in ["trill(", "trill)"]:
+                orn = E.Element("ornaments")
+                addElem(nots, orn, lev)
+                type = "start" if a.endswith("(") else "stop"
+                if type == "start":
+                    addElem(orn, E.Element("trill-mark"), lev + 1)
+                addElem(orn, E.Element("wavy-line", type=type), lev + 1)
             elif a in s.tecMap:
-                tec = E.Element ('technical')
-                addElem (nots, tec, lev)
-                addElem (tec, E.Element (s.tecMap[a]), lev + 1)
-            elif a in '0123456':
-                tec = E.Element ('technical')
-                addElem (nots, tec, lev)
-                if s.tabStaff == s.pid:             # current voice belongs to a tabStaff
-                    alt = int (nt.findtext ('pitch/alter') or 0)    # find midi number of current note
-                    step = nt.findtext ('pitch/step')
-                    oct = int (nt.findtext ('pitch/octave'))
-                    midi = oct * 12 + [0,2,4,5,7,9,11]['CDEFGAB'.index (step)] + alt + 12
-                    if a == '0':                    # no string annotation: find one
-                        firstFit = ''
-                        for smid, istr in s.tunTup: # midi numbers of open strings from high to low
-                            if midi >= smid:        # highest open string where this note can be played
-                                isvrij = s.strAlloc.isVrij (istr - 1, s.gTime [0], s.gTime [1])
-                                a = str (istr)      # string number
-                                if not firstFit: firstFit = a
-                                if isvrij: break
-                        if not isvrij:              # no free string, take the first fit (lowest fret)
+                tec = E.Element("technical")
+                addElem(nots, tec, lev)
+                addElem(tec, E.Element(s.tecMap[a]), lev + 1)
+            elif a in "0123456":
+                tec = E.Element("technical")
+                addElem(nots, tec, lev)
+                if s.tabStaff == s.pid:  # current voice belongs to a tabStaff
+                    alt = int(
+                        nt.findtext("pitch/alter") or 0
+                    )  # find midi number of current note
+                    step = nt.findtext("pitch/step")
+                    oct = int(nt.findtext("pitch/octave"))
+                    midi = (
+                        oct * 12
+                        + [0, 2, 4, 5, 7, 9, 11]["CDEFGAB".index(step)]
+                        + alt
+                        + 12
+                    )
+                    if a == "0":  # no string annotation: find one
+                        firstFit = ""
+                        for (
+                            smid,
+                            istr,
+                        ) in s.tunTup:  # midi numbers of open strings from high to low
+                            if (
+                                midi >= smid
+                            ):  # highest open string where this note can be played
+                                isvrij = s.strAlloc.isVrij(
+                                    istr - 1, s.gTime[0], s.gTime[1]
+                                )
+                                a = str(istr)  # string number
+                                if not firstFit:
+                                    firstFit = a
+                                if isvrij:
+                                    break
+                        if (
+                            not isvrij
+                        ):  # no free string, take the first fit (lowest fret)
                             a = firstFit
-                            s.strAlloc.bezet (int (a) - 1, s.gTime [0], s.gTime [1])
-                    else:                           # force annotated string number 
-                        s.strAlloc.bezet (int (a) - 1, s.gTime [0], s.gTime [1])
-                    bmidi = s.tunmid [int (a) - 1]  # midi number of allocated string (with capodastro)
-                    fret =  midi - bmidi            # fret position (respecting capodastro)
+                            s.strAlloc.bezet(int(a) - 1, s.gTime[0], s.gTime[1])
+                    else:  # force annotated string number
+                        s.strAlloc.bezet(int(a) - 1, s.gTime[0], s.gTime[1])
+                    bmidi = s.tunmid[
+                        int(a) - 1
+                    ]  # midi number of allocated string (with capodastro)
+                    fret = midi - bmidi  # fret position (respecting capodastro)
                     if fret < 25 and fret >= 0:
-                        addElemT (tec, 'fret', str (fret), lev + 1)
+                        addElemT(tec, "fret", str(fret), lev + 1)
                     else:
-                        altp = 'b' if alt == -1 else '#' if alt == 1 else ''
-                        info ('fret %d out of range, note %s%d on string %s' % (fret, step+altp, oct, a))
-                    addElemT (tec, 'string', a, lev + 1)
+                        altp = "b" if alt == -1 else "#" if alt == 1 else ""
+                        info(
+                            "fret %d out of range, note %s%d on string %s"
+                            % (fret, step + altp, oct, a)
+                        )
+                    addElemT(tec, "string", a, lev + 1)
                 else:
-                    addElemT (tec, 'fingering', a, lev + 1)
-            else: decos.append (a)  # return staff annotations
+                    addElemT(tec, "fingering", a, lev + 1)
+            else:
+                decos.append(a)  # return staff annotations
         return decos
 
-    def doLyr (s, n, nt, lev):
-        for i, lyrobj in enumerate (n.objs):
-            lyrel = E.Element ('lyric', number = str (i + 1))
-            if lyrobj.name == 'syl':
-                dash = len (lyrobj.t) == 2
+    def doLyr(s, n, nt, lev):
+        for i, lyrobj in enumerate(n.objs):
+            lyrel = E.Element("lyric", number=str(i + 1))
+            if lyrobj.name == "syl":
+                dash = len(lyrobj.t) == 2
                 if dash:
-                    if i in s.lyrdash:  type = 'middle'
-                    else:               type = 'begin'; s.lyrdash [i] = 1
+                    if i in s.lyrdash:
+                        type = "middle"
+                    else:
+                        type = "begin"
+                        s.lyrdash[i] = 1
                 else:
-                    if i in s.lyrdash:  type = 'end';   del s.lyrdash [i]
-                    else:               type = 'single'
-                addElemT (lyrel, 'syllabic', type, lev + 1)
-                txt = lyrobj.t[0]                       # the syllabe
-                txt = re.sub (r'(?<!\\)~', ' ', txt)    # replace ~ by space when not escaped (preceded by \)
-                txt = re.sub (r'\\(.)', r'\1', txt)     # replace all escaped characters by themselves (for the time being)
-                addElemT (lyrel, 'text', txt, lev + 1)
-            elif lyrobj.name == 'ext' and i in s.prevLyric:
-                pext = s.prevLyric [i].find ('extend')  # identify previous extend
+                    if i in s.lyrdash:
+                        type = "end"
+                        del s.lyrdash[i]
+                    else:
+                        type = "single"
+                addElemT(lyrel, "syllabic", type, lev + 1)
+                txt = lyrobj.t[0]  # the syllabe
+                txt = re.sub(
+                    r"(?<!\\)~", " ", txt
+                )  # replace ~ by space when not escaped (preceded by \)
+                txt = re.sub(
+                    r"\\(.)", r"\1", txt
+                )  # replace all escaped characters by themselves (for the time being)
+                addElemT(lyrel, "text", txt, lev + 1)
+            elif lyrobj.name == "ext" and i in s.prevLyric:
+                pext = s.prevLyric[i].find("extend")  # identify previous extend
                 if pext == None:
-                    ext = E.Element ('extend', type = 'start')
-                    addElem (s.prevLyric [i], ext, lev + 1)
-                elif pext.get('type') == 'stop':        # subsequent extend: stop -> continue
-                    pext.set ('type', 'continue')
-                ext = E.Element ('extend', type = 'stop')   # always stop on current extend
-                addElem (lyrel, ext, lev + 1)
-            elif lyrobj.name == 'ext': info ('lyric extend error'); continue
-            else: continue          # skip other lyric elements or errors
-            addElem (nt, lyrel, lev)
-            s.prevLyric [i] = lyrel # for extension (melisma) on the next note
+                    ext = E.Element("extend", type="start")
+                    addElem(s.prevLyric[i], ext, lev + 1)
+                elif pext.get("type") == "stop":  # subsequent extend: stop -> continue
+                    pext.set("type", "continue")
+                ext = E.Element("extend", type="stop")  # always stop on current extend
+                addElem(lyrel, ext, lev + 1)
+            elif lyrobj.name == "ext":
+                info("lyric extend error")
+                continue
+            else:
+                continue  # skip other lyric elements or errors
+            addElem(nt, lyrel, lev)
+            s.prevLyric[i] = lyrel  # for extension (melisma) on the next note
 
-    def doBeams (s, n, nt, den, lev):
-        if hasattr (n, 'chord') or hasattr (n, 'grace'):
-            s.grcbbrk = s.grcbbrk or n.bbrk.t[0]    # remember if there was any bbrk in or before a grace sequence
+    def doBeams(s, n, nt, den, lev):
+        if hasattr(n, "chord") or hasattr(n, "grace"):
+            s.grcbbrk = (
+                s.grcbbrk or n.bbrk.t[0]
+            )  # remember if there was any bbrk in or before a grace sequence
             return
         bbrk = s.grcbbrk or n.bbrk.t[0] or den < 32
         s.grcbbrk = False
-        if not s.prevNote:  pbm = None
-        else:               pbm = s.prevNote.find ('beam')
-        bm = E.Element ('beam', number='1')
-        bm.text = 'begin'
+        if not s.prevNote:
+            pbm = None
+        else:
+            pbm = s.prevNote.find("beam")
+        bm = E.Element("beam", number="1")
+        bm.text = "begin"
         if pbm != None:
             if bbrk:
-                if pbm.text == 'begin':
-                    s.prevNote.remove (pbm)
-                elif pbm.text == 'continue':
-                    pbm.text = 'end'
+                if pbm.text == "begin":
+                    s.prevNote.remove(pbm)
+                elif pbm.text == "continue":
+                    pbm.text = "end"
                 s.prevNote = None
-            else: bm.text = 'continue'
-        if den >= 32 and n.name != 'rest':
-            addElem (nt, bm, lev)
+            else:
+                bm.text = "continue"
+        if den >= 32 and n.name != "rest":
+            addElem(nt, bm, lev)
             s.prevNote = nt
 
-    def stopBeams (s):
-        if not s.prevNote: return
-        pbm = s.prevNote.find ('beam')
+    def stopBeams(s):
+        if not s.prevNote:
+            return
+        pbm = s.prevNote.find("beam")
         if pbm != None:
-            if pbm.text == 'begin':
-                s.prevNote.remove (pbm)
-            elif pbm.text == 'continue':
-                pbm.text = 'end'
+            if pbm.text == "begin":
+                s.prevNote.remove(pbm)
+            elif pbm.text == "continue":
+                pbm.text = "end"
         s.prevNote = None
 
-    def staffDecos (s, decos, maat, lev):
-        gstaff = s.gStaffNums.get (s.vid, 0)        # staff number of the current voice        
+    def staffDecos(s, decos, maat, lev):
+        gstaff = s.gStaffNums.get(s.vid, 0)  # staff number of the current voice
         for d in decos:
-            d = s.usrSyms.get (d, d).strip ('!+')   # try to replace user defined symbol
+            d = s.usrSyms.get(d, d).strip("!+")  # try to replace user defined symbol
             if d in s.dynaMap:
-                dynel = E.Element ('dynamics')
-                addDirection (maat, dynel, lev, gstaff, [E.Element (d)], 'below', s.gcue_on)
+                dynel = E.Element("dynamics")
+                addDirection(
+                    maat, dynel, lev, gstaff, [E.Element(d)], "below", s.gcue_on
+                )
             elif d in s.wedgeMap:  # wedge
-                if ')' in d: type = 'stop'
-                else: type = 'crescendo' if '<' in d or 'crescendo' in d else 'diminuendo'
-                addDirection (maat, E.Element ('wedge', type=type), lev, gstaff)
-            elif d.startswith ('8v'):
-                if 'a' in d: type, plce = 'down', 'above'
-                else:        type, plce = 'up', 'below'
-                if ')' in d: type = 'stop'
-                addDirection (maat, E.Element ('octave-shift', type=type, size='8'), lev, gstaff, placement=plce)
-            elif d in (['ped','ped-up']):
-                type = 'stop' if d.endswith ('up') else 'start'
-                addDirection (maat, E.Element ('pedal', type=type), lev, gstaff)
-            elif d in ['coda', 'segno']:
-                text, attr, val = s.capoMap [d]
-                dir = addDirection (maat, E.Element (text), lev, gstaff, placement='above')
-                sound = E.Element ('sound'); sound.set (attr, val)
-                addElem (dir, sound, lev + 1)
+                if ")" in d:
+                    type = "stop"
+                else:
+                    type = "crescendo" if "<" in d or "crescendo" in d else "diminuendo"
+                addDirection(maat, E.Element("wedge", type=type), lev, gstaff)
+            elif d.startswith("8v"):
+                if "a" in d:
+                    type, plce = "down", "above"
+                else:
+                    type, plce = "up", "below"
+                if ")" in d:
+                    type = "stop"
+                addDirection(
+                    maat,
+                    E.Element("octave-shift", type=type, size="8"),
+                    lev,
+                    gstaff,
+                    placement=plce,
+                )
+            elif d in (["ped", "ped-up"]):
+                type = "stop" if d.endswith("up") else "start"
+                addDirection(maat, E.Element("pedal", type=type), lev, gstaff)
+            elif d in ["coda", "segno"]:
+                text, attr, val = s.capoMap[d]
+                dir = addDirection(
+                    maat, E.Element(text), lev, gstaff, placement="above"
+                )
+                sound = E.Element("sound")
+                sound.set(attr, val)
+                addElem(dir, sound, lev + 1)
             elif d in s.capoMap:
-                text, attr, val = s.capoMap [d]
-                words = E.Element ('words'); words.text = text
-                dir = addDirection (maat, words, lev, gstaff, placement='above')
-                sound = E.Element ('sound'); sound.set (attr, val)
-                addElem (dir, sound, lev + 1)
-            elif d == '(' or d == '.(': s.slurbeg.append (d)   # start slur on next note
-            elif d in ['/-','//-','///-','////-']:  # duplet tremolo sequence
-                s.tmnum, s.tmden, s.ntup, s.trem, s.intrem = 2, 1, 2, len (d) - 1, 1
-            elif d in ['/','//','///']: s.trem = - len (d)  # single note tremolo
-            elif d == 'rbstop': s.rbStop = 1;   # sluit een open volta aan het eind van de maat
-            else: s.nextdecos.append (d)    # keep annotation for the next note
-
-    def doFields (s, maat, fieldmap, lev):
-        def instDir (midelm, midnum, dirtxt):
-            instId = 'I%s-%s' % (s.pid, s.vid)
-            words = E.Element ('words'); words.text = dirtxt % midnum
-            snd = E.Element ('sound')
-            mi = E.Element ('midi-instrument', id=instId)
-            dir = addDirection (maat, words, lev, gstaff, placement='above')
-            addElem (dir, snd, lev + 1)
-            addElem (snd, mi, lev + 2)
-            addElemT (mi, midelm, midnum, lev + 3)
-        def addTrans (n):
-            e = E.Element ('transpose')
-            addElemT (e, 'chromatic', n, lev + 2)  # n == signed number string given after transpose
-            atts.append ((9, e))
-        def doClef (field):
-            if re.search (r'perc|map', field):  # percussion clef or new style perc=on or map=perc
-                r = re.search (r'(perc|map)\s*=\s*(\S*)', field)
-                s.percVoice = 0 if r and r.group (2) not in ['on','true','perc'] else 1
-                field = re.sub (r'(perc|map)\s*=\s*(\S*)', '', field)   # erase the perc= for proper clef matching
-            clef, gtrans = 0, 0
-            clefn = re.search (r'alto1|alto2|alto4|alto|tenor|bass3|bass|treble|perc|none|tab', field)
-            clefm = re.search (r"(?:^m=| m=|middle=)([A-Ga-g])([,']*)", field)
-            trans_oct2 = re.search (r'octave=([-+]?\d)', field)
-            trans = re.search (r'(?:^t=| t=|transpose=)(-?[\d]+)', field)
-            trans_oct = re.search (r'([+-^_])(8|15)', field)
-            cue_onoff = re.search (r'cue=(on|off)', field)
-            strings = re.search (r"strings=(\S+)", field)
-            stafflines = re.search (r'stafflines=\s*(\d)', field)
-            capo = re.search (r'capo=(\d+)', field)
-            if clefn:
-                clef = clefn.group ()
-            if clefm:
-                note, octstr = clefm.groups ()
-                nUp = note.upper ()
-                octnum = (4 if nUp == note else 5) + (len (octstr) if "'" in octstr else -len (octstr))
-                gtrans = (3 if nUp in 'AFD' else 4) - octnum 
-                if clef not in ['perc', 'none']: clef = s.clefLineMap [nUp]
-            if clef:
-                s.gtrans = gtrans   # only change global tranposition when a clef is really defined
-                if clef != 'none': s.curClef = clef       # keep track of current abc clef (for percmap)
-                sign, line = s.clefMap [clef]
-                if not sign: return
-                c = E.Element ('clef')
-                if gstaff: c.set ('number', str (gstaff))   # only add staff number when defined
-                addElemT (c, 'sign', sign, lev + 2)
-                if line: addElemT (c, 'line', line, lev + 2)
-                if trans_oct:
-                    n = trans_oct.group (1) in '-_' and -1 or 1
-                    if trans_oct.group (2) == '15': n *= 2  # 8 => 1 octave, 15 => 2 octaves
-                    addElemT (c, 'clef-octave-change', str (n), lev + 2) # transpose print out
-                    if trans_oct.group (1) in '+-': s.gtrans += n   # also transpose all pitches with one octave
-                atts.append ((7, c))
-            if trans_oct2:  # octave= can also be in a K: field
-                n = int (trans_oct2.group (1))
-                s.gtrans = gtrans + n
-            if trans != None:   # add transposition in semitones
-                e = E.Element ('transpose')
-                addElemT (e, 'chromatic', str (trans.group (1)), lev + 3)
-                atts.append ((9, e))
-            if cue_onoff: s.gcue_on = cue_onoff.group (1) == 'on'
-            nlines = 0
-            if clef == 'tab':
-                s.tabStaff = s.pid
-                if capo: s.capo = int (capo.group (1))
-                if strings: s.tuning = strings.group (1).split (',')
-                s.tunmid = [int (boct) * 12 + [0,2,4,5,7,9,11]['CDEFGAB'.index (bstep)] + 12 + s.capo for bstep, boct in s.tuning]
-                s.tunTup = sorted (zip (s.tunmid, range (len (s.tunmid), 0, -1)), reverse=1)
-                s.tunmid.reverse ()
-                nlines = str (len (s.tuning))
-                s.strAlloc.setlines (len (s.tuning), s.pid)
-                s.nostems = 'nostems' in field  # tab clef without stems
-                s.diafret = 'diafret' in field  # tab with diatonic fretting
-            if stafflines or nlines:
-                e = E.Element ('staff-details')
-                if gstaff: e.set ('number', str (gstaff))   # only add staff number when defined
-                if not nlines: nlines = stafflines.group (1)
-                addElemT (e, 'staff-lines', nlines, lev + 2)
-                if clef == 'tab':
-                    for line, t in enumerate (s.tuning):
-                        st = E.Element ('staff-tuning', line=str(line+1))
-                        addElemT (st, 'tuning-step', t[0], lev + 3)
-                        addElemT (st, 'tuning-octave', t[1], lev + 3)
-                        addElem (e, st, lev + 2)
-                if s.capo: addElemT (e, 'capo', str (s.capo), lev + 2)
-                atts.append ((8, e))
-        s.diafret = 0           # chromatic fretting is default
-        atts = []               # collect xml attribute elements [(order-number, xml-element), ..]
-        gstaff = s.gStaffNums.get (s.vid, 0)    # staff number of the current voice
-        for ftype, field in fieldmap.items ():
-            if not field:       # skip empty fields
-                continue
-            if ftype == 'Div':  # not an abc field, but handled as if
-                d = E.Element ('divisions')
-                d.text = field
-                atts.append ((1, d))
-            elif ftype == 'gstaff':  # make grand staff
-                e = E.Element ('staves')
-                e.text = str (field)
-                atts.append ((4, e))
-            elif ftype == 'M':
-                if field == 'none': continue
-                if field == 'C': field = '4/4'
-                elif field == 'C|': field = '2/2'
-                t = E.Element ('time')
-                if '/' not in field:
-                    info ('M:%s not recognized, 4/4 assumed' % field)
-                    field = '4/4'
-                beats, btype = field.split ('/')[:2]
-                try: s.mdur = simplify (eval (beats), int (btype))  # measure duration for Z and X rests (eval allows M:2+3/4)
-                except:
-                    info ('error in M:%s, 4/4 assumed' % field)
-                    s.mdur = (4,4)
-                    beats, btype = '4','4'
-                addElemT (t, 'beats', beats, lev + 2)
-                addElemT (t, 'beat-type', btype, lev + 2)
-                atts.append ((3, t))
-            elif ftype == 'K':
-                accs = ['F','C','G','D','A','E','B']    # == s.sharpness [7:14]
-                mode = ''
-                key = re.match (r'\s*([A-G][#b]?)\s*([a-zA-Z]*)', field)
-                alts = re.search (r'\s((\s?[=^_][A-Ga-g])+)', ' ' + field)  # avoid matching middle=G and m=G
-                if key:
-                    key, mode = key.groups ()
-                    mode = mode.lower ()[:3] # only first three chars, no case
-                    if mode not in s.offTab: mode = 'maj'
-                    fifths = s.sharpness.index (key) - s.offTab [mode]
-                    if fifths >= 0: s.keyAlts = dict (zip (accs[:fifths], fifths * ['1']))
-                    else:           s.keyAlts = dict (zip (accs[fifths:], -fifths * ['-1']))
-                elif field.startswith ('none') or field == '':  # the default key
-                    fifths = 0
-                    mode = 'maj'
-                if alts:
-                    alts = re.findall (r'[=^_][A-Ga-g]', alts.group(1)) # list of explicit alterations
-                    alts = [(x[1], s.alterTab [x[0]]) for x in alts]    # [step, alter]
-                    for step, alter in alts:                # correct permanent alterations for this key
-                        s.keyAlts [step.upper ()] = alter
-                    k = E.Element ('key')
-                    koctave = []
-                    lowerCaseSteps = [step.upper () for step, alter in alts if step.islower ()]
-                    for step, alter in sorted (list (s.keyAlts.items ())):
-                        if alter == '0':                    # skip neutrals
-                            del s.keyAlts [step.upper ()]   # otherwise you get neutral signs on normal notes
-                            continue
-                        addElemT (k, 'key-step', step.upper (), lev + 2)
-                        addElemT (k, 'key-alter', alter, lev + 2)
-                        koctave.append ('5' if step in lowerCaseSteps else '4')
-                    if koctave:                     # only key signature if not empty
-                        for oct in koctave:
-                            e = E.Element ('key-octave', number=oct)
-                            addElem (k, e, lev + 2)
-                        atts.append ((2, k))
-                elif mode:
-                    k = E.Element ('key')
-                    addElemT (k, 'fifths', str (fifths), lev + 2)
-                    addElemT (k, 'mode', s.modTab [mode], lev + 2)
-                    atts.append ((2, k))
-                doClef (field)
-            elif ftype == 'L':
-                try: s.unitLcur = lmap (int, field.split ('/'))
-                except: s.unitLcur = (1,8)
-                if len (s.unitLcur) == 1 or s.unitLcur[1] not in s.typeMap:
-                    info ('L:%s is not allowed, 1/8 assumed' % field)
-                    s.unitLcur = 1,8
-            elif ftype == 'V':
-                doClef (field)
-            elif ftype == 'I':
-                s.doField_I (ftype, field, instDir, addTrans)
-            elif ftype == 'Q':
-                s.doTempo (maat, field, lev)
-            elif ftype == 'P':  # ad hoc translation of P: into a staff text direction
-                words = E.Element ('rehearsal')
-                words.set ('font-weight', 'bold')
-                words.text = field
-                addDirection (maat, words, lev, gstaff, placement='above')
-            elif ftype in 'TCOAZNGHRBDFSU':
-                info ('**illegal header field in body: %s, content: %s' % (ftype, field))
+                text, attr, val = s.capoMap[d]
+                words = E.Element("words")
+                words.text = text
+                dir = addDirection(maat, words, lev, gstaff, placement="above")
+                sound = E.Element("sound")
+                sound.set(attr, val)
+                addElem(dir, sound, lev + 1)
+            elif d == "(" or d == ".(":
+                s.slurbeg.append(d)  # start slur on next note
+            elif d in ["/-", "//-", "///-", "////-"]:  # duplet tremolo sequence
+                s.tmnum, s.tmden, s.ntup, s.trem, s.intrem = 2, 1, 2, len(d) - 1, 1
+            elif d in ["/", "//", "///"]:
+                s.trem = -len(d)  # single note tremolo
+            elif d == "rbstop":
+                s.rbStop = 1  # sluit een open volta aan het eind van de maat
             else:
-                info ('unhandled field: %s, content: %s' % (ftype, field))
+                s.nextdecos.append(d)  # keep annotation for the next note
+
+    def doFields(s, maat, fieldmap, lev):
+        def instDir(midelm, midnum, dirtxt):
+            instId = "I%s-%s" % (s.pid, s.vid)
+            words = E.Element("words")
+            words.text = dirtxt % midnum
+            snd = E.Element("sound")
+            mi = E.Element("midi-instrument", id=instId)
+            dir = addDirection(maat, words, lev, gstaff, placement="above")
+            addElem(dir, snd, lev + 1)
+            addElem(snd, mi, lev + 2)
+            addElemT(mi, midelm, midnum, lev + 3)
+
+        def addTrans(n):
+            e = E.Element("transpose")
+            addElemT(
+                e, "chromatic", n, lev + 2
+            )  # n == signed number string given after transpose
+            atts.append((9, e))
+
+        def doClef(field):
+            if re.search(
+                r"perc|map", field
+            ):  # percussion clef or new style perc=on or map=perc
+                r = re.search(r"(perc|map)\s*=\s*(\S*)", field)
+                s.percVoice = 0 if r and r.group(2) not in ["on", "true", "perc"] else 1
+                field = re.sub(
+                    r"(perc|map)\s*=\s*(\S*)", "", field
+                )  # erase the perc= for proper clef matching
+            clef, gtrans = 0, 0
+            clefn = re.search(
+                r"alto1|alto2|alto4|alto|tenor|bass3|bass|treble|perc|none|tab", field
+            )
+            clefm = re.search(r"(?:^m=| m=|middle=)([A-Ga-g])([,']*)", field)
+            trans_oct2 = re.search(r"octave=([-+]?\d)", field)
+            trans = re.search(r"(?:^t=| t=|transpose=)(-?[\d]+)", field)
+            trans_oct = re.search(r"([+-^_])(8|15)", field)
+            cue_onoff = re.search(r"cue=(on|off)", field)
+            strings = re.search(r"strings=(\S+)", field)
+            stafflines = re.search(r"stafflines=\s*(\d)", field)
+            capo = re.search(r"capo=(\d+)", field)
+            if clefn:
+                clef = clefn.group()
+            if clefm:
+                note, octstr = clefm.groups()
+                nUp = note.upper()
+                octnum = (4 if nUp == note else 5) + (
+                    len(octstr) if "'" in octstr else -len(octstr)
+                )
+                gtrans = (3 if nUp in "AFD" else 4) - octnum
+                if clef not in ["perc", "none"]:
+                    clef = s.clefLineMap[nUp]
+            if clef:
+                s.gtrans = gtrans  # only change global tranposition when a clef is really defined
+                if clef != "none":
+                    s.curClef = clef  # keep track of current abc clef (for percmap)
+                sign, line = s.clefMap[clef]
+                if not sign:
+                    return
+                c = E.Element("clef")
+                if gstaff:
+                    c.set("number", str(gstaff))  # only add staff number when defined
+                addElemT(c, "sign", sign, lev + 2)
+                if line:
+                    addElemT(c, "line", line, lev + 2)
+                if trans_oct:
+                    n = trans_oct.group(1) in "-_" and -1 or 1
+                    if trans_oct.group(2) == "15":
+                        n *= 2  # 8 => 1 octave, 15 => 2 octaves
+                    addElemT(
+                        c, "clef-octave-change", str(n), lev + 2
+                    )  # transpose print out
+                    if trans_oct.group(1) in "+-":
+                        s.gtrans += n  # also transpose all pitches with one octave
+                atts.append((7, c))
+            if trans_oct2:  # octave= can also be in a K: field
+                n = int(trans_oct2.group(1))
+                s.gtrans = gtrans + n
+            if trans != None:  # add transposition in semitones
+                e = E.Element("transpose")
+                addElemT(e, "chromatic", str(trans.group(1)), lev + 3)
+                atts.append((9, e))
+            if cue_onoff:
+                s.gcue_on = cue_onoff.group(1) == "on"
+            nlines = 0
+            if clef == "tab":
+                s.tabStaff = s.pid
+                if capo:
+                    s.capo = int(capo.group(1))
+                if strings:
+                    s.tuning = strings.group(1).split(",")
+                s.tunmid = [
+                    int(boct) * 12
+                    + [0, 2, 4, 5, 7, 9, 11]["CDEFGAB".index(bstep)]
+                    + 12
+                    + s.capo
+                    for bstep, boct in s.tuning
+                ]
+                s.tunTup = sorted(zip(s.tunmid, range(len(s.tunmid), 0, -1)), reverse=1)
+                s.tunmid.reverse()
+                nlines = str(len(s.tuning))
+                s.strAlloc.setlines(len(s.tuning), s.pid)
+                s.nostems = "nostems" in field  # tab clef without stems
+                s.diafret = "diafret" in field  # tab with diatonic fretting
+            if stafflines or nlines:
+                e = E.Element("staff-details")
+                if gstaff:
+                    e.set("number", str(gstaff))  # only add staff number when defined
+                if not nlines:
+                    nlines = stafflines.group(1)
+                addElemT(e, "staff-lines", nlines, lev + 2)
+                if clef == "tab":
+                    for line, t in enumerate(s.tuning):
+                        st = E.Element("staff-tuning", line=str(line + 1))
+                        addElemT(st, "tuning-step", t[0], lev + 3)
+                        addElemT(st, "tuning-octave", t[1], lev + 3)
+                        addElem(e, st, lev + 2)
+                if s.capo:
+                    addElemT(e, "capo", str(s.capo), lev + 2)
+                atts.append((8, e))
+
+        s.diafret = 0  # chromatic fretting is default
+        atts = []  # collect xml attribute elements [(order-number, xml-element), ..]
+        gstaff = s.gStaffNums.get(s.vid, 0)  # staff number of the current voice
+        for ftype, field in fieldmap.items():
+            if not field:  # skip empty fields
+                continue
+            if ftype == "Div":  # not an abc field, but handled as if
+                d = E.Element("divisions")
+                d.text = field
+                atts.append((1, d))
+            elif ftype == "gstaff":  # make grand staff
+                e = E.Element("staves")
+                e.text = str(field)
+                atts.append((4, e))
+            elif ftype == "M":
+                if field == "none":
+                    continue
+                if field == "C":
+                    field = "4/4"
+                elif field == "C|":
+                    field = "2/2"
+                t = E.Element("time")
+                if "/" not in field:
+                    info("M:%s not recognized, 4/4 assumed" % field)
+                    field = "4/4"
+                beats, btype = field.split("/")[:2]
+                try:
+                    s.mdur = simplify(
+                        eval(beats), int(btype)
+                    )  # measure duration for Z and X rests (eval allows M:2+3/4)
+                except:
+                    info("error in M:%s, 4/4 assumed" % field)
+                    s.mdur = (4, 4)
+                    beats, btype = "4", "4"
+                addElemT(t, "beats", beats, lev + 2)
+                addElemT(t, "beat-type", btype, lev + 2)
+                atts.append((3, t))
+            elif ftype == "K":
+                accs = ["F", "C", "G", "D", "A", "E", "B"]  # == s.sharpness [7:14]
+                mode = ""
+                key = re.match(r"\s*([A-G][#b]?)\s*([a-zA-Z]*)", field)
+                alts = re.search(
+                    r"\s((\s?[=^_][A-Ga-g])+)", " " + field
+                )  # avoid matching middle=G and m=G
+                if key:
+                    key, mode = key.groups()
+                    mode = mode.lower()[:3]  # only first three chars, no case
+                    if mode not in s.offTab:
+                        mode = "maj"
+                    fifths = s.sharpness.index(key) - s.offTab[mode]
+                    if fifths >= 0:
+                        s.keyAlts = dict(zip(accs[:fifths], fifths * ["1"]))
+                    else:
+                        s.keyAlts = dict(zip(accs[fifths:], -fifths * ["-1"]))
+                elif field.startswith("none") or field == "":  # the default key
+                    fifths = 0
+                    mode = "maj"
+                if alts:
+                    alts = re.findall(
+                        r"[=^_][A-Ga-g]", alts.group(1)
+                    )  # list of explicit alterations
+                    alts = [(x[1], s.alterTab[x[0]]) for x in alts]  # [step, alter]
+                    for (
+                        step,
+                        alter,
+                    ) in alts:  # correct permanent alterations for this key
+                        s.keyAlts[step.upper()] = alter
+                    k = E.Element("key")
+                    koctave = []
+                    lowerCaseSteps = [
+                        step.upper() for step, alter in alts if step.islower()
+                    ]
+                    for step, alter in sorted(list(s.keyAlts.items())):
+                        if alter == "0":  # skip neutrals
+                            del s.keyAlts[
+                                step.upper()
+                            ]  # otherwise you get neutral signs on normal notes
+                            continue
+                        addElemT(k, "key-step", step.upper(), lev + 2)
+                        addElemT(k, "key-alter", alter, lev + 2)
+                        koctave.append("5" if step in lowerCaseSteps else "4")
+                    if koctave:  # only key signature if not empty
+                        for oct in koctave:
+                            e = E.Element("key-octave", number=oct)
+                            addElem(k, e, lev + 2)
+                        atts.append((2, k))
+                elif mode:
+                    k = E.Element("key")
+                    addElemT(k, "fifths", str(fifths), lev + 2)
+                    addElemT(k, "mode", s.modTab[mode], lev + 2)
+                    atts.append((2, k))
+                doClef(field)
+            elif ftype == "L":
+                try:
+                    s.unitLcur = lmap(int, field.split("/"))
+                except:
+                    s.unitLcur = (1, 8)
+                if len(s.unitLcur) == 1 or s.unitLcur[1] not in s.typeMap:
+                    info("L:%s is not allowed, 1/8 assumed" % field)
+                    s.unitLcur = 1, 8
+            elif ftype == "V":
+                doClef(field)
+            elif ftype == "I":
+                s.doField_I(ftype, field, instDir, addTrans)
+            elif ftype == "Q":
+                s.doTempo(maat, field, lev)
+            elif ftype == "P":  # ad hoc translation of P: into a staff text direction
+                words = E.Element("rehearsal")
+                words.set("font-weight", "bold")
+                words.text = field
+                addDirection(maat, words, lev, gstaff, placement="above")
+            elif ftype in "TCOAZNGHRBDFSU":
+                info("**illegal header field in body: %s, content: %s" % (ftype, field))
+            else:
+                info("unhandled field: %s, content: %s" % (ftype, field))
 
         if atts:
-            att = E.Element ('attributes')      # insert sub elements in the order required by musicXML
-            addElem (maat, att, lev)
-            for _, att_elem in sorted (atts, key=lambda x: x[0]):   # ordering !
-                addElem (att, att_elem, lev + 1)
+            att = E.Element(
+                "attributes"
+            )  # insert sub elements in the order required by musicXML
+            addElem(maat, att, lev)
+            for _, att_elem in sorted(atts, key=lambda x: x[0]):  # ordering !
+                addElem(att, att_elem, lev + 1)
         if s.diafret:
-            other = E.Element ('other-direction'); other.text = 'diatonic fretting'
-            addDirection (maat, other, lev, 0)
+            other = E.Element("other-direction")
+            other.text = "diatonic fretting"
+            addDirection(maat, other, lev, 0)
 
-    def doTempo (s, maat, field, lev):
-        gstaff = s.gStaffNums.get (s.vid, 0)    # staff number of the current voice
-        t = re.search (r'(\d)/(\d\d?)\s*=\s*(\d[.\d]*)|(\d[.\d]*)', field)
-        rtxt = re.search (r'"([^"]*)"', field) # look for text in Q: field
-        if not t and not rtxt: return
+    def doTempo(s, maat, field, lev):
+        gstaff = s.gStaffNums.get(s.vid, 0)  # staff number of the current voice
+        t = re.search(r"(\d)/(\d\d?)\s*=\s*(\d[.\d]*)|(\d[.\d]*)", field)
+        rtxt = re.search(r'"([^"]*)"', field)  # look for text in Q: field
+        if not t and not rtxt:
+            return
         elems = []  # [(element, sub-elements)] will be added as direction-types
         if rtxt:
-            num, den, upm = 1, 4, s.tempoMap.get (rtxt.group (1).lower ().strip (), 120)
-            words = E.Element ('words'); words.text = rtxt.group (1)
-            elems.append ((words, []))
+            num, den, upm = 1, 4, s.tempoMap.get(rtxt.group(1).lower().strip(), 120)
+            words = E.Element("words")
+            words.text = rtxt.group(1)
+            elems.append((words, []))
         if t:
             try:
-                if t.group (4): num, den, upm = 1, s.unitLcur[1] , float (t.group (4))  # old syntax Q:120
-                else:           num, den, upm = int (t.group (1)), int (t.group (2)), float (t.group (3))
-            except: info ('conversion error: %s' % field); return
-            num, den = simplify (num, den);
+                if t.group(4):
+                    num, den, upm = (
+                        1,
+                        s.unitLcur[1],
+                        float(t.group(4)),
+                    )  # old syntax Q:120
+                else:
+                    num, den, upm = int(t.group(1)), int(t.group(2)), float(t.group(3))
+            except:
+                info("conversion error: %s" % field)
+                return
+            num, den = simplify(num, den)
             dotted, den_not = (1, den // 2) if num == 3 else (0, den)
-            metro = E.Element ('metronome')
-            u = E.Element ('beat-unit'); u.text = s.typeMap.get (4 * den_not, 'quarter')
-            pm = E.Element ('per-minute'); pm.text = ('%.2f' % upm).rstrip ('0').rstrip ('.')
-            subelms = [u, E.Element ('beat-unit-dot'), pm] if dotted else [u, pm]
-            elems.append ((metro, subelms))
-        dir = addDirection (maat, elems, lev, gstaff, [], placement='above')
-        if num != 1 and num != 3: info ('in Q: numerator in %d/%d not supported' % (num, den))
-        qpm = 4. * num * upm / den
-        sound = E.Element ('sound'); sound.set ('tempo', '%.2f' % qpm)
-        addElem (dir, sound, lev + 1)
+            metro = E.Element("metronome")
+            u = E.Element("beat-unit")
+            u.text = s.typeMap.get(4 * den_not, "quarter")
+            pm = E.Element("per-minute")
+            pm.text = ("%.2f" % upm).rstrip("0").rstrip(".")
+            subelms = [u, E.Element("beat-unit-dot"), pm] if dotted else [u, pm]
+            elems.append((metro, subelms))
+        dir = addDirection(maat, elems, lev, gstaff, [], placement="above")
+        if num != 1 and num != 3:
+            info("in Q: numerator in %d/%d not supported" % (num, den))
+        qpm = 4.0 * num * upm / den
+        sound = E.Element("sound")
+        sound.set("tempo", "%.2f" % qpm)
+        addElem(dir, sound, lev + 1)
 
-    def mkBarline (s, maat, loc, lev, style='', dir='', ending=''):
-        b = E.Element ('barline', location=loc)
+    def mkBarline(s, maat, loc, lev, style="", dir="", ending=""):
+        b = E.Element("barline", location=loc)
         if style:
-            addElemT (b, 'bar-style', style, lev + 1)
-        if s.curVolta:    # first stop a current volta
-            end = E.Element ('ending', number=s.curVolta, type='stop')
-            s.curVolta = ''
-            if loc == 'left':   # stop should always go to a right barline
-                bp = E.Element ('barline', location='right')
-                addElem (bp, end, lev + 1)
-                addElem (s.prevmsre, bp, lev)   # prevmsre has no right barline! (ending would have stopped there)
+            addElemT(b, "bar-style", style, lev + 1)
+        if s.curVolta:  # first stop a current volta
+            end = E.Element("ending", number=s.curVolta, type="stop")
+            s.curVolta = ""
+            if loc == "left":  # stop should always go to a right barline
+                bp = E.Element("barline", location="right")
+                addElem(bp, end, lev + 1)
+                addElem(
+                    s.prevmsre, bp, lev
+                )  # prevmsre has no right barline! (ending would have stopped there)
             else:
-                addElem (b, end, lev + 1)
+                addElem(b, end, lev + 1)
         if ending:
-            ending = ending.replace ('-',',')   # MusicXML only accepts comma's
-            endtxt = ''
-            if ending.startswith ('"'):     # ending is a quoted string
-                endtxt = ending.strip ('"')
-                ending = '33'               # any number that is not likely to occur elsewhere
-            end = E.Element ('ending', number=ending, type='start')
-            if endtxt: end.text = endtxt    # text appears in score in stead of number attribute
-            addElem (b, end, lev + 1)
+            ending = ending.replace("-", ",")  # MusicXML only accepts comma's
+            endtxt = ""
+            if ending.startswith('"'):  # ending is a quoted string
+                endtxt = ending.strip('"')
+                ending = "33"  # any number that is not likely to occur elsewhere
+            end = E.Element("ending", number=ending, type="start")
+            if endtxt:
+                end.text = endtxt  # text appears in score in stead of number attribute
+            addElem(b, end, lev + 1)
             s.curVolta = ending
         if dir:
-            r = E.Element ('repeat', direction=dir)
-            addElem (b, r, lev + 1)
-        addElem (maat, b, lev)
+            r = E.Element("repeat", direction=dir)
+            addElem(b, r, lev + 1)
+        addElem(maat, b, lev)
 
-    def doChordSym (s, maat, sym, lev):
-        alterMap = {'#':'1','=':'0','b':'-1'}
+    def doChordSym(s, maat, sym, lev):
+        alterMap = {"#": "1", "=": "0", "b": "-1"}
         rnt = sym.root.t
-        chord = E.Element ('harmony')
-        addElem (maat, chord, lev)
-        root = E.Element ('root')
-        addElem (chord, root, lev + 1)
-        addElemT (root, 'root-step', rnt[0], lev + 2)
-        if len (rnt) == 2: addElemT (root, 'root-alter', alterMap [rnt[1]], lev + 2)
-        kind = s.chordTab.get (sym.kind.t[0], 'major') if sym.kind.t else 'major'
-        addElemT (chord, 'kind', kind, lev + 1)
-        if hasattr (sym, 'bass'):
+        chord = E.Element("harmony")
+        addElem(maat, chord, lev)
+        root = E.Element("root")
+        addElem(chord, root, lev + 1)
+        addElemT(root, "root-step", rnt[0], lev + 2)
+        if len(rnt) == 2:
+            addElemT(root, "root-alter", alterMap[rnt[1]], lev + 2)
+        kind = s.chordTab.get(sym.kind.t[0], "major") if sym.kind.t else "major"
+        addElemT(chord, "kind", kind, lev + 1)
+        if hasattr(sym, "bass"):
             bnt = sym.bass.t
-            bass = E.Element ('bass')
-            addElem (chord, bass, lev + 1)
-            addElemT (bass, 'bass-step', bnt[0], lev + 2)
-            if len (bnt) == 2: addElemT (bass, 'bass-alter', alterMap [bnt[1]], lev + 2)
-        degs = getattr (sym, 'degree', '')
+            bass = E.Element("bass")
+            addElem(chord, bass, lev + 1)
+            addElemT(bass, "bass-step", bnt[0], lev + 2)
+            if len(bnt) == 2:
+                addElemT(bass, "bass-alter", alterMap[bnt[1]], lev + 2)
+        degs = getattr(sym, "degree", "")
         if degs:
-            if type (degs) != list_type: degs = [degs]
+            if type(degs) != list_type:
+                degs = [degs]
             for deg in degs:
                 deg = deg.t[0]
-                if deg[0] == '#':   alter = '1';  deg = deg[1:]
-                elif deg[0] == 'b': alter = '-1'; deg = deg[1:]
-                else:               alter = '0';  deg = deg
-                degree = E.Element ('degree')
-                addElem (chord, degree, lev + 1)
-                addElemT (degree, 'degree-value', deg, lev + 2)
-                addElemT (degree, 'degree-alter', alter, lev + 2)
-                addElemT (degree, 'degree-type', 'add', lev + 2)
+                if deg[0] == "#":
+                    alter = "1"
+                    deg = deg[1:]
+                elif deg[0] == "b":
+                    alter = "-1"
+                    deg = deg[1:]
+                else:
+                    alter = "0"
+                    deg = deg
+                degree = E.Element("degree")
+                addElem(chord, degree, lev + 1)
+                addElemT(degree, "degree-value", deg, lev + 2)
+                addElemT(degree, "degree-alter", alter, lev + 2)
+                addElemT(degree, "degree-type", "add", lev + 2)
 
-    def mkMeasure (s, i, t, lev, fieldmap={}):
+    def mkMeasure(s, i, t, lev, fieldmap={}):
         s.msreAlts = {}
         s.ntup, s.trem, s.intrem = -1, 0, 0
-        s.acciatura = 0 # next grace element gets acciatura attribute
-        s.rbStop = 0    # sluit een open volta aan het eind van de maat
+        s.acciatura = 0  # next grace element gets acciatura attribute
+        s.rbStop = 0  # sluit een open volta aan het eind van de maat
         overlay = 0
-        maat = E.Element ('measure', number = str(i))
-        if fieldmap: s.doFields (maat, fieldmap, lev + 1)
-        if s.linebrk:   # there was a line break in the previous measure
-            e = E.Element ('print')
-            e.set ('new-system', 'yes')
-            addElem (maat, e, lev + 1)
+        maat = E.Element("measure", number=str(i))
+        if fieldmap:
+            s.doFields(maat, fieldmap, lev + 1)
+        if s.linebrk:  # there was a line break in the previous measure
+            e = E.Element("print")
+            e.set("new-system", "yes")
+            addElem(maat, e, lev + 1)
             s.linebrk = 0
-        for it, x in enumerate (t):
-            if x.name == 'note' or x.name == 'rest':
-                if x.dur.t[0] == 0:  # a leading zero was used for stemmless in abcm2ps, we only support !stemless!
-                    x.dur.t = tuple ([1, x.dur.t[1]])
-                note = s.mkNote (x, lev + 1)
-                addElem (maat, note, lev + 1)
-            elif x.name == 'lbar':
+        for it, x in enumerate(t):
+            if x.name == "note" or x.name == "rest":
+                if (
+                    x.dur.t[0] == 0
+                ):  # a leading zero was used for stemmless in abcm2ps, we only support !stemless!
+                    x.dur.t = tuple([1, x.dur.t[1]])
+                note = s.mkNote(x, lev + 1)
+                addElem(maat, note, lev + 1)
+            elif x.name == "lbar":
                 bar = x.t[0]
-                if bar == '|' or bar == '[|': pass # skip redundant bar
-                elif ':' in bar:    # forward repeat
-                    volta = x.t[1] if len (x.t) == 2  else ''
-                    s.mkBarline (maat, 'left', lev + 1, style='heavy-light', dir='forward', ending=volta)
-                else:               # bar must be a volta number
-                    s.mkBarline (maat, 'left', lev + 1, ending=bar)
-            elif x.name == 'rbar':
+                if bar == "|" or bar == "[|":
+                    pass  # skip redundant bar
+                elif ":" in bar:  # forward repeat
+                    volta = x.t[1] if len(x.t) == 2 else ""
+                    s.mkBarline(
+                        maat,
+                        "left",
+                        lev + 1,
+                        style="heavy-light",
+                        dir="forward",
+                        ending=volta,
+                    )
+                else:  # bar must be a volta number
+                    s.mkBarline(maat, "left", lev + 1, ending=bar)
+            elif x.name == "rbar":
                 bar = x.t[0]
-                if bar == '.|':
-                    s.mkBarline (maat, 'right', lev + 1, style='dotted')
-                elif ':' in bar:  # backward repeat
-                    s.mkBarline (maat, 'right', lev + 1, style='light-heavy', dir='backward')
-                elif bar == '||':
-                    s.mkBarline (maat, 'right', lev + 1, style='light-light')
-                elif bar == '[|]' or bar == '[]':
-                    s.mkBarline (maat, 'right', lev + 1, style='none')
-                elif '[' in bar or ']' in bar:
-                    s.mkBarline (maat, 'right', lev + 1, style='light-heavy')
-                elif bar == '|' and s.rbStop:   # normale barline hoeft niet, behalve om een volta te stoppen
-                    s.mkBarline (maat, 'right', lev + 1, style='regular')
-                elif bar[0] == '&': overlay = 1
-            elif x.name == 'tup':
-                if   len (x.t) == 3: n, into, nts = x.t
-                elif len (x.t) == 2: n, into, nts = x.t + [0]
-                else:                n, into, nts = x.t[0], 0, 0
-                if into == 0: into = 3 if n in [2,4,8] else 2
-                if nts == 0: nts = n
-                s.tmnum, s.tmden, s.ntup = n, into, nts
-            elif x.name == 'deco':
-                s.staffDecos (x.t, maat, lev + 1)   # output staff decos, postpone note decos to next note
-            elif x.name == 'text':
-                pos, text = x.t[:2]
-                place = 'above' if pos == '^' else 'below'
-                words = E.Element ('words')
-                words.text = text
-                gstaff = s.gStaffNums.get (s.vid, 0)    # staff number of the current voice
-                addDirection (maat, words, lev + 1, gstaff, placement=place)
-            elif x.name == 'inline':
-                fieldtype, fieldval = x.t[0], ' '.join (x.t[1:])
-                s.doFields (maat, {fieldtype:fieldval}, lev + 1)
-            elif x.name == 'accia': s.acciatura = 1
-            elif x.name == 'linebrk':
-                s.supports_tag = 1
-                if it > 0 and t[it -1].name == 'lbar':  # we are at start of measure
-                    e = E.Element ('print')             # output linebreak now
-                    e.set ('new-system', 'yes')
-                    addElem (maat, e, lev + 1)
+                if bar == ".|":
+                    s.mkBarline(maat, "right", lev + 1, style="dotted")
+                elif ":" in bar:  # backward repeat
+                    s.mkBarline(
+                        maat, "right", lev + 1, style="light-heavy", dir="backward"
+                    )
+                elif bar == "||":
+                    s.mkBarline(maat, "right", lev + 1, style="light-light")
+                elif bar == "[|]" or bar == "[]":
+                    s.mkBarline(maat, "right", lev + 1, style="none")
+                elif "[" in bar or "]" in bar:
+                    s.mkBarline(maat, "right", lev + 1, style="light-heavy")
+                elif (
+                    bar == "|" and s.rbStop
+                ):  # normale barline hoeft niet, behalve om een volta te stoppen
+                    s.mkBarline(maat, "right", lev + 1, style="regular")
+                elif bar[0] == "&":
+                    overlay = 1
+            elif x.name == "tup":
+                if len(x.t) == 3:
+                    n, into, nts = x.t
+                elif len(x.t) == 2:
+                    n, into, nts = x.t + [0]
                 else:
-                    s.linebrk = 1   # output linebreak at start of next measure
-            elif x.name == 'chordsym':
-                s.doChordSym (maat, x, lev + 1)
-        s.stopBeams ()
+                    n, into, nts = x.t[0], 0, 0
+                if into == 0:
+                    into = 3 if n in [2, 4, 8] else 2
+                if nts == 0:
+                    nts = n
+                s.tmnum, s.tmden, s.ntup = n, into, nts
+            elif x.name == "deco":
+                s.staffDecos(
+                    x.t, maat, lev + 1
+                )  # output staff decos, postpone note decos to next note
+            elif x.name == "text":
+                pos, text = x.t[:2]
+                place = "above" if pos == "^" else "below"
+                words = E.Element("words")
+                words.text = text
+                gstaff = s.gStaffNums.get(s.vid, 0)  # staff number of the current voice
+                addDirection(maat, words, lev + 1, gstaff, placement=place)
+            elif x.name == "inline":
+                fieldtype, fieldval = x.t[0], " ".join(x.t[1:])
+                s.doFields(maat, {fieldtype: fieldval}, lev + 1)
+            elif x.name == "accia":
+                s.acciatura = 1
+            elif x.name == "linebrk":
+                s.supports_tag = 1
+                if it > 0 and t[it - 1].name == "lbar":  # we are at start of measure
+                    e = E.Element("print")  # output linebreak now
+                    e.set("new-system", "yes")
+                    addElem(maat, e, lev + 1)
+                else:
+                    s.linebrk = 1  # output linebreak at start of next measure
+            elif x.name == "chordsym":
+                s.doChordSym(maat, x, lev + 1)
+        s.stopBeams()
         s.prevmsre = maat
         return maat, overlay
 
-    def mkPart (s, maten, id, lev, attrs, nstaves, rOpt):
+    def mkPart(s, maten, id, lev, attrs, nstaves, rOpt):
         s.slurstack = {}
-        s.glisnum = 0;          # xml number attribute for glissandos
-        s.slidenum = 0;         # xml number attribute for slides
-        s.unitLcur = s.unitL    # set the default unit length at begin of each voice
-        s.curVolta = ''
+        s.glisnum = 0  # xml number attribute for glissandos
+        s.slidenum = 0  # xml number attribute for slides
+        s.unitLcur = s.unitL  # set the default unit length at begin of each voice
+        s.curVolta = ""
         s.lyrdash = {}
         s.linebrk = 0
-        s.midprg = ['', '', '', ''] # MIDI channel nr, program nr, volume, panning for the current part
-        s.gcue_on = 0           # reset cue note marker for each new voice
-        s.gtrans = 0            # reset octave transposition (by clef)
-        s.percVoice = 0         # 1 if percussion clef encountered
-        s.curClef = ''          # current abc clef (for percmap)
-        s.nostems = 0           # for the tab clef
+        s.midprg = [
+            "",
+            "",
+            "",
+            "",
+        ]  # MIDI channel nr, program nr, volume, panning for the current part
+        s.gcue_on = 0  # reset cue note marker for each new voice
+        s.gtrans = 0  # reset octave transposition (by clef)
+        s.percVoice = 0  # 1 if percussion clef encountered
+        s.curClef = ""  # current abc clef (for percmap)
+        s.nostems = 0  # for the tab clef
         s.tuning = s.tuningDef  # reset string tuning to default
-        part = E.Element ('part', id=id)
-        s.overlayVnum = 0       # overlay voice number to relate ties that extend from one overlayed measure to the next
-        gstaff = s.gStaffNums.get (s.vid, 0)    # staff number of the current voice
-        attrs_cpy = attrs.copy ()   # don't change attrs itself in next line
-        if gstaff == 1: attrs_cpy ['gstaff'] = nstaves  # make a grand staff
-        if 'perc' in attrs_cpy.get ('V', ''): del attrs_cpy ['K'] # remove key from percussion voice
-        msre, overlay = s.mkMeasure (1, maten[0], lev + 1, attrs_cpy)
-        addElem (part, msre, lev + 1)
-        for i, maat in enumerate (maten[1:]):
+        part = E.Element("part", id=id)
+        s.overlayVnum = 0  # overlay voice number to relate ties that extend from one overlayed measure to the next
+        gstaff = s.gStaffNums.get(s.vid, 0)  # staff number of the current voice
+        attrs_cpy = attrs.copy()  # don't change attrs itself in next line
+        if gstaff == 1:
+            attrs_cpy["gstaff"] = nstaves  # make a grand staff
+        if "perc" in attrs_cpy.get("V", ""):
+            del attrs_cpy["K"]  # remove key from percussion voice
+        msre, overlay = s.mkMeasure(1, maten[0], lev + 1, attrs_cpy)
+        addElem(part, msre, lev + 1)
+        for i, maat in enumerate(maten[1:]):
             s.overlayVnum = s.overlayVnum + 1 if overlay else 0
-            msre, next_overlay = s.mkMeasure (i+2, maat, lev + 1)
-            if overlay: mergePartMeasure (part, msre, s.overlayVnum, rOpt)
-            else:       addElem (part, msre, lev + 1)
+            msre, next_overlay = s.mkMeasure(i + 2, maat, lev + 1)
+            if overlay:
+                mergePartMeasure(part, msre, s.overlayVnum, rOpt)
+            else:
+                addElem(part, msre, lev + 1)
             overlay = next_overlay
         return part
 
-    def mkScorePart (s, id, vids_p, partAttr, lev):
-        def mkInst (instId, vid, midchan, midprog, midnot, vol, pan, lev):
-            si = E.Element ('score-instrument', id=instId)
-            pnm = partAttr.get (vid, [''])[0]   # part name if present
-            addElemT (si, 'instrument-name', pnm or 'dummy', lev + 2)   # MuseScore needs a name
-            mi = E.Element ('midi-instrument', id=instId)
-            if midchan: addElemT (mi, 'midi-channel', midchan, lev + 2)
-            if midprog: addElemT (mi, 'midi-program', str (int (midprog) + 1), lev + 2) # compatible with abc2midi
-            if midnot:  addElemT (mi, 'midi-unpitched', str (int (midnot) + 1), lev + 2)
-            if vol: addElemT (mi, 'volume', '%.2f' % (int (vol) / 1.27), lev + 2)
-            if pan: addElemT (mi, 'pan', '%.2f' % (int (pan) / 127. * 180 - 90), lev + 2)
+    def mkScorePart(s, id, vids_p, partAttr, lev):
+        def mkInst(instId, vid, midchan, midprog, midnot, vol, pan, lev):
+            si = E.Element("score-instrument", id=instId)
+            pnm = partAttr.get(vid, [""])[0]  # part name if present
+            addElemT(
+                si, "instrument-name", pnm or "dummy", lev + 2
+            )  # MuseScore needs a name
+            mi = E.Element("midi-instrument", id=instId)
+            if midchan:
+                addElemT(mi, "midi-channel", midchan, lev + 2)
+            if midprog:
+                addElemT(
+                    mi, "midi-program", str(int(midprog) + 1), lev + 2
+                )  # compatible with abc2midi
+            if midnot:
+                addElemT(mi, "midi-unpitched", str(int(midnot) + 1), lev + 2)
+            if vol:
+                addElemT(mi, "volume", "%.2f" % (int(vol) / 1.27), lev + 2)
+            if pan:
+                addElemT(mi, "pan", "%.2f" % (int(pan) / 127.0 * 180 - 90), lev + 2)
             return (si, mi)
-        naam, subnm, midprg = partAttr [id]
-        sp = E.Element ('score-part', id='P'+id)
-        nm = E.Element ('part-name')
+
+        naam, subnm, midprg = partAttr[id]
+        sp = E.Element("score-part", id="P" + id)
+        nm = E.Element("part-name")
         nm.text = naam
-        addElem (sp, nm, lev + 1)
-        snm = E.Element ('part-abbreviation')
+        addElem(sp, nm, lev + 1)
+        snm = E.Element("part-abbreviation")
         snm.text = subnm
-        if subnm: addElem (sp, snm, lev + 1)    # only add if subname was given
+        if subnm:
+            addElem(sp, snm, lev + 1)  # only add if subname was given
         inst = []
-        for instId, (pid, vid, chan, midprg, vol, pan) in sorted (s.midiInst.items ()):
-            midprg, midnot = ('0', midprg) if chan == '10' else (midprg, '')
-            if pid == id: inst.append (mkInst (instId, vid, chan, midprg, midnot, vol, pan, lev))
-        for si, mi in inst: addElem (sp, si, lev + 1)
-        for si, mi in inst: addElem (sp, mi, lev + 1)
+        for instId, (pid, vid, chan, midprg, vol, pan) in sorted(s.midiInst.items()):
+            midprg, midnot = ("0", midprg) if chan == "10" else (midprg, "")
+            if pid == id:
+                inst.append(mkInst(instId, vid, chan, midprg, midnot, vol, pan, lev))
+        for si, mi in inst:
+            addElem(sp, si, lev + 1)
+        for si, mi in inst:
+            addElem(sp, mi, lev + 1)
         return sp
 
-    def mkPartlist (s, vids, partAttr, lev):
-        def addPartGroup (sym, num):
-            pg = E.Element ('part-group', number=str (num), type='start')
-            addElem (partlist, pg, lev + 1)
-            addElemT (pg, 'group-symbol', sym, lev + 2)
-            addElemT (pg, 'group-barline', 'yes', lev + 2)
-        partlist = E.Element ('part-list')
-        g_num = 0       # xml group number
-        for g in (s.groups or vids):    # brace/bracket or abc_voice_id
-            if   g == '[': g_num += 1; addPartGroup ('bracket', g_num)
-            elif g == '{': g_num += 1; addPartGroup ('brace', g_num)
-            elif g in '}]':
-                pg = E.Element ('part-group', number=str (g_num), type='stop')
-                addElem (partlist, pg, lev + 1)
+    def mkPartlist(s, vids, partAttr, lev):
+        def addPartGroup(sym, num):
+            pg = E.Element("part-group", number=str(num), type="start")
+            addElem(partlist, pg, lev + 1)
+            addElemT(pg, "group-symbol", sym, lev + 2)
+            addElemT(pg, "group-barline", "yes", lev + 2)
+
+        partlist = E.Element("part-list")
+        g_num = 0  # xml group number
+        for g in s.groups or vids:  # brace/bracket or abc_voice_id
+            if g == "[":
+                g_num += 1
+                addPartGroup("bracket", g_num)
+            elif g == "{":
+                g_num += 1
+                addPartGroup("brace", g_num)
+            elif g in "}]":
+                pg = E.Element("part-group", number=str(g_num), type="stop")
+                addElem(partlist, pg, lev + 1)
                 g_num -= 1
-            else:   # g = abc_voice_id
-                if g not in vids: continue  # error in %%score
-                sp = s.mkScorePart (g, vids, partAttr, lev + 1)
-                addElem (partlist, sp, lev + 1)
+            else:  # g = abc_voice_id
+                if g not in vids:
+                    continue  # error in %%score
+                sp = s.mkScorePart(g, vids, partAttr, lev + 1)
+                addElem(partlist, sp, lev + 1)
         return partlist
 
-    def doField_I (s, type, x, instDir, addTrans):
-        def instChange (midchan, midprog):  # instDir -> doFields
-            if midchan and midchan != s.midprg [0]: instDir ('midi-channel', midchan, 'chan: %s')
-            if midprog and midprog != s.midprg [1]: instDir ('midi-program', str (int (midprog) + 1), 'prog: %s')
-        def readPfmt (x, n): # read ABC page formatting constant
-            if not s.pageFmtAbc: s.pageFmtAbc = s.pageFmtDef    # set the default values on first change
-            ro = re.search (r'[^.\d]*([\d.]+)\s*(cm|in|pt)?', x)    # float followed by unit
+    def doField_I(s, type, x, instDir, addTrans):
+        def instChange(midchan, midprog):  # instDir -> doFields
+            if midchan and midchan != s.midprg[0]:
+                instDir("midi-channel", midchan, "chan: %s")
+            if midprog and midprog != s.midprg[1]:
+                instDir("midi-program", str(int(midprog) + 1), "prog: %s")
+
+        def readPfmt(x, n):  # read ABC page formatting constant
+            if not s.pageFmtAbc:
+                s.pageFmtAbc = s.pageFmtDef  # set the default values on first change
+            ro = re.search(
+                r"[^.\d]*([\d.]+)\s*(cm|in|pt)?", x
+            )  # float followed by unit
             if ro:
-                x, unit = ro.groups ()  # unit == None when not present
-                u = {'cm':10., 'in':25.4, 'pt':25.4/72} [unit] if unit else 1.
-                s.pageFmtAbc [n] = float (x) * u   # convert ABC values to millimeters
-            else: info ('error in page format: %s' % x)
-        def readPercMap (x):    # parse I:percmap <abc_note> <step> <MIDI> <notehead>
-            def getMidNum (sndnm):          # find midi number of GM drum sound name
-                pnms = sndnm.split ('-')    # sound name parts (from I:percmap)
-                ps = s.percsnd [:]          # copy of the instruments
-                _f = lambda ip, xs, pnm: ip < len (xs) and xs[ip].find (pnm) > -1   # part xs[ip] and pnm match
-                for ip, pnm in enumerate (pnms):    # match all percmap sound name parts
-                    ps = [(nm, mnum) for nm, mnum in ps if _f (ip, nm.split ('-'), pnm) ]   # filter instruments
-                    if len (ps) <= 1: break # no match or one instrument left
-                if len (ps) == 0: info ('drum sound: %s not found' % sndnm); return '38'
-                return ps [0][1]            # midi number of (first) instrument found
-            def midiVal (acc, step, oct):   # abc note -> midi note number
-                oct = (4 if step.upper() == step else 5) + int (oct)
-                return oct * 12 + [0,2,4,5,7,9,11]['CDEFGAB'.index (step.upper())] + {'^':1,'_':-1,'=':0}.get (acc, 0) + 12
-            p0, p1, p2, p3, p4 = abc_percmap.parseString (x).asList ()  # percmap, abc-note, display-step, midi, note-head
-            acc, astep, aoct = p1
-            nstep, noct = (astep, aoct) if p2 == '*' else p2
-            if p3 == '*':                           midi = str (midiVal (acc, astep, aoct))
-            elif isinstance (p3, list_type):        midi = str (midiVal (p3[0], p3[1], p3[2]))
-            elif isinstance (p3, int_type):         midi = str (p3)
-            else:                                   midi = getMidNum (p3.lower ())
-            head = re.sub (r'(.)-([^x])', r'\1 \2', p4) # convert abc note head names to xml
-            s.percMap [(s.pid, acc + astep, aoct)] = (nstep, noct, midi, head)
-        if x.startswith ('score') or x.startswith ('staves'):
-            s.staveDefs += [x]          # collect all voice mappings
-        elif x.startswith ('staffwidth'): info ('skipped I-field: %s' % x)
-        elif x.startswith ('staff'):    # set new staff number of the current voice
-            r1 = re.search (r'staff *([+-]?)(\d)', x)
-            if r1:
-                sign = r1.group (1)
-                num = int (r1.group (2))
-                gstaff = s.gStaffNums.get (s.vid, 0)    # staff number of the current voice
-                if sign:                                # relative staff number
-                    num = (sign == '-') and gstaff - num or gstaff + num
-                else:                                   # absolute abc staff number
-                    try: vabc = s.staves [num - 1][0]   # vid of (first voice of) abc-staff num
-                    except: vabc = 0; info ('abc staff %s does not exist' % num)
-                    num = s.gStaffNumsOrg.get (vabc, 0) # xml staff number of abc-staff num
-                if gstaff and num > 0 and num <= s.gNstaves [s.vid]:
-                    s.gStaffNums [s.vid] = num
-                else: info ('could not relocate to staff: %s' % r1.group ())
-            else: info ('not a valid staff redirection: %s' % x)
-        elif x.startswith ('scale'): readPfmt (x, 0)
-        elif x.startswith ('pageheight'): readPfmt (x, 1)
-        elif x.startswith ('pagewidth'): readPfmt (x, 2)
-        elif x.startswith ('leftmargin'): readPfmt (x, 3)
-        elif x.startswith ('rightmargin'): readPfmt (x, 4)
-        elif x.startswith ('topmargin'): readPfmt (x, 5)
-        elif x.startswith ('botmargin'): readPfmt (x, 6)
-        elif x.startswith ('MIDI') or x.startswith ('midi'):
-            r1 = re.search (r'program *(\d*) +(\d+)', x)
-            r2 = re.search (r'channel *(\d+)', x)
-            r3 = re.search (r"drummap\s+([_=^]*)([A-Ga-g])([,']*)\s+(\d+)", x)
-            r4 = re.search (r'control *(\d+) +(\d+)', x)
-            ch_nw, prg_nw, vol_nw, pan_nw = '', '', '', ''
-            if r1: ch_nw, prg_nw = r1.groups () # channel nr or '', program nr
-            if r2: ch_nw = r2.group (1)         # channel nr only
-            if r4:
-                cnum, cval = r4.groups ()       # controller number, controller value
-                if cnum == '7': vol_nw = cval
-                if cnum == '10': pan_nw = cval
-            if r1 or r2 or r4:
-                ch  = ch_nw  or s.midprg [0]
-                prg = prg_nw or s.midprg [1]
-                vol = vol_nw or s.midprg [2]
-                pan = pan_nw or s.midprg [3]
-                instId = 'I%s-%s' % (s.pid, s.vid)              # only look for real instruments, no percussion
-                if instId in s.midiInst: instChange (ch, prg)   # instChance -> doFields
-                s.midprg = [ch, prg, vol, pan]  # mknote: new instrument -> s.midiInst
-            if r3:      # translate drummap to percmap
-                acc, step, oct, midi = r3.groups ()
-                oct = -len (oct) if ',' in x else len (oct)
-                notehead = 'x' if acc == '^' else 'circle-x' if acc == '_' else 'normal'
-                s.percMap [(s.pid, acc + step, oct)] = (step, oct, midi, notehead)
-            r = re.search (r'transpose[^-\d]*(-?\d+)', x)
-            if r: addTrans (r.group (1))        # addTrans -> doFields
-        elif x.startswith ('percmap'): readPercMap (x); s.pMapFound = 1
-        else: info ('skipped I-field: %s' % x)
-
-    def parseStaveDef (s, vdefs):
-        for vid in vdefs: s.vcepid [vid] = vid              # default: each voice becomes an xml part
-        if not s.staveDefs: return vdefs
-        for x in s.staveDefs [1:]: info ('%%%%%s dropped, multiple stave mappings not supported' % x)
-        x = s.staveDefs [0]                                 # only the first %%score is honoured
-        score = abc_scoredef.parseString (x) [0]
-        f = lambda x: type (x) == uni_type and [x] or x
-        s.staves = lmap (f, mkStaves (score, vdefs))        # [[vid] for each staff]
-        s.grands = lmap (f, mkGrand (score, vdefs))         # [staff-id], staff-id == [vid][0]
-        s.groups = mkGroups (score)
-        vce_groups = [vids for vids in s.staves if len (vids) > 1]  # all voice groups
-        d = {}                                              # for each voice group: map first voice id -> all merged voice ids
-        for vgr in vce_groups: d [vgr[0]] = vgr
-        for gstaff in s.grands:                             # for all grand staves
-            if len (gstaff) == 1: continue                  # skip single parts
-            for v, stf_num in zip (gstaff, range (1, len (gstaff) + 1)):
-                for vx in d.get (v, [v]):                   # allocate staff numbers
-                    s.gStaffNums [vx] = stf_num             # to all constituant voices
-                    s.gNstaves [vx] = len (gstaff)          # also remember total number of staves
-        s.gStaffNumsOrg = s.gStaffNums.copy ()              # keep original allocation for abc -> xml staff map
-        for xmlpart in s.grands:
-            pid = xmlpart [0]                               # part id == first staff id == first voice id
-            vces = [v for stf in xmlpart for v in d.get (stf, [stf])]
-            for v in vces: s.vcepid [v] = pid
-        return vdefs
-
-    def voiceNamesAndMaps (s, ps):  # get voice names and mappings
-        vdefs = {}
-        for vid, vcedef, vce in ps: # vcedef == emtpy or first pObj == voice definition
-            pname, psubnm = '', ''  # part name and abbreviation
-            if not vcedef:          # simple abc without voice definitions
-                vdefs [vid] =  pname, psubnm, ''
-            else:                   # abc with voice definitions
-                if vid != vcedef.t[1]: info ('voice ids unequal: %s (reg-ex) != %s (grammar)' % (vid, vcedef.t[1]))
-                rn = re.search (r'(?:name|nm)="([^"]*)"', vcedef.t[2])
-                if rn: pname = rn.group (1)
-                rn = re.search (r'(?:subname|snm|sname)="([^"]*)"', vcedef.t[2])
-                if rn: psubnm = rn.group (1)
-                vcedef.t[2] = vcedef.t[2].replace ('"%s"' % pname, '""').replace ('"%s"' % psubnm, '""')   # clear voice name to avoid false clef matches later on
-                vdefs [vid] =  pname, psubnm, vcedef.t[2]
-            xs = [pObj.t[1] for maat in vce for pObj in maat if pObj.name == 'inline']  # all inline statements in vce
-            s.staveDefs += [x.replace ('%5d',']') for x in xs if x.startswith ('score') or x.startswith ('staves')] # filter %%score and %%staves
-        return vdefs
-
-    def doHeaderField (s, fld, attrmap):
-        type, value = fld.t[0], fld.t[1].replace ('%5d',']')    # restore closing brackets (see splitHeaderVoices)
-        if not value:    # skip empty field
-            return
-        if type == 'M':
-            attrmap [type] = value
-        elif type == 'L':
-            try: s.unitL = lmap (int, fld.t[1].split ('/'))
-            except:
-                info ('illegal unit length:%s, 1/8 assumed' % fld.t[1])
-                s.unitL = 1,8
-            if len (s.unitL) == 1 or s.unitL[1] not in s.typeMap:
-                info ('L:%s is not allowed, 1/8 assumed' % fld.t[1])
-                s.unitL = 1,8
-        elif type == 'K':
-            attrmap[type] = value
-        elif type == 'T':
-            s.title = s.title + '\n' + value if s.title else value
-        elif type == 'U':
-            sym = fld.t[2].strip ('!+')
-            s.usrSyms [value] = sym
-        elif type == 'I':
-            s.doField_I (type, value, lambda x,y,z:0, lambda x:0)
-        elif type == 'Q':
-            attrmap[type] = value
-        elif type in 'CRZNOAGHBDFSP':           # part maps are treated as meta data
-            type = s.metaMap.get (type, type)   # respect the (user defined --meta) mapping of various ABC fields to XML meta data types
-            c = s.metadata.get (type, '')
-            s.metadata [type] = c + '\n' + value if c else value    # concatenate multiple info fields with new line as separator
-        else:
-            info ('skipped header: %s' % fld)
-
-    def mkIdentification (s, score, lev):
-        if s.title:
-            xs = s.title.split ('\n')   # the first T: line goes to work-title
-            ys = '\n'.join (xs [1:])    # place subsequent T: lines into work-number
-            w = E.Element ('work')
-            addElem (score, w, lev + 1)
-            if ys: addElemT (w, 'work-number', ys, lev + 2)
-            addElemT (w, 'work-title', xs[0], lev + 2)
-        ident = E.Element ('identification')
-        addElem (score, ident, lev + 1)
-        for mtype, mval in s.metadata.items ():
-            if mtype in s.metaTypes and mtype != 'rights':    # all metaTypes are MusicXML creator types
-                c = E.Element ('creator', type=mtype)
-                c.text = mval
-                addElem (ident, c, lev + 2)
-        if 'rights' in s.metadata:
-            c = addElemT (ident, 'rights', s.metadata ['rights'], lev + 2)
-        encoding = E.Element ('encoding')
-        addElem (ident, encoding, lev + 2)
-        encoder = E.Element ('encoder')
-        encoder.text = 'abc2xml version %d' % VERSION
-        addElem (encoding, encoder, lev + 3)
-        if s.supports_tag:  # avoids interference of auto-flowing and explicit linebreaks
-            suports = E.Element ('supports', attribute="new-system", element="print", type="yes", value="yes")
-            addElem (encoding, suports, lev + 3)
-        encodingDate = E.Element ('encoding-date')
-        encodingDate.text = str (datetime.date.today ())
-        addElem (encoding, encodingDate, lev + 3)
-        s.addMeta (ident, lev + 2)
-
-    def mkDefaults (s, score, lev):
-        if s.pageFmtCmd: s.pageFmtAbc = s.pageFmtCmd
-        if not s.pageFmtAbc: return # do not output the defaults if none is desired
-        abcScale, h, w, l, r, t, b = s.pageFmtAbc
-        space = abcScale * 2.117    # 2.117 = 6pt = space between staff lines for scale = 1.0 in abcm2ps
-        mils = 4 * space    # staff height in millimeters
-        scale = 40. / mils  # tenth's per millimeter
-        dflts = E.Element ('defaults')
-        addElem (score, dflts, lev)
-        scaling = E.Element ('scaling')
-        addElem (dflts, scaling, lev + 1)
-        addElemT (scaling, 'millimeters', '%g' % mils, lev + 2)
-        addElemT (scaling, 'tenths', '40', lev + 2)
-        layout = E.Element ('page-layout')
-        addElem (dflts, layout, lev + 1)
-        addElemT (layout, 'page-height', '%g' % (h * scale), lev + 2)
-        addElemT (layout, 'page-width', '%g' % (w * scale), lev + 2)
-        margins = E.Element ('page-margins', type='both')
-        addElem (layout, margins, lev + 2)
-        addElemT (margins, 'left-margin', '%g' % (l * scale), lev + 3)
-        addElemT (margins, 'right-margin', '%g' % (r * scale), lev + 3)
-        addElemT (margins, 'top-margin', '%g' % (t * scale), lev + 3)
-        addElemT (margins, 'bottom-margin', '%g' % (b * scale), lev + 3)
-
-    def addMeta (s, parent, lev):
-        misc = E.Element ('miscellaneous')
-        mf = 0
-        for mtype, mval in sorted (s.metadata.items ()):
-            if mtype == 'S':
-                addElemT (parent, 'source', mval, lev)
-            elif mtype in s.metaTypes: continue  # mapped meta data has already been output (in creator elements)
+                x, unit = ro.groups()  # unit == None when not present
+                u = {"cm": 10.0, "in": 25.4, "pt": 25.4 / 72}[unit] if unit else 1.0
+                s.pageFmtAbc[n] = float(x) * u  # convert ABC values to millimeters
             else:
-                mf = E.Element ('miscellaneous-field', name=s.metaTab [mtype])
-                mf.text = mval
-                addElem (misc, mf, lev + 1)
-        if mf != 0: addElem (parent, misc, lev)
+                info("error in page format: %s" % x)
 
-    def parse (s, abc_string, rOpt=False, bOpt=False, fOpt=False):
-        abctext = abc_string.replace ('[I:staff ','[I:staff')  # avoid false beam breaks
-        s.reset (fOpt)
-        header, voices = splitHeaderVoices (abctext)
+        def readPercMap(x):  # parse I:percmap <abc_note> <step> <MIDI> <notehead>
+            def getMidNum(sndnm):  # find midi number of GM drum sound name
+                pnms = sndnm.split("-")  # sound name parts (from I:percmap)
+                ps = s.percsnd[:]  # copy of the instruments
+                _f = (
+                    lambda ip, xs, pnm: ip < len(xs) and xs[ip].find(pnm) > -1
+                )  # part xs[ip] and pnm match
+                for ip, pnm in enumerate(pnms):  # match all percmap sound name parts
+                    ps = [
+                        (nm, mnum) for nm, mnum in ps if _f(ip, nm.split("-"), pnm)
+                    ]  # filter instruments
+                    if len(ps) <= 1:
+                        break  # no match or one instrument left
+                if len(ps) == 0:
+                    info("drum sound: %s not found" % sndnm)
+                    return "38"
+                return ps[0][1]  # midi number of (first) instrument found
+
+            def midiVal(acc, step, oct):  # abc note -> midi note number
+                oct = (4 if step.upper() == step else 5) + int(oct)
+                return (
+                    oct * 12
+                    + [0, 2, 4, 5, 7, 9, 11]["CDEFGAB".index(step.upper())]
+                    + {"^": 1, "_": -1, "=": 0}.get(acc, 0)
+                    + 12
+                )
+
+            p0, p1, p2, p3, p4 = abc_percmap.parseString(
+                x
+            ).asList()  # percmap, abc-note, display-step, midi, note-head
+            acc, astep, aoct = p1
+            nstep, noct = (astep, aoct) if p2 == "*" else p2
+            if p3 == "*":
+                midi = str(midiVal(acc, astep, aoct))
+            elif isinstance(p3, list_type):
+                midi = str(midiVal(p3[0], p3[1], p3[2]))
+            elif isinstance(p3, int_type):
+                midi = str(p3)
+            else:
+                midi = getMidNum(p3.lower())
+            head = re.sub(
+                r"(.)-([^x])", r"\1 \2", p4
+            )  # convert abc note head names to xml
+            s.percMap[(s.pid, acc + astep, aoct)] = (nstep, noct, midi, head)
+
+        if x.startswith("score") or x.startswith("staves"):
+            s.staveDefs += [x]  # collect all voice mappings
+        elif x.startswith("staffwidth"):
+            info("skipped I-field: %s" % x)
+        elif x.startswith("staff"):  # set new staff number of the current voice
+            r1 = re.search(r"staff *([+-]?)(\d)", x)
+            if r1:
+                sign = r1.group(1)
+                num = int(r1.group(2))
+                gstaff = s.gStaffNums.get(s.vid, 0)  # staff number of the current voice
+                if sign:  # relative staff number
+                    num = (sign == "-") and gstaff - num or gstaff + num
+                else:  # absolute abc staff number
+                    try:
+                        vabc = s.staves[num - 1][
+                            0
+                        ]  # vid of (first voice of) abc-staff num
+                    except:
+                        vabc = 0
+                        info("abc staff %s does not exist" % num)
+                    num = s.gStaffNumsOrg.get(
+                        vabc, 0
+                    )  # xml staff number of abc-staff num
+                if gstaff and num > 0 and num <= s.gNstaves[s.vid]:
+                    s.gStaffNums[s.vid] = num
+                else:
+                    info("could not relocate to staff: %s" % r1.group())
+            else:
+                info("not a valid staff redirection: %s" % x)
+        elif x.startswith("scale"):
+            readPfmt(x, 0)
+        elif x.startswith("pageheight"):
+            readPfmt(x, 1)
+        elif x.startswith("pagewidth"):
+            readPfmt(x, 2)
+        elif x.startswith("leftmargin"):
+            readPfmt(x, 3)
+        elif x.startswith("rightmargin"):
+            readPfmt(x, 4)
+        elif x.startswith("topmargin"):
+            readPfmt(x, 5)
+        elif x.startswith("botmargin"):
+            readPfmt(x, 6)
+        elif x.startswith("MIDI") or x.startswith("midi"):
+            r1 = re.search(r"program *(\d*) +(\d+)", x)
+            r2 = re.search(r"channel *(\d+)", x)
+            r3 = re.search(r"drummap\s+([_=^]*)([A-Ga-g])([,']*)\s+(\d+)", x)
+            r4 = re.search(r"control *(\d+) +(\d+)", x)
+            ch_nw, prg_nw, vol_nw, pan_nw = "", "", "", ""
+            if r1:
+                ch_nw, prg_nw = r1.groups()  # channel nr or '', program nr
+            if r2:
+                ch_nw = r2.group(1)  # channel nr only
+            if r4:
+                cnum, cval = r4.groups()  # controller number, controller value
+                if cnum == "7":
+                    vol_nw = cval
+                if cnum == "10":
+                    pan_nw = cval
+            if r1 or r2 or r4:
+                ch = ch_nw or s.midprg[0]
+                prg = prg_nw or s.midprg[1]
+                vol = vol_nw or s.midprg[2]
+                pan = pan_nw or s.midprg[3]
+                instId = "I%s-%s" % (
+                    s.pid,
+                    s.vid,
+                )  # only look for real instruments, no percussion
+                if instId in s.midiInst:
+                    instChange(ch, prg)  # instChance -> doFields
+                s.midprg = [ch, prg, vol, pan]  # mknote: new instrument -> s.midiInst
+            if r3:  # translate drummap to percmap
+                acc, step, oct, midi = r3.groups()
+                oct = -len(oct) if "," in x else len(oct)
+                notehead = "x" if acc == "^" else "circle-x" if acc == "_" else "normal"
+                s.percMap[(s.pid, acc + step, oct)] = (step, oct, midi, notehead)
+            r = re.search(r"transpose[^-\d]*(-?\d+)", x)
+            if r:
+                addTrans(r.group(1))  # addTrans -> doFields
+        elif x.startswith("percmap"):
+            readPercMap(x)
+            s.pMapFound = 1
+        else:
+            info("skipped I-field: %s" % x)
+
+    def parseStaveDef(s, vdefs):
+        for vid in vdefs:
+            s.vcepid[vid] = vid  # default: each voice becomes an xml part
+        if not s.staveDefs:
+            return vdefs
+        for x in s.staveDefs[1:]:
+            info("%%%%%s dropped, multiple stave mappings not supported" % x)
+        x = s.staveDefs[0]  # only the first %%score is honoured
+        score = abc_scoredef.parseString(x)[0]
+        f = lambda x: type(x) == uni_type and [x] or x
+        s.staves = lmap(f, mkStaves(score, vdefs))  # [[vid] for each staff]
+        s.grands = lmap(f, mkGrand(score, vdefs))  # [staff-id], staff-id == [vid][0]
+        s.groups = mkGroups(score)
+        vce_groups = [vids for vids in s.staves if len(vids) > 1]  # all voice groups
+        d = {}  # for each voice group: map first voice id -> all merged voice ids
+        for vgr in vce_groups:
+            d[vgr[0]] = vgr
+        for gstaff in s.grands:  # for all grand staves
+            if len(gstaff) == 1:
+                continue  # skip single parts
+            for v, stf_num in zip(gstaff, range(1, len(gstaff) + 1)):
+                for vx in d.get(v, [v]):  # allocate staff numbers
+                    s.gStaffNums[vx] = stf_num  # to all constituant voices
+                    s.gNstaves[vx] = len(gstaff)  # also remember total number of staves
+        s.gStaffNumsOrg = (
+            s.gStaffNums.copy()
+        )  # keep original allocation for abc -> xml staff map
+        for xmlpart in s.grands:
+            pid = xmlpart[0]  # part id == first staff id == first voice id
+            vces = [v for stf in xmlpart for v in d.get(stf, [stf])]
+            for v in vces:
+                s.vcepid[v] = pid
+        return vdefs
+
+    def voiceNamesAndMaps(s, ps):  # get voice names and mappings
+        vdefs = {}
+        for vid, vcedef, vce in ps:  # vcedef == emtpy or first pObj == voice definition
+            pname, psubnm = "", ""  # part name and abbreviation
+            if not vcedef:  # simple abc without voice definitions
+                vdefs[vid] = pname, psubnm, ""
+            else:  # abc with voice definitions
+                if vid != vcedef.t[1]:
+                    info(
+                        "voice ids unequal: %s (reg-ex) != %s (grammar)"
+                        % (vid, vcedef.t[1])
+                    )
+                rn = re.search(r'(?:name|nm)="([^"]*)"', vcedef.t[2])
+                if rn:
+                    pname = rn.group(1)
+                rn = re.search(r'(?:subname|snm|sname)="([^"]*)"', vcedef.t[2])
+                if rn:
+                    psubnm = rn.group(1)
+                vcedef.t[2] = (
+                    vcedef.t[2]
+                    .replace('"%s"' % pname, '""')
+                    .replace('"%s"' % psubnm, '""')
+                )  # clear voice name to avoid false clef matches later on
+                vdefs[vid] = pname, psubnm, vcedef.t[2]
+            xs = [
+                pObj.t[1] for maat in vce for pObj in maat if pObj.name == "inline"
+            ]  # all inline statements in vce
+            s.staveDefs += [
+                x.replace("%5d", "]")
+                for x in xs
+                if x.startswith("score") or x.startswith("staves")
+            ]  # filter %%score and %%staves
+        return vdefs
+
+    def doHeaderField(s, fld, attrmap):
+        type, value = fld.t[0], fld.t[1].replace(
+            "%5d", "]"
+        )  # restore closing brackets (see splitHeaderVoices)
+        if not value:  # skip empty field
+            return
+        if type == "M":
+            attrmap[type] = value
+        elif type == "L":
+            try:
+                s.unitL = lmap(int, fld.t[1].split("/"))
+            except:
+                info("illegal unit length:%s, 1/8 assumed" % fld.t[1])
+                s.unitL = 1, 8
+            if len(s.unitL) == 1 or s.unitL[1] not in s.typeMap:
+                info("L:%s is not allowed, 1/8 assumed" % fld.t[1])
+                s.unitL = 1, 8
+        elif type == "K":
+            attrmap[type] = value
+        elif type == "T":
+            s.title = s.title + "\n" + value if s.title else value
+        elif type == "U":
+            sym = fld.t[2].strip("!+")
+            s.usrSyms[value] = sym
+        elif type == "I":
+            s.doField_I(type, value, lambda x, y, z: 0, lambda x: 0)
+        elif type == "Q":
+            attrmap[type] = value
+        elif type in "CRZNOAGHBDFSP":  # part maps are treated as meta data
+            type = s.metaMap.get(
+                type, type
+            )  # respect the (user defined --meta) mapping of various ABC fields to XML meta data types
+            c = s.metadata.get(type, "")
+            s.metadata[type] = (
+                c + "\n" + value if c else value
+            )  # concatenate multiple info fields with new line as separator
+        else:
+            info("skipped header: %s" % fld)
+
+    def mkIdentification(s, score, lev):
+        if s.title:
+            xs = s.title.split("\n")  # the first T: line goes to work-title
+            ys = "\n".join(xs[1:])  # place subsequent T: lines into work-number
+            w = E.Element("work")
+            addElem(score, w, lev + 1)
+            if ys:
+                addElemT(w, "work-number", ys, lev + 2)
+            addElemT(w, "work-title", xs[0], lev + 2)
+        ident = E.Element("identification")
+        addElem(score, ident, lev + 1)
+        for mtype, mval in s.metadata.items():
+            if (
+                mtype in s.metaTypes and mtype != "rights"
+            ):  # all metaTypes are MusicXML creator types
+                c = E.Element("creator", type=mtype)
+                c.text = mval
+                addElem(ident, c, lev + 2)
+        if "rights" in s.metadata:
+            c = addElemT(ident, "rights", s.metadata["rights"], lev + 2)
+        encoding = E.Element("encoding")
+        addElem(ident, encoding, lev + 2)
+        encoder = E.Element("encoder")
+        encoder.text = "abc2xml version %d" % VERSION
+        addElem(encoding, encoder, lev + 3)
+        if (
+            s.supports_tag
+        ):  # avoids interference of auto-flowing and explicit linebreaks
+            suports = E.Element(
+                "supports",
+                attribute="new-system",
+                element="print",
+                type="yes",
+                value="yes",
+            )
+            addElem(encoding, suports, lev + 3)
+        encodingDate = E.Element("encoding-date")
+        encodingDate.text = str(datetime.date.today())
+        addElem(encoding, encodingDate, lev + 3)
+        s.addMeta(ident, lev + 2)
+
+    def mkDefaults(s, score, lev):
+        if s.pageFmtCmd:
+            s.pageFmtAbc = s.pageFmtCmd
+        if not s.pageFmtAbc:
+            return  # do not output the defaults if none is desired
+        abcScale, h, w, l, r, t, b = s.pageFmtAbc
+        space = (
+            abcScale * 2.117
+        )  # 2.117 = 6pt = space between staff lines for scale = 1.0 in abcm2ps
+        mils = 4 * space  # staff height in millimeters
+        scale = 40.0 / mils  # tenth's per millimeter
+        dflts = E.Element("defaults")
+        addElem(score, dflts, lev)
+        scaling = E.Element("scaling")
+        addElem(dflts, scaling, lev + 1)
+        addElemT(scaling, "millimeters", "%g" % mils, lev + 2)
+        addElemT(scaling, "tenths", "40", lev + 2)
+        layout = E.Element("page-layout")
+        addElem(dflts, layout, lev + 1)
+        addElemT(layout, "page-height", "%g" % (h * scale), lev + 2)
+        addElemT(layout, "page-width", "%g" % (w * scale), lev + 2)
+        margins = E.Element("page-margins", type="both")
+        addElem(layout, margins, lev + 2)
+        addElemT(margins, "left-margin", "%g" % (l * scale), lev + 3)
+        addElemT(margins, "right-margin", "%g" % (r * scale), lev + 3)
+        addElemT(margins, "top-margin", "%g" % (t * scale), lev + 3)
+        addElemT(margins, "bottom-margin", "%g" % (b * scale), lev + 3)
+
+    def addMeta(s, parent, lev):
+        misc = E.Element("miscellaneous")
+        mf = 0
+        for mtype, mval in sorted(s.metadata.items()):
+            if mtype == "S":
+                addElemT(parent, "source", mval, lev)
+            elif mtype in s.metaTypes:
+                continue  # mapped meta data has already been output (in creator elements)
+            else:
+                mf = E.Element("miscellaneous-field", name=s.metaTab[mtype])
+                mf.text = mval
+                addElem(misc, mf, lev + 1)
+        if mf != 0:
+            addElem(parent, misc, lev)
+
+    def parse(s, abc_string, rOpt=False, bOpt=False, fOpt=False):
+        abctext = abc_string.replace("[I:staff ", "[I:staff")  # avoid false beam breaks
+        s.reset(fOpt)
+        header, voices = splitHeaderVoices(abctext)
         ps = []
         try:
-            lbrk_insert = 0 if re.search (r'I:linebreak\s*([!$]|none)|I:continueall\s*(1|true)', header) else bOpt
-            hs = abc_header.parseString (header) if header else ''
+            lbrk_insert = (
+                0
+                if re.search(
+                    r"I:linebreak\s*([!$]|none)|I:continueall\s*(1|true)", header
+                )
+                else bOpt
+            )
+            hs = abc_header.parseString(header) if header else ""
             for id, voice in voices:
-                if lbrk_insert:                                 # insert linebreak at EOL
-                    r1 = re.compile (r'\[[wA-Z]:[^]]*\]')       # inline field
-                    has_abc = lambda x: r1.sub ('', x).strip () # empty if line only contains inline fields
-                    voice = '\n'.join ([balk.rstrip ('$!') + '$' if has_abc (balk) else balk for balk in voice.splitlines ()])
-                prevLeftBar = None      # previous voice ended with a left-bar symbol (double repeat)
-                s.orderChords = s.fOpt and ('tab' in voice [:200] or [x for x in hs if x.t[0] == 'K' and 'tab' in x.t[1]])
-                vce = abc_voice.parseString (voice).asList ()
-                lyr_notes = []          # remember notes between lyric blocks
-                for m in vce:           # all measures
-                    for e in m:         # all abc-elements
-                        if e.name == 'lyr_blk':         # -> e.objs is list of lyric lines
-                            lyr = [line.objs for line in e.objs]    # line.objs is listof syllables
-                            alignLyr (lyr_notes, lyr)   # put all syllables into corresponding notes
+                if lbrk_insert:  # insert linebreak at EOL
+                    r1 = re.compile(r"\[[wA-Z]:[^]]*\]")  # inline field
+                    has_abc = lambda x: r1.sub(
+                        "", x
+                    ).strip()  # empty if line only contains inline fields
+                    voice = "\n".join(
+                        [
+                            balk.rstrip("$!") + "$" if has_abc(balk) else balk
+                            for balk in voice.splitlines()
+                        ]
+                    )
+                prevLeftBar = (
+                    None  # previous voice ended with a left-bar symbol (double repeat)
+                )
+                s.orderChords = s.fOpt and (
+                    "tab" in voice[:200]
+                    or [x for x in hs if x.t[0] == "K" and "tab" in x.t[1]]
+                )
+                vce = abc_voice.parseString(voice).asList()
+                lyr_notes = []  # remember notes between lyric blocks
+                for m in vce:  # all measures
+                    for e in m:  # all abc-elements
+                        if e.name == "lyr_blk":  # -> e.objs is list of lyric lines
+                            lyr = [
+                                line.objs for line in e.objs
+                            ]  # line.objs is listof syllables
+                            alignLyr(
+                                lyr_notes, lyr
+                            )  # put all syllables into corresponding notes
                             lyr_notes = []
                         else:
-                            lyr_notes.append (e)
-                if not vce:             # empty voice, insert an inline field that will be rejected
-                    vce = [[pObj ('inline', ['I', 'empty voice'])]]
+                            lyr_notes.append(e)
+                if not vce:  # empty voice, insert an inline field that will be rejected
+                    vce = [[pObj("inline", ["I", "empty voice"])]]
                 if prevLeftBar:
-                    vce[0].insert (0, prevLeftBar)  # insert at begin of first measure
+                    vce[0].insert(0, prevLeftBar)  # insert at begin of first measure
                     prevLeftBar = None
-                if vce[-1] and vce[-1][-1].name == 'lbar':  # last measure ends with an lbar
+                if (
+                    vce[-1] and vce[-1][-1].name == "lbar"
+                ):  # last measure ends with an lbar
                     prevLeftBar = vce[-1][-1]
-                    if len (vce) > 1:   # vce should not become empty (-> exception when taking vcelyr [0][0])
-                        del vce[-1]     # lbar was the only element in measure vce[-1]
+                    if (
+                        len(vce) > 1
+                    ):  # vce should not become empty (-> exception when taking vcelyr [0][0])
+                        del vce[-1]  # lbar was the only element in measure vce[-1]
                 vcelyr = vce
-                elem1 = vcelyr [0][0]   # the first element of the first measure
-                if  elem1.name == 'inline'and elem1.t[0] == 'V':    # is a voice definition
-                    voicedef = elem1 
-                    del vcelyr [0][0]   # do not read voicedef twice
+                elem1 = vcelyr[0][0]  # the first element of the first measure
+                if (
+                    elem1.name == "inline" and elem1.t[0] == "V"
+                ):  # is a voice definition
+                    voicedef = elem1
+                    del vcelyr[0][0]  # do not read voicedef twice
                 else:
-                    voicedef = ''
-                ps.append ((id, voicedef, vcelyr))
+                    voicedef = ""
+                ps.append((id, voicedef, vcelyr))
         except ParseException as err:
-            if err.loc > 40:    # limit length of error message, compatible with markInputline
-                err.pstr = err.pstr [err.loc - 40: err.loc + 40]
+            if (
+                err.loc > 40
+            ):  # limit length of error message, compatible with markInputline
+                err.pstr = err.pstr[err.loc - 40 : err.loc + 40]
                 err.loc = 40
-            xs = err.line[err.col-1:]
-            info (err.line, warn=0)
-            info ((err.col-1) * '-' + '^', warn=0)
-            if   re.search (r'\[U:', xs):
-                info ('Error: illegal user defined symbol: %s' % xs[1:], warn=0)
-            elif re.search (r'\[[OAPZNGHRBDFSXTCIU]:', xs):
-                info ('Error: header-only field %s appears after K:' % xs[1:], warn=0)
+            xs = err.line[err.col - 1 :]
+            info(err.line, warn=0)
+            info((err.col - 1) * "-" + "^", warn=0)
+            if re.search(r"\[U:", xs):
+                info("Error: illegal user defined symbol: %s" % xs[1:], warn=0)
+            elif re.search(r"\[[OAPZNGHRBDFSXTCIU]:", xs):
+                info("Error: header-only field %s appears after K:" % xs[1:], warn=0)
             else:
-                info ('Syntax error at column %d' % err.col, warn=0)
+                info("Syntax error at column %d" % err.col, warn=0)
             raise
 
-        score = E.Element ('score-partwise')
-        attrmap = {'Div': str (s.divisions), 'K':'C treble', 'M':'4/4'}
+        score = E.Element("score-partwise")
+        attrmap = {"Div": str(s.divisions), "K": "C treble", "M": "4/4"}
         for res in hs:
-            if res.name == 'field':
-                s.doHeaderField (res, attrmap)
+            if res.name == "field":
+                s.doHeaderField(res, attrmap)
             else:
-                info ('unexpected header item: %s' % res)
+                info("unexpected header item: %s" % res)
 
-        vdefs = s.voiceNamesAndMaps (ps)
-        vdefs = s.parseStaveDef (vdefs)
+        vdefs = s.voiceNamesAndMaps(ps)
+        vdefs = s.parseStaveDef(vdefs)
 
         lev = 0
         vids, parts, partAttr = [], [], {}
-        s.strAlloc = stringAlloc ()
-        for vid, _, vce in ps:          # voice id, voice parse tree
-            pname, psubnm, voicedef = vdefs [vid]   # part name
-            attrmap ['V'] = voicedef    # abc text of first voice definition (after V:vid) or empty
-            pid = 'P%s' % vid           # let part id start with an alpha
-            s.vid = vid                 # avoid parameter passing, needed in mkNote for instrument id
-            s.pid = s.vcepid [s.vid]    # xml part-id for the current voice
-            s.gTime = (0, 0)            # reset time
-            s.strAlloc.beginZoek ()     # reset search index
-            part = s.mkPart (vce, pid, lev + 1, attrmap, s.gNstaves.get (vid, 0), rOpt)
-            if 'Q' in attrmap: del attrmap ['Q']    # header tempo only in first part
-            parts.append (part)
-            vids.append (vid)
-            partAttr [vid] = (pname, psubnm, s.midprg)
-            if s.midprg != ['', '', '', ''] and not s.percVoice:    # when a part has only rests
-                instId = 'I%s-%s' % (s.pid, s.vid)
-                if instId not in s.midiInst: s.midiInst [instId] = (s.pid, s.vid, s.midprg [0], s.midprg [1], s.midprg [2], s.midprg [3])
-        parts, vidsnew = mergeParts (parts, vids, s.staves, rOpt) # merge parts into staves as indicated by %%score
-        parts, vidsnew = mergeParts (parts, vidsnew, s.grands, rOpt, 1) # merge grand staves
-        reduceMids (parts, vidsnew, s.midiInst)
+        s.strAlloc = stringAlloc()
+        for vid, _, vce in ps:  # voice id, voice parse tree
+            pname, psubnm, voicedef = vdefs[vid]  # part name
+            attrmap["V"] = (
+                voicedef  # abc text of first voice definition (after V:vid) or empty
+            )
+            pid = "P%s" % vid  # let part id start with an alpha
+            s.vid = vid  # avoid parameter passing, needed in mkNote for instrument id
+            s.pid = s.vcepid[s.vid]  # xml part-id for the current voice
+            s.gTime = (0, 0)  # reset time
+            s.strAlloc.beginZoek()  # reset search index
+            part = s.mkPart(vce, pid, lev + 1, attrmap, s.gNstaves.get(vid, 0), rOpt)
+            if "Q" in attrmap:
+                del attrmap["Q"]  # header tempo only in first part
+            parts.append(part)
+            vids.append(vid)
+            partAttr[vid] = (pname, psubnm, s.midprg)
+            if (
+                s.midprg != ["", "", "", ""] and not s.percVoice
+            ):  # when a part has only rests
+                instId = "I%s-%s" % (s.pid, s.vid)
+                if instId not in s.midiInst:
+                    s.midiInst[instId] = (
+                        s.pid,
+                        s.vid,
+                        s.midprg[0],
+                        s.midprg[1],
+                        s.midprg[2],
+                        s.midprg[3],
+                    )
+        parts, vidsnew = mergeParts(
+            parts, vids, s.staves, rOpt
+        )  # merge parts into staves as indicated by %%score
+        parts, vidsnew = mergeParts(
+            parts, vidsnew, s.grands, rOpt, 1
+        )  # merge grand staves
+        reduceMids(parts, vidsnew, s.midiInst)
 
-        s.mkIdentification (score, lev)
-        s.mkDefaults (score, lev + 1)
+        s.mkIdentification(score, lev)
+        s.mkDefaults(score, lev + 1)
 
-        partlist = s.mkPartlist (vids, partAttr, lev + 1)
-        addElem (score, partlist, lev + 1)
-        for ip, part in enumerate (parts): addElem (score, part, lev + 1)
+        partlist = s.mkPartlist(vids, partAttr, lev + 1)
+        addElem(score, partlist, lev + 1)
+        for ip, part in enumerate(parts):
+            addElem(score, part, lev + 1)
 
         return score
 
 
-def decodeInput (data_string):
-    try:        enc = 'utf-8';   unicode_string = data_string.decode (enc)
+def decodeInput(data_string):
+    try:
+        enc = "utf-8"
+        unicode_string = data_string.decode(enc)
     except:
-        try:    enc = 'latin-1'; unicode_string = data_string.decode (enc)
-        except: raise ValueError ('data not encoded in utf-8 nor in latin-1')
-    info ('decoded from %s' % enc)
+        try:
+            enc = "latin-1"
+            unicode_string = data_string.decode(enc)
+        except:
+            raise ValueError("data not encoded in utf-8 nor in latin-1")
+    info("decoded from %s" % enc)
     return unicode_string
 
-def ggd (a, b): # greatest common divisor
-    return a if b == 0 else ggd (b, a % b)
 
-xmlVersion = "<?xml version='1.0' encoding='utf-8'?>"    
-def fixDoctype (elem):
-    if python3: xs = E.tostring (elem, encoding='unicode')  # writing to file will auto-encode to utf-8
-    else:       xs = E.tostring (elem, encoding='utf-8')    # keep the string utf-8 encoded for writing to file
-    ys = xs.split ('\n')
-    ys.insert (0, xmlVersion)  # crooked logic of ElementTree lib
-    ys.insert (1, '<!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 3.0 Partwise//EN" "http://www.musicxml.org/dtds/partwise.dtd">')
-    return '\n'.join (ys)
+def ggd(a, b):  # greatest common divisor
+    return a if b == 0 else ggd(b, a % b)
 
-def xml2mxl (pad, fnm, data):   # write xml data to compressed .mxl file
+
+xmlVersion = "<?xml version='1.0' encoding='utf-8'?>"
+
+
+def fixDoctype(elem):
+    if python3:
+        xs = E.tostring(
+            elem, encoding="unicode"
+        )  # writing to file will auto-encode to utf-8
+    else:
+        xs = E.tostring(
+            elem, encoding="utf-8"
+        )  # keep the string utf-8 encoded for writing to file
+    ys = xs.split("\n")
+    ys.insert(0, xmlVersion)  # crooked logic of ElementTree lib
+    ys.insert(
+        1,
+        '<!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 3.0 Partwise//EN" "http://www.musicxml.org/dtds/partwise.dtd">',
+    )
+    return "\n".join(ys)
+
+
+def xml2mxl(pad, fnm, data):  # write xml data to compressed .mxl file
     from zipfile import ZipFile, ZIP_DEFLATED
-    fnmext = fnm + '.xml'       # file name with extension, relative to the root within the archive
-    outfile = os.path.join (pad, fnm + '.mxl')
-    meta  = '%s\n<container><rootfiles>\n' % xmlVersion
-    meta += '<rootfile full-path="%s" media-type="application/vnd.recordare.musicxml+xml"/>\n' % fnmext
-    meta += '</rootfiles></container>'
-    f = ZipFile (outfile, 'w', ZIP_DEFLATED)
-    f.writestr ('META-INF/container.xml', meta)
-    f.writestr (fnmext, data)
-    f.close ()
-    info ('%s written' % outfile, warn=0)
 
-def convert (pad, fnm, abc_string, mxl, rOpt=False, tOpt=False, bOpt=False, fOpt=False):  # not used, backwards compatibility
-    score = mxm.parse (abc_string, rOpt, bOpt, fOpt)
-    writefile (pad, fnm, '', score, mxl, tOpt)
+    fnmext = (
+        fnm + ".xml"
+    )  # file name with extension, relative to the root within the archive
+    outfile = os.path.join(pad, fnm + ".mxl")
+    meta = "%s\n<container><rootfiles>\n" % xmlVersion
+    meta += (
+        '<rootfile full-path="%s" media-type="application/vnd.recordare.musicxml+xml"/>\n'
+        % fnmext
+    )
+    meta += "</rootfiles></container>"
+    f = ZipFile(outfile, "w", ZIP_DEFLATED)
+    f.writestr("META-INF/container.xml", meta)
+    f.writestr(fnmext, data)
+    f.close()
+    info("%s written" % outfile, warn=0)
 
-def writefile (pad, fnm, fnmNum, xmldoc, mxlOpt, tOpt=False):
-    ipad, ifnm = os.path.split (fnm)                    # base name of input path is
+
+def convert(
+    pad, fnm, abc_string, mxl, rOpt=False, tOpt=False, bOpt=False, fOpt=False
+):  # not used, backwards compatibility
+    score = mxm.parse(abc_string, rOpt, bOpt, fOpt)
+    writefile(pad, fnm, "", score, mxl, tOpt)
+
+
+def writefile(pad, fnm, fnmNum, xmldoc, mxlOpt, tOpt=False):
+    ipad, ifnm = os.path.split(fnm)  # base name of input path is
     if tOpt:
-        x = xmldoc.findtext ('work/work-title', 'no_title')
-        ifnm = x.replace (',','_').replace ("'",'_').replace ('?','_')
+        x = xmldoc.findtext("work/work-title", "no_title")
+        ifnm = x.replace(",", "_").replace("'", "_").replace("?", "_")
     else:
         ifnm += fnmNum
-    xmlstr = fixDoctype (xmldoc)
+    xmlstr = fixDoctype(xmldoc)
     if pad:
-        if not mxlOpt or mxlOpt in ['a', 'add']:
-            outfnm = os.path.join (pad, ifnm + '.xml')  # joined with path from -o option
-            outfile = open (outfnm, 'w')
-            outfile.write (xmlstr)
-            outfile.close ()
-            info ('%s written' % outfnm, warn=0)
-        if mxlOpt: xml2mxl (pad, ifnm, xmlstr)          # also write a compressed version
+        if not mxlOpt or mxlOpt in ["a", "add"]:
+            outfnm = os.path.join(pad, ifnm + ".xml")  # joined with path from -o option
+            outfile = open(outfnm, "w")
+            outfile.write(xmlstr)
+            outfile.close()
+            info("%s written" % outfnm, warn=0)
+        if mxlOpt:
+            xml2mxl(pad, ifnm, xmlstr)  # also write a compressed version
     else:
         outfile = sys.stdout
-        outfile.write (xmlstr)
-        outfile.write ('\n')
+        outfile.write(xmlstr)
+        outfile.write("\n")
 
-def readfile (fnmext, errmsg='read error: '):
+
+def readfile(fnmext, errmsg="read error: "):
     try:
-        if fnmext == '-.abc': fobj = stdin  # see python2/3 differences
-        else: fobj = open (fnmext, 'rb')
-        encoded_data = fobj.read ()
-        fobj.close ()
-        return encoded_data if type (encoded_data) == uni_type else decodeInput (encoded_data)
+        if fnmext == "-.abc":
+            fobj = stdin  # see python2/3 differences
+        else:
+            fobj = open(fnmext, "rb")
+        encoded_data = fobj.read()
+        fobj.close()
+        return (
+            encoded_data
+            if type(encoded_data) == uni_type
+            else decodeInput(encoded_data)
+        )
     except Exception as e:
-        info (errmsg + repr (e) + ' ' + fnmext)
+        info(errmsg + repr(e) + " " + fnmext)
         return None
 
-def expand_abc_include (abctxt):
+
+def expand_abc_include(abctxt):
     ys = []
-    for x in abctxt.splitlines ():
-        if x.startswith ('%%abc-include') or x.startswith ('I:abc-include'):
-            x = readfile (x[13:].strip (), 'include error: ')
-        if x != None: ys.append (x)
-    return '\n'.join (ys)
+    for x in abctxt.splitlines():
+        if x.startswith("%%abc-include") or x.startswith("I:abc-include"):
+            x = readfile(x[13:].strip(), "include error: ")
+        if x != None:
+            ys.append(x)
+    return "\n".join(ys)
 
-abc_header, abc_voice, abc_scoredef, abc_percmap = abc_grammar () # compute grammars only once
-mxm = MusicXml ()               # same for instance of MusicXml
 
-def getXmlScores (abc_string, skip=0, num=1, rOpt=False, bOpt=False, fOpt=False): # not used, backwards compatibility
-    return [fixDoctype (xml_doc) for xml_doc in
-        getXmlDocs (abc_string, skip=0, num=1, rOpt=False, bOpt=False, fOpt=False)]
+abc_header, abc_voice, abc_scoredef, abc_percmap = (
+    abc_grammar()
+)  # compute grammars only once
+mxm = MusicXml()  # same for instance of MusicXml
 
-def getXmlDocs (abc_string, skip=0, num=1, rOpt=False, bOpt=False, fOpt=False): # added by David Randolph
+
+def getXmlScores(
+    abc_string, skip=0, num=1, rOpt=False, bOpt=False, fOpt=False
+):  # not used, backwards compatibility
+    return [
+        fixDoctype(xml_doc)
+        for xml_doc in getXmlDocs(
+            abc_string, skip=0, num=1, rOpt=False, bOpt=False, fOpt=False
+        )
+    ]
+
+
+def getXmlDocs(
+    abc_string, skip=0, num=1, rOpt=False, bOpt=False, fOpt=False
+):  # added by David Randolph
     xml_docs = []
-    abctext = expand_abc_include (abc_string)
-    fragments = re.split (r'^\s*X:', abctext, flags=re.M)
-    preamble = fragments [0]    # tunes can be preceeded by formatting instructions
+    abctext = expand_abc_include(abc_string)
+    fragments = re.split(r"^\s*X:", abctext, flags=re.M)
+    preamble = fragments[0]  # tunes can be preceeded by formatting instructions
     tunes = fragments[1:]
-    if not tunes and preamble: tunes, preamble = ['1\n' + preamble], ''  # tune without X:
-    for itune, tune in enumerate (tunes):
-        if itune < skip: continue           # skip tunes, then read at most num tunes
-        if itune >= skip + num: break
-        tune = preamble + 'X:' + tune       # restore preamble before each tune
-        try:                                # convert string abctext -> file pad/fnmNum.xml
-            score = mxm.parse (tune, rOpt, bOpt, fOpt)
-            ds = list (score.iter ('duration')) # need to iterate twice
-            ss = [int (d.text) for d in ds]
-            deler = reduce (ggd, ss + [21]) # greatest common divisor of all durations
-            for i, d in enumerate (ds): d.text = str (ss [i] // deler)
-            for d in score.iter ('divisions'): d.text = str (int (d.text) // deler)
-            xml_docs.append (score)
+    if not tunes and preamble:
+        tunes, preamble = ["1\n" + preamble], ""  # tune without X:
+    for itune, tune in enumerate(tunes):
+        if itune < skip:
+            continue  # skip tunes, then read at most num tunes
+        if itune >= skip + num:
+            break
+        tune = preamble + "X:" + tune  # restore preamble before each tune
+        try:  # convert string abctext -> file pad/fnmNum.xml
+            score = mxm.parse(tune, rOpt, bOpt, fOpt)
+            ds = list(score.iter("duration"))  # need to iterate twice
+            ss = [int(d.text) for d in ds]
+            deler = reduce(ggd, ss + [21])  # greatest common divisor of all durations
+            for i, d in enumerate(ds):
+                d.text = str(ss[i] // deler)
+            for d in score.iter("divisions"):
+                d.text = str(int(d.text) // deler)
+            xml_docs.append(score)
         except ParseException:
-            pass         # output already printed
+            pass  # output already printed
         except Exception as err:
-            info ('an exception occurred.\n%s' % err)
+            info("an exception occurred.\n%s" % err)
     return xml_docs
 
-#----------------
+
+# ----------------
 # Main Program
-#----------------
-if __name__ == '__main__':
+# ----------------
+if __name__ == "__main__":
     from optparse import OptionParser
     from glob import glob
     import time
 
-    parser = OptionParser (usage='%prog [-h] [-r] [-t] [-b] [-m SKIP NUM] [-o DIR] [-p PFMT] [-z MODE] [--meta MAP] <file1> [<file2> ...]', version='version %d' % VERSION)
-    parser.add_option ("-o", action="store", help="store xml files in DIR", default='', metavar='DIR')
-    parser.add_option ("-m", action="store", help="skip SKIP (0) tunes, then read at most NUM (1) tunes", nargs=2, type='int', default=(0,1), metavar='SKIP NUM')
-    parser.add_option ("-p", action="store", help="pageformat PFMT (mm) = scale (0.75), pageheight (297), pagewidth (210), leftmargin (18), rightmargin (18), topmargin (10), botmargin (10)", default='', metavar='PFMT')
-    parser.add_option ("-z", "--mxl", dest="mxl", help="store as compressed mxl, MODE = a(dd) or r(eplace)", default='', metavar='MODE')
-    parser.add_option ("-r", action="store_true", help="show whole measure rests in merged staffs", default=False)
-    parser.add_option ("-t", action="store_true", help="use tune title as file name", default=False)
-    parser.add_option ("-b", action="store_true", help="line break at EOL", default=False)
-    parser.add_option ("--meta", action="store", help="map infofields to XML metadata, MAP = R:poet,Z:lyricist,N:...", default='', metavar='MAP')
-    parser.add_option ("-f", action="store_true", help="force string/fret allocations for tab staves", default=False)
-    options, args = parser.parse_args ()
-    if len (args) == 0: parser.error ('no input file given')
+    parser = OptionParser(
+        usage="%prog [-h] [-r] [-t] [-b] [-m SKIP NUM] [-o DIR] [-p PFMT] [-z MODE] [--meta MAP] <file1> [<file2> ...]",
+        version="version %d" % VERSION,
+    )
+    parser.add_option(
+        "-o", action="store", help="store xml files in DIR", default="", metavar="DIR"
+    )
+    parser.add_option(
+        "-m",
+        action="store",
+        help="skip SKIP (0) tunes, then read at most NUM (1) tunes",
+        nargs=2,
+        type="int",
+        default=(0, 1),
+        metavar="SKIP NUM",
+    )
+    parser.add_option(
+        "-p",
+        action="store",
+        help="pageformat PFMT (mm) = scale (0.75), pageheight (297), pagewidth (210), leftmargin (18), rightmargin (18), topmargin (10), botmargin (10)",
+        default="",
+        metavar="PFMT",
+    )
+    parser.add_option(
+        "-z",
+        "--mxl",
+        dest="mxl",
+        help="store as compressed mxl, MODE = a(dd) or r(eplace)",
+        default="",
+        metavar="MODE",
+    )
+    parser.add_option(
+        "-r",
+        action="store_true",
+        help="show whole measure rests in merged staffs",
+        default=False,
+    )
+    parser.add_option(
+        "-t", action="store_true", help="use tune title as file name", default=False
+    )
+    parser.add_option(
+        "-b", action="store_true", help="line break at EOL", default=False
+    )
+    parser.add_option(
+        "--meta",
+        action="store",
+        help="map infofields to XML metadata, MAP = R:poet,Z:lyricist,N:...",
+        default="",
+        metavar="MAP",
+    )
+    parser.add_option(
+        "-f",
+        action="store_true",
+        help="force string/fret allocations for tab staves",
+        default=False,
+    )
+    options, args = parser.parse_args()
+    if len(args) == 0:
+        parser.error("no input file given")
     pad = options.o
-    if options.mxl and options.mxl not in ['a','add', 'r', 'replace']:
-        parser.error ('MODE should be a(dd) or r(eplace), not: %s' % options.mxl)
+    if options.mxl and options.mxl not in ["a", "add", "r", "replace"]:
+        parser.error("MODE should be a(dd) or r(eplace), not: %s" % options.mxl)
     if pad:
-        if not os.path.exists (pad): os.mkdir (pad)
-        if not os.path.isdir (pad): parser.error ('%s is not a directory' % pad)
-    if options.p:   # set page formatting values
-        try:        # space, page-height, -width, margin-left, -right, -top, -bottom
-            mxm.pageFmtCmd = lmap (float, options.p.split (','))
-            if len (mxm.pageFmtCmd) != 7: raise ValueError ('-p needs 7 values')
-        except Exception as err: parser.error (err)
-    for x in options.meta.split (','):
-        if not x: continue
-        try: field, tag = x.split (':')
-        except: parser.error ('--meta: %s cannot be split on colon' % x)
-        if field not in 'OAZNGHRBDFSPW': parser.error ('--meta: field %s is no valid ABC field' % field)
-        if tag not in mxm.metaTypes: parser.error ('--meta: tag %s is no valid XML creator type' % tag)
-        mxm.metaMap [field] = tag
+        if not os.path.exists(pad):
+            os.mkdir(pad)
+        if not os.path.isdir(pad):
+            parser.error("%s is not a directory" % pad)
+    if options.p:  # set page formatting values
+        try:  # space, page-height, -width, margin-left, -right, -top, -bottom
+            mxm.pageFmtCmd = lmap(float, options.p.split(","))
+            if len(mxm.pageFmtCmd) != 7:
+                raise ValueError("-p needs 7 values")
+        except Exception as err:
+            parser.error(err)
+    for x in options.meta.split(","):
+        if not x:
+            continue
+        try:
+            field, tag = x.split(":")
+        except:
+            parser.error("--meta: %s cannot be split on colon" % x)
+        if field not in "OAZNGHRBDFSPW":
+            parser.error("--meta: field %s is no valid ABC field" % field)
+        if tag not in mxm.metaTypes:
+            parser.error("--meta: tag %s is no valid XML creator type" % tag)
+        mxm.metaMap[field] = tag
     fnmext_list = []
     for i in args:
-        if i == '-': fnmext_list.append ('-.abc')   # represents standard input
-        else:        fnmext_list += glob (i)
-    if not fnmext_list: parser.error ('none of the input files exist')
-    t_start = time.time ()
+        if i == "-":
+            fnmext_list.append("-.abc")  # represents standard input
+        else:
+            fnmext_list += glob(i)
+    if not fnmext_list:
+        parser.error("none of the input files exist")
+    t_start = time.time()
     for fnmext in fnmext_list:
-        fnm, ext = os.path.splitext (fnmext)
-        if ext.lower () not in ('.abc'):
-            info ('skipped input file %s, it should have extension .abc' % fnmext)
+        fnm, ext = os.path.splitext(fnmext)
+        if ext.lower() not in (".abc"):
+            info("skipped input file %s, it should have extension .abc" % fnmext)
             continue
-        if os.path.isdir (fnmext):
-            info ('skipped directory %s. Only files are accepted' % fnmext)
+        if os.path.isdir(fnmext):
+            info("skipped directory %s. Only files are accepted" % fnmext)
             continue
-        abctext = readfile (fnmext)
+        abctext = readfile(fnmext)
         skip, num = options.m
-        xml_docs = getXmlDocs (abctext, skip, num, options.r, options.b, options.f)
-        for itune, xmldoc in enumerate (xml_docs):
-            fnmNum = '%02d' % (itune + 1) if len (xml_docs) > 1 else ''
-            writefile (pad, fnm, fnmNum, xmldoc, options.mxl, options.t)
-    info ('done in %.2f secs' % (time.time () - t_start))
+        xml_docs = getXmlDocs(abctext, skip, num, options.r, options.b, options.f)
+        for itune, xmldoc in enumerate(xml_docs):
+            fnmNum = "%02d" % (itune + 1) if len(xml_docs) > 1 else ""
+            writefile(pad, fnm, fnmNum, xmldoc, options.mxl, options.t)
+    info("done in %.2f secs" % (time.time() - t_start))

--- a/notebook/demo.ipynb
+++ b/notebook/demo.ipynb
@@ -7,20 +7,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import os\n",
     "import re\n",
     "import time\n",
     "import torch\n",
-    "import torch\n",
     "import random\n",
     "import bisect\n",
-    "import json\n",
     "from pathlib import Path\n",
-    "from tokenizers import Tokenizer\n",
-    "from transformers import GPT2Model, GPT2LMHeadModel, GPT2Config, LlamaModel, LlamaForCausalLM, PreTrainedModel \n",
+    "from transformers import GPT2Model, GPT2LMHeadModel, GPT2Config, PreTrainedModel \n",
     "from samplings import top_p_sampling, top_k_sampling, temperature_sampling\n",
-    "from abctoolkit.utils import Exclaim_re, Quote_re, SquareBracket_re, Barline_regexPattern\n",
-    "from abctoolkit.transpose import Note_list, Pitch_sign_list\n",
+    "from abctoolkit.utils import Barline_regexPattern\n",
+    "from abctoolkit.transpose import Note_list\n",
     "from abctoolkit.duration import calculate_bartext_duration"
    ]
   },

--- a/pretrain/config.py
+++ b/pretrain/config.py
@@ -1,39 +1,46 @@
-import os
-
 # Configuration for the data
-DATA_TRAIN_INDEX_PATH = "" 
-DATA_EVAL_INDEX_PATH  = ""
+DATA_TRAIN_INDEX_PATH = ""
+DATA_EVAL_INDEX_PATH = ""
 
 # Configuration for the model
 PATCH_STREAM = True
-PATCH_SIZE = 16                                                # Patch Size
-PATCH_LENGTH = 2048                                             # Patch Length
-CHAR_NUM_LAYERS = 3                                             # Number of layers in the decoder
-PATCH_NUM_LAYERS = 12                                           # Number of layers in the encoder
-HIDDEN_SIZE = 768                                               # Hidden Size
+PATCH_SIZE = 16  # Patch Size
+PATCH_LENGTH = 2048  # Patch Length
+CHAR_NUM_LAYERS = 3  # Number of layers in the decoder
+PATCH_NUM_LAYERS = 12  # Number of layers in the encoder
+HIDDEN_SIZE = 768  # Hidden Size
 
 # Configuration for the training
-BATCH_SIZE = 4         
-LEARNING_RATE = 1e-4   
-NUM_EPOCHS = 128                                                 # Number of epochs to train for (if early stopping doesn't intervene)
-ACCUMULATION_STEPS = 1                                          # Accumulation steps to simulate large batch size
-PATCH_SAMPLING_BATCH_SIZE = 0                                   # Batch size for patch during training, 0 for full conaudio
-LOAD_FROM_CHECKPOINT = False                                    # Whether to load weights from a checkpoint
-WANDB_LOGGING = False                                           # Whether to log to wandb
-WANDB_KEY = '<your_wandb_key>'
+BATCH_SIZE = 4
+LEARNING_RATE = 1e-4
+NUM_EPOCHS = 128  # Number of epochs to train for (if early stopping doesn't intervene)
+ACCUMULATION_STEPS = 1  # Accumulation steps to simulate large batch size
+PATCH_SAMPLING_BATCH_SIZE = (
+    0  # Batch size for patch during training, 0 for full conaudio
+)
+LOAD_FROM_CHECKPOINT = False  # Whether to load weights from a checkpoint
+WANDB_LOGGING = False  # Whether to log to wandb
+WANDB_KEY = "<your_wandb_key>"
 
-EXP_TAG = 'pretrain'                                            # Experiment tag for differentiation
-NAME =  EXP_TAG + \
-        "_p_size_" + str(PATCH_SIZE) + \
-        "_p_length_" + str(PATCH_LENGTH) + \
-        "_p_layers_" + str(PATCH_NUM_LAYERS) + \
-        "_c_layers_" + str(CHAR_NUM_LAYERS) + \
-        "_h_size_" + str(HIDDEN_SIZE) + \
-        "_lr_" + str(LEARNING_RATE) + \
-        "_batch_" + str(BATCH_SIZE)
+EXP_TAG = "pretrain"  # Experiment tag for differentiation
+NAME = (
+    EXP_TAG
+    + "_p_size_"
+    + str(PATCH_SIZE)
+    + "_p_length_"
+    + str(PATCH_LENGTH)
+    + "_p_layers_"
+    + str(PATCH_NUM_LAYERS)
+    + "_c_layers_"
+    + str(CHAR_NUM_LAYERS)
+    + "_h_size_"
+    + str(HIDDEN_SIZE)
+    + "_lr_"
+    + str(LEARNING_RATE)
+    + "_batch_"
+    + str(BATCH_SIZE)
+)
 
-WEIGHTS_PATH = "weights_notagen_" + NAME + ".pth"                  # Path to save weights
-LOGS_PATH    = "logs_notagen_"    + NAME + ".txt"                     # Path to save logs
+WEIGHTS_PATH = "weights_notagen_" + NAME + ".pth"  # Path to save weights
+LOGS_PATH = "logs_notagen_" + NAME + ".txt"  # Path to save logs
 WANDB_NAME = NAME
-
-                                                                                   

--- a/pretrain/train-gen.py
+++ b/pretrain/train-gen.py
@@ -6,8 +6,26 @@ import wandb
 import torch
 import random
 import numpy as np
-from utils import *
-from config import *
+from utils import Patchilizer, NotaGenLMHeadModel
+from config import (
+    BATCH_SIZE,
+    PATCH_NUM_LAYERS,
+    PATCH_LENGTH,
+    HIDDEN_SIZE,
+    CHAR_NUM_LAYERS,
+    PATCH_SIZE,
+    LEARNING_RATE,
+    WANDB_LOGGING,
+    WANDB_KEY,
+    WANDB_NAME,
+    DATA_TRAIN_INDEX_PATH,
+    DATA_EVAL_INDEX_PATH,
+    NUM_EPOCHS,
+    ACCUMULATION_STEPS,
+    LOAD_FROM_CHECKPOINT,
+    WEIGHTS_PATH,
+    LOGS_PATH,
+)
 from tqdm import tqdm
 from copy import deepcopy
 from torch.cuda.amp import autocast, GradScaler

--- a/pretrain/train-gen.py
+++ b/pretrain/train-gen.py
@@ -1,7 +1,6 @@
 import os
 import gc
 import time
-import math
 import json
 import wandb
 import torch
@@ -13,23 +12,23 @@ from tqdm import tqdm
 from copy import deepcopy
 from torch.cuda.amp import autocast, GradScaler
 from torch.utils.data import Dataset, DataLoader
-from transformers import GPT2Config, LlamaConfig, get_scheduler, get_constant_schedule_with_warmup
+from transformers import GPT2Config, get_constant_schedule_with_warmup
 import torch.distributed as dist
 from torch.nn.parallel import DistributedDataParallel as DDP
 from torch.utils.data.distributed import DistributedSampler
 
 # Set up distributed training
-world_size = int(os.environ['WORLD_SIZE']) if 'WORLD_SIZE' in os.environ else 1
-global_rank = int(os.environ['RANK']) if 'RANK' in os.environ else 0
-local_rank = int(os.environ['LOCAL_RANK']) if 'LOCAL_RANK' in os.environ else 0
+world_size = int(os.environ["WORLD_SIZE"]) if "WORLD_SIZE" in os.environ else 1
+global_rank = int(os.environ["RANK"]) if "RANK" in os.environ else 0
+local_rank = int(os.environ["LOCAL_RANK"]) if "LOCAL_RANK" in os.environ else 0
 
 if world_size > 1:
     torch.cuda.set_device(local_rank)
     device = torch.device("cuda", local_rank)
-    dist.init_process_group(backend='nccl') if world_size > 1 else None
+    dist.init_process_group(backend="nccl") if world_size > 1 else None
 else:
     device = torch.device("cuda") if torch.cuda.is_available() else torch.device("cpu")
-    
+
 # Set random seed
 seed = 0 + global_rank
 random.seed(seed)
@@ -43,28 +42,40 @@ batch_size = BATCH_SIZE
 
 patchilizer = Patchilizer()
 
-patch_config = GPT2Config(num_hidden_layers=PATCH_NUM_LAYERS, 
-                    max_length=PATCH_LENGTH, 
-                    max_position_embeddings=PATCH_LENGTH,
-                    n_embd=HIDDEN_SIZE,
-                    num_attention_heads=HIDDEN_SIZE//64,
-                    vocab_size=1)
-char_config = GPT2Config(num_hidden_layers=CHAR_NUM_LAYERS, 
-                            max_length=PATCH_SIZE+1, 
-                            max_position_embeddings=PATCH_SIZE+1,
-                            hidden_size=HIDDEN_SIZE,
-                            num_attention_heads=HIDDEN_SIZE//64,
-                            vocab_size=128)
+patch_config = GPT2Config(
+    num_hidden_layers=PATCH_NUM_LAYERS,
+    max_length=PATCH_LENGTH,
+    max_position_embeddings=PATCH_LENGTH,
+    n_embd=HIDDEN_SIZE,
+    num_attention_heads=HIDDEN_SIZE // 64,
+    vocab_size=1,
+)
+char_config = GPT2Config(
+    num_hidden_layers=CHAR_NUM_LAYERS,
+    max_length=PATCH_SIZE + 1,
+    max_position_embeddings=PATCH_SIZE + 1,
+    hidden_size=HIDDEN_SIZE,
+    num_attention_heads=HIDDEN_SIZE // 64,
+    vocab_size=128,
+)
 
 model = NotaGenLMHeadModel(encoder_config=patch_config, decoder_config=char_config)
 
 model = model.to(device)
 
 # print parameter number
-print("Parameter Number: "+str(sum(p.numel() for p in model.parameters() if p.requires_grad)))
+print(
+    "Parameter Number: "
+    + str(sum(p.numel() for p in model.parameters() if p.requires_grad))
+)
 
 if world_size > 1:
-    model = DDP(model, device_ids=[local_rank], output_device=local_rank,  find_unused_parameters=True)
+    model = DDP(
+        model,
+        device_ids=[local_rank],
+        output_device=local_rank,
+        find_unused_parameters=True,
+    )
 
 scaler = GradScaler()
 is_autocast = True
@@ -79,24 +90,32 @@ def clear_unused_tensors():
             model_tensors = {id(p) for p in model.module.parameters()}
         else:
             model_tensors = {id(p) for p in model.parameters()}
-        
+
         # Get the set of tensor ids used by the optimizer
         optimizer_tensors = {
-            id(state) 
-            for state_dict in optimizer.state.values() 
+            id(state)
+            for state_dict in optimizer.state.values()
             for state in state_dict.values()
             if isinstance(state, torch.Tensor)  # Ensure only tensors are considered
         }
 
         # List of all CUDA tensors currently in memory
-        tensors = [obj for obj in gc.get_objects() if isinstance(obj, torch.Tensor) and obj.is_cuda]
-        
+        tensors = [
+            obj
+            for obj in gc.get_objects()
+            if isinstance(obj, torch.Tensor) and obj.is_cuda
+        ]
+
         # Create weak references to avoid interfering with garbage collection
         tensor_refs = [weakref.ref(tensor) for tensor in tensors]
 
         for tensor_ref in tensor_refs:
             tensor = tensor_ref()  # Dereference the weak reference
-            if tensor is not None and id(tensor) not in model_tensors and id(tensor) not in optimizer_tensors:
+            if (
+                tensor is not None
+                and id(tensor) not in model_tensors
+                and id(tensor) not in optimizer_tensors
+            ):
                 # Mark the tensor for deletion
                 tensor.detach_()  # Detach from computation graph
                 del tensor  # Delete the tensor reference
@@ -108,13 +127,19 @@ def clear_unused_tensors():
         gc.collect()  # Force a garbage collection
         torch.cuda.empty_cache()  # Clear the CUDA cache
 
+
 def collate_batch(input_batches):
-    
+
     input_patches, input_masks = zip(*input_batches)
-    input_patches = torch.nn.utils.rnn.pad_sequence(input_patches, batch_first=True, padding_value=0)
-    input_masks = torch.nn.utils.rnn.pad_sequence(input_masks, batch_first=True, padding_value=0)
+    input_patches = torch.nn.utils.rnn.pad_sequence(
+        input_patches, batch_first=True, padding_value=0
+    )
+    input_masks = torch.nn.utils.rnn.pad_sequence(
+        input_masks, batch_first=True, padding_value=0
+    )
 
     return input_patches.to(device), input_masks.to(device)
+
 
 def split_into_minibatches(input_patches, input_masks, minibatch_size):
     minibatches = []
@@ -125,6 +150,7 @@ def split_into_minibatches(input_patches, input_masks, minibatch_size):
         minibatches.append((minibatch_patches, minibatch_masks))
     return minibatches
 
+
 class NotaGenDataset(Dataset):
     def __init__(self, filenames):
         self.filenames = filenames
@@ -134,24 +160,43 @@ class NotaGenDataset(Dataset):
 
     def __getitem__(self, idx):
 
-        filepath = self.filenames[idx]['path']
+        filepath = self.filenames[idx]["path"]
 
-        key = random.choice(['C#', 'F#', 'B', 'E', 'A', 'D', 'G', 'C', 'F', 'Bb', 'Eb', 'Ab', 'Db', 'Gb', 'Cb'])
+        key = random.choice(
+            [
+                "C#",
+                "F#",
+                "B",
+                "E",
+                "A",
+                "D",
+                "G",
+                "C",
+                "F",
+                "Bb",
+                "Eb",
+                "Ab",
+                "Db",
+                "Gb",
+                "Cb",
+            ]
+        )
 
         folder = os.path.dirname(filepath)
         name = os.path.split(filepath)[-1]
-        des_filepath = os.path.join(folder, key, name + '_' + key + '.abc')
-        
-        with open(des_filepath, 'r', encoding='utf-8') as f:
+        des_filepath = os.path.join(folder, key, name + "_" + key + ".abc")
+
+        with open(des_filepath, "r", encoding="utf-8") as f:
             abc_text = f.read()
-        
+
         file_bytes = patchilizer.encode_train(abc_text)
         file_masks = [1] * len(file_bytes)
 
         file_bytes = torch.tensor(file_bytes, dtype=torch.long)
         file_masks = torch.tensor(file_masks, dtype=torch.long)
-        
+
         return file_bytes, file_masks
+
 
 def process_one_batch(batch):
     input_patches, input_masks = batch
@@ -173,10 +218,12 @@ def train_epoch(epoch):
     total_train_loss = 0
     iter_idx = 1
     model.train()
-    train_steps = (epoch-1)*len(train_set)
+    train_steps = (epoch - 1) * len(train_set)
 
     for batch in tqdm_train_set:
-        minibatches = split_into_minibatches(batch[0], batch[1], BATCH_SIZE//ACCUMULATION_STEPS)
+        minibatches = split_into_minibatches(
+            batch[0], batch[1], BATCH_SIZE // ACCUMULATION_STEPS
+        )
         for minibatch in minibatches:
             with autocast():
                 loss = process_one_batch(minibatch) / ACCUMULATION_STEPS
@@ -184,21 +231,24 @@ def train_epoch(epoch):
             total_train_loss += loss.item()
         scaler.step(optimizer)
         scaler.update()
-        
+
         lr_scheduler.step()
         model.zero_grad(set_to_none=True)
-        tqdm_train_set.set_postfix({str(global_rank)+'_train_loss': total_train_loss / iter_idx})
+        tqdm_train_set.set_postfix(
+            {str(global_rank) + "_train_loss": total_train_loss / iter_idx}
+        )
         train_steps += 1
 
         # Log the training loss to wandb
-        if global_rank==0 and WANDB_LOGGING:
+        if global_rank == 0 and WANDB_LOGGING:
             wandb.log({"train_loss": total_train_loss / iter_idx}, step=train_steps)
 
         iter_idx += 1
         if iter_idx % 1000 == 0:
             clear_unused_tensors()
-        
-    return total_train_loss / (iter_idx-1)
+
+    return total_train_loss / (iter_idx - 1)
+
 
 # do one epoch for eval
 def eval_epoch():
@@ -207,119 +257,153 @@ def eval_epoch():
     total_eval_bpb = 0
     iter_idx = 1
     model.eval()
-  
+
     # Evaluate data for one epoch
-    for batch in tqdm_eval_set: 
-        minibatches = split_into_minibatches(batch[0], batch[1], BATCH_SIZE//ACCUMULATION_STEPS)
+    for batch in tqdm_eval_set:
+        minibatches = split_into_minibatches(
+            batch[0], batch[1], BATCH_SIZE // ACCUMULATION_STEPS
+        )
         for minibatch in minibatches:
             with torch.no_grad():
                 loss = process_one_batch(minibatch) / ACCUMULATION_STEPS
             total_eval_loss += loss.item()
-        tqdm_eval_set.set_postfix({str(global_rank)+'_eval_loss': total_eval_loss / iter_idx})
+        tqdm_eval_set.set_postfix(
+            {str(global_rank) + "_eval_loss": total_eval_loss / iter_idx}
+        )
         iter_idx += 1
-    return total_eval_loss / (iter_idx-1)
+    return total_eval_loss / (iter_idx - 1)
+
 
 # train and eval
 if __name__ == "__main__":
-    
+
     # Initialize wandb
-    if WANDB_LOGGING and global_rank==0:
+    if WANDB_LOGGING and global_rank == 0:
         wandb.login(key=WANDB_KEY)
-        wandb.init(project="notagen",
-                   name=WANDB_NAME)
-    
+        wandb.init(project="notagen", name=WANDB_NAME)
+
     # load data
     with open(DATA_TRAIN_INDEX_PATH, "r", encoding="utf-8") as f:
         print("Loading Data...")
         train_files = []
         for line in f:
             train_files.append(json.loads(line))
-    
+
     with open(DATA_EVAL_INDEX_PATH, "r", encoding="utf-8") as f:
         print("Loading Data...")
         eval_files = []
         for line in f:
             eval_files.append(json.loads(line))
-       
+
     train_batch_nums = int(len(train_files) / batch_size)
     eval_batch_nums = int(len(eval_files) / batch_size)
-
 
     random.shuffle(train_files)
     random.shuffle(eval_files)
 
-    train_files = train_files[:train_batch_nums*batch_size]
-    eval_files = eval_files[:eval_batch_nums*batch_size]
+    train_files = train_files[: train_batch_nums * batch_size]
+    eval_files = eval_files[: eval_batch_nums * batch_size]
 
     train_set = NotaGenDataset(train_files)
     eval_set = NotaGenDataset(eval_files)
 
-    train_sampler = DistributedSampler(train_set, num_replicas=world_size, rank=local_rank)
-    eval_sampler = DistributedSampler(eval_set, num_replicas=world_size, rank=local_rank)
+    train_sampler = DistributedSampler(
+        train_set, num_replicas=world_size, rank=local_rank
+    )
+    eval_sampler = DistributedSampler(
+        eval_set, num_replicas=world_size, rank=local_rank
+    )
 
-    train_set = DataLoader(train_set, batch_size=batch_size, collate_fn=collate_batch, sampler=train_sampler, shuffle = (train_sampler is None))
-    eval_set = DataLoader(eval_set, batch_size=batch_size, collate_fn=collate_batch, sampler=eval_sampler, shuffle = (train_sampler is None))
+    train_set = DataLoader(
+        train_set,
+        batch_size=batch_size,
+        collate_fn=collate_batch,
+        sampler=train_sampler,
+        shuffle=(train_sampler is None),
+    )
+    eval_set = DataLoader(
+        eval_set,
+        batch_size=batch_size,
+        collate_fn=collate_batch,
+        sampler=eval_sampler,
+        shuffle=(train_sampler is None),
+    )
 
-    lr_scheduler = get_constant_schedule_with_warmup(optimizer=optimizer, num_warmup_steps=1000)
+    lr_scheduler = get_constant_schedule_with_warmup(
+        optimizer=optimizer, num_warmup_steps=1000
+    )
 
     model = model.to(device)
     optimizer = torch.optim.AdamW(model.parameters(), lr=LEARNING_RATE)
 
     if LOAD_FROM_CHECKPOINT and os.path.exists(WEIGHTS_PATH):
         # Load checkpoint to CPU
-        checkpoint = torch.load(WEIGHTS_PATH, map_location='cpu')
+        checkpoint = torch.load(WEIGHTS_PATH, map_location="cpu")
 
         # Here, model is assumed to be on GPU
         # Load state dict to CPU model first, then move the model to GPU
         if torch.cuda.device_count() > 1:
             # If you have a DataParallel model, you need to load to model.module instead
             cpu_model = deepcopy(model.module)
-            cpu_model.load_state_dict(checkpoint['model'])
+            cpu_model.load_state_dict(checkpoint["model"])
             model.module.load_state_dict(cpu_model.state_dict())
         else:
             # Load to a CPU clone of the model, then load back
             cpu_model = deepcopy(model)
-            cpu_model.load_state_dict(checkpoint['model'])
+            cpu_model.load_state_dict(checkpoint["model"])
             model.load_state_dict(cpu_model.state_dict())
-        optimizer.load_state_dict(checkpoint['optimizer'])
-        lr_scheduler.load_state_dict(checkpoint['lr_sched'])
-        pre_epoch = checkpoint['epoch']
-        best_epoch = checkpoint['best_epoch']
-        min_eval_loss = checkpoint['min_eval_loss']
+        optimizer.load_state_dict(checkpoint["optimizer"])
+        lr_scheduler.load_state_dict(checkpoint["lr_sched"])
+        pre_epoch = checkpoint["epoch"]
+        best_epoch = checkpoint["best_epoch"]
+        min_eval_loss = checkpoint["min_eval_loss"]
         print("Successfully Loaded Checkpoint from Epoch %d" % pre_epoch)
         checkpoint = None
-    
+
     else:
         pre_epoch = 0
         best_epoch = 0
         min_eval_loss = 100
 
-    for epoch in range(1+pre_epoch, NUM_EPOCHS+1):
+    for epoch in range(1 + pre_epoch, NUM_EPOCHS + 1):
         train_sampler.set_epoch(epoch)
         eval_sampler.set_epoch(epoch)
-        print('-' * 21 + "Epoch " + str(epoch) + '-' * 21)
+        print("-" * 21 + "Epoch " + str(epoch) + "-" * 21)
         train_loss = train_epoch(epoch)
         eval_loss = eval_epoch()
-        if global_rank==0:
-            with open(LOGS_PATH,'a') as f:
-                f.write("Epoch " + str(epoch) + "\ntrain_loss: " + str(train_loss) + "\neval_loss: " +str(eval_loss) + "\ntime: " + time.asctime(time.localtime(time.time())) + "\n\n")
+        if global_rank == 0:
+            with open(LOGS_PATH, "a") as f:
+                f.write(
+                    "Epoch "
+                    + str(epoch)
+                    + "\ntrain_loss: "
+                    + str(train_loss)
+                    + "\neval_loss: "
+                    + str(eval_loss)
+                    + "\ntime: "
+                    + time.asctime(time.localtime(time.time()))
+                    + "\n\n"
+                )
             if eval_loss < min_eval_loss:
                 best_epoch = epoch
                 min_eval_loss = eval_loss
-                checkpoint = { 
-                                'model': model.module.state_dict() if hasattr(model, "module") else model.state_dict(),
-                                'optimizer': optimizer.state_dict(),
-                                'lr_sched': lr_scheduler.state_dict(),
-                                'epoch': epoch,
-                                'best_epoch': best_epoch,
-                                'min_eval_loss': min_eval_loss
-                                }
+                checkpoint = {
+                    "model": (
+                        model.module.state_dict()
+                        if hasattr(model, "module")
+                        else model.state_dict()
+                    ),
+                    "optimizer": optimizer.state_dict(),
+                    "lr_sched": lr_scheduler.state_dict(),
+                    "epoch": epoch,
+                    "best_epoch": best_epoch,
+                    "min_eval_loss": min_eval_loss,
+                }
                 torch.save(checkpoint, WEIGHTS_PATH)
-        
+
         if world_size > 1:
             dist.barrier()
 
-    if global_rank==0:
-        print("Best Eval Epoch : "+str(best_epoch))
-        print("Min Eval Loss : "+str(min_eval_loss))
-
+    if global_rank == 0:
+        print("Best Eval Epoch : " + str(best_epoch))
+        print("Min Eval Loss : " + str(min_eval_loss))

--- a/pretrain/utils.py
+++ b/pretrain/utils.py
@@ -1,20 +1,18 @@
 import torch
 import random
 import bisect
-import json
 import re
 import numpy as np
 from config import *
-from transformers import GPT2Model, GPT2LMHeadModel, LlamaModel, LlamaForCausalLM, PreTrainedModel
+from transformers import GPT2Model, GPT2LMHeadModel, PreTrainedModel
 from samplings import top_p_sampling, top_k_sampling, temperature_sampling
-from tokenizers import Tokenizer
 
 
 class Patchilizer:
     def __init__(self, stream=PATCH_STREAM):
         self.stream = stream
         self.delimiters = ["|:", "::", ":|", "[|", "||", "|]", "|"]
-        self.regexPattern = '(' + '|'.join(map(re.escape, self.delimiters)) + ')'
+        self.regexPattern = "(" + "|".join(map(re.escape, self.delimiters)) + ")"
         self.bos_token_id = 1
         self.eos_token_id = 2
         self.special_token_id = 0
@@ -34,11 +32,17 @@ class Patchilizer:
                     new_line_bars = line_bars
                 else:
                     if line_bars[0] in self.delimiters:
-                        new_line_bars = [line_bars[i] + line_bars[i + 1] for i in range(0, len(line_bars), 2)]
+                        new_line_bars = [
+                            line_bars[i] + line_bars[i + 1]
+                            for i in range(0, len(line_bars), 2)
+                        ]
                     else:
-                        new_line_bars = [line_bars[0]] + [line_bars[i] + line_bars[i + 1] for i in range(1, len(line_bars), 2)]
-                    if 'V' not in new_line_bars[-1]:
-                        new_line_bars[-2] += new_line_bars[-1] 
+                        new_line_bars = [line_bars[0]] + [
+                            line_bars[i] + line_bars[i + 1]
+                            for i in range(1, len(line_bars), 2)
+                        ]
+                    if "V" not in new_line_bars[-1]:
+                        new_line_bars[-2] += new_line_bars[-1]
                         new_line_bars = new_line_bars[:-1]
                 new_bars += new_line_bars
         except:
@@ -49,14 +53,16 @@ class Patchilizer:
     def split_patches(self, abc_text, patch_size=PATCH_SIZE, generate_last=False):
         if not generate_last and len(abc_text) % patch_size != 0:
             abc_text += chr(self.eos_token_id)
-        patches = [abc_text[i : i + patch_size] for i in range(0, len(abc_text), patch_size)]
+        patches = [
+            abc_text[i : i + patch_size] for i in range(0, len(abc_text), patch_size)
+        ]
         return patches
 
     def patch2chars(self, patch):
         """
         Convert a patch into a bar.
         """
-        bytes = ''
+        bytes = ""
         for idx in patch:
             if idx == self.eos_token_id:
                 break
@@ -64,7 +70,6 @@ class Patchilizer:
                 pass
             bytes += chr(idx)
         return bytes
-        
 
     def patchilize_metadata(self, metadata_lines):
 
@@ -73,77 +78,103 @@ class Patchilizer:
             metadata_patches += self.split_patches(line)
 
         return metadata_patches
-    
-    def patchilize_tunebody(self, tunebody_lines, encode_mode='train'):
+
+    def patchilize_tunebody(self, tunebody_lines, encode_mode="train"):
 
         tunebody_patches = []
         bars = self.split_bars(tunebody_lines)
-        if encode_mode == 'train':
+        if encode_mode == "train":
             for bar in bars:
                 tunebody_patches += self.split_patches(bar)
-        elif encode_mode == 'generate':
+        elif encode_mode == "generate":
             for bar in bars[:-1]:
                 tunebody_patches += self.split_patches(bar)
             tunebody_patches += self.split_patches(bars[-1], generate_last=True)
-       
+
         return tunebody_patches
 
-    def encode_train(self, abc_text, patch_length=PATCH_LENGTH, patch_size=PATCH_SIZE, add_special_patches=True, cut=True):
+    def encode_train(
+        self,
+        abc_text,
+        patch_length=PATCH_LENGTH,
+        patch_size=PATCH_SIZE,
+        add_special_patches=True,
+        cut=True,
+    ):
 
-        lines = abc_text.split('\n')
+        lines = abc_text.split("\n")
         lines = list(filter(None, lines))
-        lines = [line + '\n' for line in lines]
+        lines = [line + "\n" for line in lines]
 
         tunebody_index = -1
         for i, line in enumerate(lines):
-            if line.startswith('[V:'):
+            if line.startswith("[V:"):
                 tunebody_index = i
                 break
 
-        metadata_lines = lines[ : tunebody_index]
-        tunebody_lines = lines[tunebody_index : ]
+        metadata_lines = lines[:tunebody_index]
+        tunebody_lines = lines[tunebody_index:]
 
         if self.stream:
-            tunebody_lines = ['[r:' + str(line_index) + '/' + str(len(tunebody_lines) - line_index - 1) + ']' + line for line_index, line in
-                                enumerate(tunebody_lines)]    # [r:n/n]
+            tunebody_lines = [
+                "[r:"
+                + str(line_index)
+                + "/"
+                + str(len(tunebody_lines) - line_index - 1)
+                + "]"
+                + line
+                for line_index, line in enumerate(tunebody_lines)
+            ]  # [r:n/n]
 
         metadata_patches = self.patchilize_metadata(metadata_lines)
-        tunebody_patches = self.patchilize_tunebody(tunebody_lines, encode_mode='train')
+        tunebody_patches = self.patchilize_tunebody(tunebody_lines, encode_mode="train")
 
         if add_special_patches:
-            bos_patch = chr(self.bos_token_id) * (patch_size - 1) + chr(self.eos_token_id)
-            eos_patch = chr(self.bos_token_id) + chr(self.eos_token_id) * (patch_size - 1)
+            bos_patch = chr(self.bos_token_id) * (patch_size - 1) + chr(
+                self.eos_token_id
+            )
+            eos_patch = chr(self.bos_token_id) + chr(self.eos_token_id) * (
+                patch_size - 1
+            )
 
             metadata_patches = [bos_patch] + metadata_patches
             tunebody_patches = tunebody_patches + [eos_patch]
 
         if self.stream:
             if len(metadata_patches) + len(tunebody_patches) > patch_length:
-                available_cut_indexes = [0] + [index + 1 for index, patch in enumerate(tunebody_patches) if '\n' in patch]
-                line_index_for_cut_index = list(range(len(available_cut_indexes)))  
+                available_cut_indexes = [0] + [
+                    index + 1
+                    for index, patch in enumerate(tunebody_patches)
+                    if "\n" in patch
+                ]
+                line_index_for_cut_index = list(range(len(available_cut_indexes)))
                 end_index = len(metadata_patches) + len(tunebody_patches) - patch_length
-                biggest_index = bisect.bisect_left(available_cut_indexes, end_index) 
-                available_cut_indexes = available_cut_indexes[:biggest_index + 1]
+                biggest_index = bisect.bisect_left(available_cut_indexes, end_index)
+                available_cut_indexes = available_cut_indexes[: biggest_index + 1]
 
                 if len(available_cut_indexes) == 1:
-                    choices = ['head']
+                    choices = ["head"]
                 elif len(available_cut_indexes) == 2:
-                    choices = ['head', 'tail']
+                    choices = ["head", "tail"]
                 else:
-                    choices = ['head', 'tail', 'middle']
+                    choices = ["head", "tail", "middle"]
                 choice = random.choice(choices)
-                if choice == 'head':
+                if choice == "head":
                     patches = metadata_patches + tunebody_patches[0:]
                 else:
-                    if choice == 'tail':
+                    if choice == "tail":
                         cut_index = len(available_cut_indexes) - 1
                     else:
-                        cut_index = random.choice(range(1, len(available_cut_indexes) - 1))
+                        cut_index = random.choice(
+                            range(1, len(available_cut_indexes) - 1)
+                        )
 
-                    line_index = line_index_for_cut_index[cut_index] 
-                    stream_tunebody_lines = tunebody_lines[line_index : ]
-                    
-                    stream_tunebody_patches = self.patchilize_tunebody(stream_tunebody_lines, encode_mode='train')
+                    line_index = line_index_for_cut_index[cut_index]
+                    stream_tunebody_lines = tunebody_lines[line_index:]
+
+                    stream_tunebody_patches = self.patchilize_tunebody(
+                        stream_tunebody_lines, encode_mode="train"
+                    )
                     if add_special_patches:
                         stream_tunebody_patches = stream_tunebody_patches + [eos_patch]
                     patches = metadata_patches + stream_tunebody_patches
@@ -152,52 +183,68 @@ class Patchilizer:
         else:
             patches = metadata_patches + tunebody_patches
 
-        if cut: 
-            patches = patches[ : patch_length]
-        else:   
+        if cut:
+            patches = patches[:patch_length]
+        else:
             pass
 
         # encode to ids
         id_patches = []
         for patch in patches:
-            id_patch = [ord(c) for c in patch] + [self.special_token_id] * (patch_size - len(patch))
+            id_patch = [ord(c) for c in patch] + [self.special_token_id] * (
+                patch_size - len(patch)
+            )
             id_patches.append(id_patch)
 
         return id_patches
 
-    def encode_generate(self, abc_code, patch_length=PATCH_LENGTH, patch_size=PATCH_SIZE, add_special_patches=True):
+    def encode_generate(
+        self,
+        abc_code,
+        patch_length=PATCH_LENGTH,
+        patch_size=PATCH_SIZE,
+        add_special_patches=True,
+    ):
 
-        lines = abc_code.split('\n')
+        lines = abc_code.split("\n")
         lines = list(filter(None, lines))
-    
+
         tunebody_index = None
         for i, line in enumerate(lines):
-            if line.startswith('[V:') or line.startswith('[r:'):
+            if line.startswith("[V:") or line.startswith("[r:"):
                 tunebody_index = i
                 break
-    
-        metadata_lines = lines[ : tunebody_index]
-        tunebody_lines = lines[tunebody_index : ]   
-    
-        metadata_lines = [line + '\n' for line in metadata_lines]
+
+        metadata_lines = lines[:tunebody_index]
+        tunebody_lines = lines[tunebody_index:]
+
+        metadata_lines = [line + "\n" for line in metadata_lines]
         if self.stream:
-            if not abc_code.endswith('\n'):
-                tunebody_lines = [tunebody_lines[i] + '\n' for i in range(len(tunebody_lines) - 1)] + [tunebody_lines[-1]]
+            if not abc_code.endswith("\n"):
+                tunebody_lines = [
+                    tunebody_lines[i] + "\n" for i in range(len(tunebody_lines) - 1)
+                ] + [tunebody_lines[-1]]
             else:
-                tunebody_lines = [tunebody_lines[i] + '\n' for i in range(len(tunebody_lines))]
+                tunebody_lines = [
+                    tunebody_lines[i] + "\n" for i in range(len(tunebody_lines))
+                ]
         else:
-            tunebody_lines = [line + '\n' for line in tunebody_lines]
-    
+            tunebody_lines = [line + "\n" for line in tunebody_lines]
+
         metadata_patches = self.patchilize_metadata(metadata_lines)
-        tunebody_patches = self.patchilize_tunebody(tunebody_lines, encode_mode='generate')
-    
+        tunebody_patches = self.patchilize_tunebody(
+            tunebody_lines, encode_mode="generate"
+        )
+
         if add_special_patches:
-            bos_patch = chr(self.bos_token_id) * (patch_size - 1) + chr(self.eos_token_id)
+            bos_patch = chr(self.bos_token_id) * (patch_size - 1) + chr(
+                self.eos_token_id
+            )
 
             metadata_patches = [bos_patch] + metadata_patches
-    
+
         patches = metadata_patches + tunebody_patches
-        patches = patches[ : patch_length]
+        patches = patches[:patch_length]
 
         # encode to ids
         id_patches = []
@@ -205,34 +252,33 @@ class Patchilizer:
             if len(patch) < PATCH_SIZE and patch[-1] != chr(self.eos_token_id):
                 id_patch = [ord(c) for c in patch]
             else:
-                id_patch = [ord(c) for c in patch] + [self.special_token_id] * (patch_size - len(patch))
+                id_patch = [ord(c) for c in patch] + [self.special_token_id] * (
+                    patch_size - len(patch)
+                )
             id_patches.append(id_patch)
-        
+
         return id_patches
 
     def decode(self, patches):
         """
         Decode patches into music.
         """
-        return ''.join(self.patch2chars(patch) for patch in patches)
-
-        
+        return "".join(self.patch2chars(patch) for patch in patches)
 
 
 class PatchLevelDecoder(PreTrainedModel):
     """
-    A Patch-level Decoder model for generating patch features in an auto-regressive manner. 
+    A Patch-level Decoder model for generating patch features in an auto-regressive manner.
     It inherits PreTrainedModel from transformers.
     """
+
     def __init__(self, config):
         super().__init__(config)
         self.patch_embedding = torch.nn.Linear(PATCH_SIZE * 128, config.n_embd)
         torch.nn.init.normal_(self.patch_embedding.weight, std=0.02)
         self.base = GPT2Model(config)
 
-    def forward(self,
-                patches: torch.Tensor,
-                masks=None) -> torch.Tensor:
+    def forward(self, patches: torch.Tensor, masks=None) -> torch.Tensor:
         """
         The forward pass of the patch-level decoder model.
         :param patches: the patches to be encoded
@@ -243,11 +289,10 @@ class PatchLevelDecoder(PreTrainedModel):
         patches = patches.reshape(len(patches), -1, PATCH_SIZE * (128))
         patches = self.patch_embedding(patches.to(self.device))
 
-        if masks==None:
+        if masks == None:
             return self.base(inputs_embeds=patches)
         else:
-            return self.base(inputs_embeds=patches,
-                             attention_mask=masks)
+            return self.base(inputs_embeds=patches, attention_mask=masks)
 
 
 class CharLevelDecoder(PreTrainedModel):
@@ -255,6 +300,7 @@ class CharLevelDecoder(PreTrainedModel):
     A Char-level Decoder model for generating the chars within each patch in an auto-regressive manner
     based on the encoded patch features. It inherits PreTrainedModel from transformers.
     """
+
     def __init__(self, config):
         super().__init__(config)
         self.special_token_id = 0
@@ -262,9 +308,7 @@ class CharLevelDecoder(PreTrainedModel):
 
         self.base = GPT2LMHeadModel(config)
 
-    def forward(self,
-                encoded_patches: torch.Tensor,
-                target_patches: torch.Tensor):
+    def forward(self, encoded_patches: torch.Tensor, target_patches: torch.Tensor):
         """
         The forward pass of the char-level decoder model.
         :param encoded_patches: the encoded patches
@@ -272,7 +316,13 @@ class CharLevelDecoder(PreTrainedModel):
         :return: the output of the model
         """
         # preparing the labels for model training
-        target_patches = torch.cat((torch.ones_like(target_patches[:,0:1])*self.bos_token_id, target_patches), dim=1)
+        target_patches = torch.cat(
+            (
+                torch.ones_like(target_patches[:, 0:1]) * self.bos_token_id,
+                target_patches,
+            ),
+            dim=1,
+        )
 
         target_masks = target_patches == self.special_token_id
         labels = target_patches.clone().masked_fill_(target_masks, -100)
@@ -282,30 +332,35 @@ class CharLevelDecoder(PreTrainedModel):
         target_masks = target_masks.masked_fill_(labels == -100, 0)
 
         # select patches
-        if PATCH_SAMPLING_BATCH_SIZE!=0 and PATCH_SAMPLING_BATCH_SIZE<target_patches.shape[0]:
+        if (
+            PATCH_SAMPLING_BATCH_SIZE != 0
+            and PATCH_SAMPLING_BATCH_SIZE < target_patches.shape[0]
+        ):
             indices = list(range(len(target_patches)))
             random.shuffle(indices)
             selected_indices = sorted(indices[:PATCH_SAMPLING_BATCH_SIZE])
 
-            target_patches = target_patches[selected_indices,:]
-            target_masks = target_masks[selected_indices,:]
-            encoded_patches = encoded_patches[selected_indices,:]
+            target_patches = target_patches[selected_indices, :]
+            target_masks = target_masks[selected_indices, :]
+            encoded_patches = encoded_patches[selected_indices, :]
 
         # get input embeddings
-        inputs_embeds = torch.nn.functional.embedding(target_patches, self.base.transformer.wte.weight)
+        inputs_embeds = torch.nn.functional.embedding(
+            target_patches, self.base.transformer.wte.weight
+        )
 
         # concatenate the encoded patches with the input embeddings
-        inputs_embeds = torch.cat((encoded_patches.unsqueeze(1), inputs_embeds[:,1:,:]), dim=1)
+        inputs_embeds = torch.cat(
+            (encoded_patches.unsqueeze(1), inputs_embeds[:, 1:, :]), dim=1
+        )
 
-        output = self.base(inputs_embeds=inputs_embeds, 
-                         attention_mask=target_masks,
-                         labels=labels)
+        output = self.base(
+            inputs_embeds=inputs_embeds, attention_mask=target_masks, labels=labels
+        )
 
         return output
 
-    def generate(self,
-                 encoded_patch: torch.Tensor,
-                 tokens: torch.Tensor):
+    def generate(self, encoded_patch: torch.Tensor, tokens: torch.Tensor):
         """
         The generate function for generating a patch based on the encoded patch and already generated tokens.
         :param encoded_patch: the encoded patch
@@ -319,15 +374,16 @@ class CharLevelDecoder(PreTrainedModel):
         tokens = torch.nn.functional.embedding(tokens, self.base.transformer.wte.weight)
 
         # Concatenate the encoded patch with the input embeddings
-        tokens = torch.cat((encoded_patch, tokens[:,1:,:]), dim=1)
-        
+        tokens = torch.cat((encoded_patch, tokens[:, 1:, :]), dim=1)
+
         # Get output from model
         outputs = self.base(inputs_embeds=tokens)
-        
+
         # Get probabilities of next token
         probs = torch.nn.functional.softmax(outputs.logits.squeeze(0)[-1], dim=-1)
 
         return probs
+
 
 def safe_normalize_probs(probs):
     epsilon = 1e-12
@@ -342,6 +398,7 @@ def safe_normalize_probs(probs):
         probs[0] = 1.0
     return probs
 
+
 class NotaGenLMHeadModel(PreTrainedModel):
     """
     NotaGen is a language model with a hierarchical structure.
@@ -350,6 +407,7 @@ class NotaGenLMHeadModel(PreTrainedModel):
     The char-level decoder is used to generate the chars within each patch in an auto-regressive manner.
     It inherits PreTrainedModel from transformers.
     """
+
     def __init__(self, encoder_config, decoder_config):
         super().__init__(encoder_config)
         self.special_token_id = 0
@@ -358,9 +416,7 @@ class NotaGenLMHeadModel(PreTrainedModel):
         self.patch_level_decoder = PatchLevelDecoder(encoder_config)
         self.char_level_decoder = CharLevelDecoder(decoder_config)
 
-    def forward(self,
-                patches: torch.Tensor,
-                masks: torch.Tensor):
+    def forward(self, patches: torch.Tensor, masks: torch.Tensor):
         """
         The forward pass of the bGPT model.
         :param patches: the patches to be encoded
@@ -369,20 +425,16 @@ class NotaGenLMHeadModel(PreTrainedModel):
         """
         patches = patches.reshape(len(patches), -1, PATCH_SIZE)
         encoded_patches = self.patch_level_decoder(patches, masks)["last_hidden_state"]
-        
+
         left_shift_masks = masks * (masks.flip(1).cumsum(1).flip(1) > 1)
         masks[:, 0] = 0
-        
+
         encoded_patches = encoded_patches[left_shift_masks == 1]
         patches = patches[masks == 1]
-        
+
         return self.char_level_decoder(encoded_patches, patches)
-        
-    def generate(self,
-                 patches: torch.Tensor,
-                 top_k=0,
-                 top_p=1,
-                 temperature=1.0):
+
+    def generate(self, patches: torch.Tensor, top_k=0, top_p=1, temperature=1.0):
         """
         The generate function for generating patches based on patches.
         :param patches: the patches to be encoded
@@ -392,18 +444,25 @@ class NotaGenLMHeadModel(PreTrainedModel):
         :return: the generated patches
         """
         if patches.shape[-1] % PATCH_SIZE != 0:
-            tokens = patches[:,:,-(patches.shape[-1]%PATCH_SIZE):].squeeze(0, 1)
-            tokens = torch.cat((torch.tensor([self.bos_token_id], device=self.device), tokens), dim=-1)
-            patches = patches[:,:,:-(patches.shape[-1]%PATCH_SIZE)]
+            tokens = patches[:, :, -(patches.shape[-1] % PATCH_SIZE) :].squeeze(0, 1)
+            tokens = torch.cat(
+                (torch.tensor([self.bos_token_id], device=self.device), tokens), dim=-1
+            )
+            patches = patches[:, :, : -(patches.shape[-1] % PATCH_SIZE)]
         else:
-            tokens =  torch.tensor([self.bos_token_id], device=self.device)
+            tokens = torch.tensor([self.bos_token_id], device=self.device)
 
         patches = patches.reshape(len(patches), -1, PATCH_SIZE)
         encoded_patches = self.patch_level_decoder(patches)["last_hidden_state"]
-        generated_patch = []            
+        generated_patch = []
 
         while True:
-            prob = self.char_level_decoder.generate(encoded_patches[0][-1], tokens).cpu().detach().numpy()
+            prob = (
+                self.char_level_decoder.generate(encoded_patches[0][-1], tokens)
+                .cpu()
+                .detach()
+                .numpy()
+            )
             prob = safe_normalize_probs(prob)
             prob = top_k_sampling(prob, top_k=top_k, return_probs=True)
             prob = safe_normalize_probs(prob)
@@ -416,6 +475,8 @@ class NotaGenLMHeadModel(PreTrainedModel):
             if len(tokens) >= PATCH_SIZE:
                 break
             else:
-                tokens = torch.cat((tokens, torch.tensor([token], device=self.device)), dim=0)
-        
+                tokens = torch.cat(
+                    (tokens, torch.tensor([token], device=self.device)), dim=0
+                )
+
         return generated_patch

--- a/pretrain/utils.py
+++ b/pretrain/utils.py
@@ -3,7 +3,7 @@ import random
 import bisect
 import re
 import numpy as np
-from config import *
+from config import PATCH_STREAM, PATCH_SIZE, PATCH_LENGTH, PATCH_SAMPLING_BATCH_SIZE
 from transformers import GPT2Model, GPT2LMHeadModel, PreTrainedModel
 from samplings import top_p_sampling, top_k_sampling, temperature_sampling
 


### PR DESCRIPTION
# Refactor: Replace wildcard imports with explicit imports and improve code style

## Summary

This pull request improves code clarity and maintainability by:

- Replacing all wildcard imports (`from ... import *`) in the `pretrain` module with explicit imports of only the required symbols.
- Resolving linter warnings related to undefined names and unused imports.
- Making minor formatting and spacing improvements in `data/abc2xml.py` for better readability and consistency.

These changes enhance code quality, make dependencies explicit, and facilitate static analysis and future maintenance.